### PR TITLE
Bug fixes for bug 716808 and bug 716799

### DIFF
--- a/manifests/SyncAndroidManifest_activities.xml.in
+++ b/manifests/SyncAndroidManifest_activities.xml.in
@@ -2,7 +2,9 @@
             android:icon="@drawable/sync_ic_launcher"
             android:label="@string/sync_app_name"
             android:launchMode="singleTask"
+            android:configChanges="orientation"
             android:name="org.mozilla.gecko.sync.setup.activities.SetupSyncActivity" >
+            <!-- android:configChanges: SetupSyncActivity will handle orientation changes; no longer restarts activity (default) -->
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/res/layout/sync_setup.xml
+++ b/res/layout/sync_setup.xml
@@ -20,9 +20,8 @@
         android:text="@string/sync_subtitle_pair" />
 
     <TextView
-        style="@style/SyncTextItem"
-        android:autoLink="web"
-        android:clickable="true"
+        style="@style/SyncLinkItem"
+        android:onClick="showClickHandler"
         android:text="@string/sync_link_show" />
 
     <LinearLayout
@@ -38,8 +37,7 @@
 
     <TextView
         android:id="@+id/link_nodevice"
-        style="@style/SyncTextItem"
-        android:clickable="true"
+        style="@style/SyncLinkItem"
         android:onClick="manualClickHandler"
         android:text="@string/sync_link_nodevice" />
 

--- a/res/layout/sync_setup_pair.xml
+++ b/res/layout/sync_setup_pair.xml
@@ -17,9 +17,8 @@
         android:text="@string/sync_subtitle_connect" />
 
     <TextView
-        style="@style/SyncTextItem"
-        android:autoLink="web"
-        android:clickable="true"
+        style="@style/SyncLinkItem"
+        android:onClick="showClickHandler"
         android:text="@string/sync_link_show" />
 
     <LinearLayout

--- a/res/layout/sync_setup_success.xml
+++ b/res/layout/sync_setup_success.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <TableLayout xmlns:android="http://schemas.android.com/apk/res/android"
     style="@style/SyncTextFrame" >
+
     <TextView
         style="@style/SyncTextTitle"
         android:text="@string/sync_title_success" />
-    <View
-        style="@style/SyncViewLine" />
+
+    <View style="@style/SyncViewLine" />
 
     <TextView
         android:id="@+id/setup_success_subtitle"
@@ -14,6 +15,7 @@
         android:gravity="center"
         android:padding="20dp"
         android:text="@string/sync_subtitle_success" />
+
     <Button
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -21,10 +23,15 @@
         android:onClick="settingsClickHandler"
         android:text="@string/sync_settings" />
 
+    <View
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:layout_weight="1" />
+
     <TextView
         android:id="@+id/link_pair"
-        style="@style/SyncTextItem"
-        android:clickable="true"
+        style="@style/SyncLinkItem"
+        android:layout_gravity="center|bottom"
         android:onClick="pairClickHandler"
         android:text="@string/sync_title_pair" />
 

--- a/res/values/sync_styles.xml
+++ b/res/values/sync_styles.xml
@@ -16,6 +16,10 @@
     <item name="android:layout_gravity">center_vertical</item>
     <item name="android:textSize">15dp</item>
   </style>
+  <style name="SyncLinkItem" parent="SyncTextItem">
+    <item name="android:clickable">true</item>
+    <item name="android:textColor">#99CCFF</item>
+  </style>
   <style name="SyncTextTitle" parent="@style/SyncTextItem">
     <item name="android:gravity">center</item>
     <item name="android:paddingBottom">10dp</item>

--- a/src/main/java/org/mozilla/gecko/sync/setup/Constants.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/Constants.java
@@ -52,6 +52,10 @@ public class Constants {
   public static final String INTENT_EXTRA_IS_PAIR                        = "isPair";
   public static final int    FLAG_ACTIVITY_REORDER_TO_FRONT_NO_ANIMATION = Intent.FLAG_ACTIVITY_REORDER_TO_FRONT | Intent.FLAG_ACTIVITY_NO_ANIMATION;
 
+  // Links for J-PAKE setup help pages.
+  public static final String LINK_FIND_CODE                              = "https://support.mozilla.org/kb/find-code-to-add-device-to-firefox-sync";
+  public static final String LINK_FIND_ADD_DEVICE                        = "https://support.mozilla.org/kb/add-a-device-to-firefox-sync";
+
   // Constants for JSON payload
   public static final String JSON_KEY_PAYLOAD                            = "payload";
   public static final String JSON_KEY_CIPHERTEXT                         = "ciphertext";

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSyncActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSyncActivity.java
@@ -51,6 +51,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
+import android.net.Uri;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -177,6 +178,17 @@ public class SetupSyncActivity extends AccountAuthenticatorActivity {
     // Start J-PAKE.
     jClient = new JPakeClient(this);
     jClient.pairWithPin(pin, false);
+  }
+
+  public void showClickHandler(View target) {
+    Uri uri = null;
+    // TODO: fetch these from fennec
+    if (pairWithPin) {
+      uri = Uri.parse(Constants.LINK_FIND_CODE);
+    } else {
+      uri = Uri.parse(Constants.LINK_FIND_ADD_DEVICE);
+    }
+    startActivity(new Intent(Intent.ACTION_VIEW, uri));
   }
 
   /* Controller methods */

--- a/sync_strings.dtd.in
+++ b/sync_strings.dtd.in
@@ -12,8 +12,8 @@
 <!ENTITY sync.subtitle.connect.label 'To activate your new device, select “Set up &syncBrand.shortName.label;” on the device.'>
 <!ENTITY sync.subtitle.pair.label 'To activate, select “Pair a device” on your other device.'>
 <!ENTITY sync.pin.default.label '...\n...\n...\n'>
-<!ENTITY sync.link.show.label '<a href="https://support.mozilla.com/kb/add-a-device-to-firefox-sync">Show me how</a>'>
-<!ENTITY sync.link.nodevice.label '<a href="#">I don\&apos;t have the device with me…</a>'>
+<!ENTITY sync.link.show.label 'Show me how.'>
+<!ENTITY sync.link.nodevice.label 'I don\&apos;t have the device with me…'>
 
 <!-- J-PAKE Waiting Screen -->
 <!ENTITY sync.jpake.subtitle.waiting.label 'Waiting for other device…'>


### PR DESCRIPTION
Bug 716808: pair link spacing and placement on success screen.
Moved pair link to bottom of screen. Also made link style changes, propagated to other links

Bug 716799: screen rotation restarting J-PAKE
Set manifest attribute android:configChanges to control orientation changes from activity, instead of restarting activity (default).
