### PR TITLE
b716804: duplicate '/' in URIs.

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/jpake/JPakeClient.java
+++ b/src/main/java/org/mozilla/gecko/sync/jpake/JPakeClient.java
@@ -144,7 +144,7 @@ public class JPakeClient implements JPakeRequestDelegate {
     jpakePollInterval = 1 * 1000; // 1 second
     jpakeMaxTries = MAX_TRIES;
 
-    if (jpakeServer.endsWith("/")) {
+    if (!jpakeServer.endsWith("/")) {
       jpakeServer += "/";
     }
 


### PR DESCRIPTION
Whoops. Was introduced in "Fixes per quick code review" (a3b8d07ab7db48960dcc88d649d55784dfd543b6).
