### PR TITLE
Remove cast warnings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 AndroidManifest.xml
+R.java
 src/main/java/org/mozilla/gecko/sync/repositories/android/Authorities.java
 res/xml/sync_syncadapter.xml
 res/values/strings.xml

--- a/src/main/java/org/mozilla/gecko/sync/Utils.java
+++ b/src/main/java/org/mozilla/gecko/sync/Utils.java
@@ -184,7 +184,7 @@ public class Utils {
     return (long)(decimal * 1000);
   }
   public static long decimalSecondsToMilliseconds(Long decimal) {
-    return (long)(decimal * 1000);
+    return (decimal * 1000);
   }
   public static long decimalSecondsToMilliseconds(Integer decimal) {
     return (long)(decimal * 1000);

--- a/src/main/java/org/mozilla/gecko/sync/jpake/JPakeClient.java
+++ b/src/main/java/org/mozilla/gecko/sync/jpake/JPakeClient.java
@@ -1060,7 +1060,7 @@ public class JPakeClient implements JPakeRequestDelegate {
     byte[] rBytes = generateRandomBytes(JPAKE_LENGTH_SECRET);
     StringBuilder secret = new StringBuilder();
     for (byte b : rBytes) {
-      secret.append(key.charAt((int) (Math.abs(b) * keylen / 256)));
+      secret.append(key.charAt(Math.abs(b) * keylen / 256));
     }
     this.secret = secret.toString();
   }

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserHistoryDataAccessor.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserHistoryDataAccessor.java
@@ -74,7 +74,7 @@ public class AndroidBrowserHistoryDataAccessor extends AndroidBrowserRepositoryD
     cv.put(BrowserContract.History.TITLE,           rec.title);
     cv.put(BrowserContract.History.URL,        rec.histURI);
     if (rec.visits != null) {
-      JSONArray visits = (JSONArray) rec.visits;
+      JSONArray visits = rec.visits;
       long mostRecent = 0;
       for (int i = 0; i < visits.size(); i++) {
         JSONObject visit = (JSONObject) visits.get(i);

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserHistoryRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserHistoryRepositorySession.java
@@ -93,7 +93,7 @@ public class AndroidBrowserHistoryRepositorySession extends AndroidBrowserReposi
 
           // Set fake visit timestamp to be just previous to
           // the real one we are about to add.
-          fake.put(KEY_DATE, (long) hist.fennecDateVisited - (1 + j));
+          fake.put(KEY_DATE, hist.fennecDateVisited - (1 + j));
           fake.put(KEY_TYPE, DEFAULT_VISIT_TYPE);
           visitsArray.add(fake);
         }


### PR DESCRIPTION
In addition to the redundant cast warning changes, I found that the unchecked warnings shown here

https://bugzilla.mozilla.org/show_bug.cgi?id=716073#c0

can be resolved by parameterizing the JSONObject class definition as shown here

http://pastebin.mozilla.org/1440881

based on the issue from here

http://code.google.com/p/json-simple/issues/detail?id=15

However, I'm not sure if it's okay to modify this since it's an external dependency.
