### PR TITLE
Scrolling in manual setup, kill portrait mode in J-PAKE, activity flow.

### DIFF
--- a/manifests/SyncAndroidManifest_activities.xml.in
+++ b/manifests/SyncAndroidManifest_activities.xml.in
@@ -2,7 +2,9 @@
             android:icon="@drawable/sync_ic_launcher"
             android:label="@string/sync_app_name"
             android:launchMode="singleTask"
+            android:screenOrientation="portrait"
             android:configChanges="orientation"
+            android:windowSoftInputMode="adjustResize"
             android:name="org.mozilla.gecko.sync.setup.activities.SetupSyncActivity" >
             <!-- android:configChanges: SetupSyncActivity will handle orientation changes; no longer restarts activity (default) -->
             <intent-filter>
@@ -18,7 +20,7 @@
             android:clearTaskOnLaunch="true"
             android:launchMode="singleTask"
             android:name="org.mozilla.gecko.sync.setup.activities.AccountActivity"
-            android:windowSoftInputMode="stateVisible|adjustResize"/>
+            android:windowSoftInputMode="adjustPan"/>
         <activity
             android:name="org.mozilla.gecko.sync.setup.activities.SetupFailureActivity" />
         <activity

--- a/res/layout/sync_account.xml
+++ b/res/layout/sync_account.xml
@@ -2,6 +2,11 @@
 <TableLayout xmlns:android="http://schemas.android.com/apk/res/android"
   style="@style/SyncTextFrame" >
 
+  <ScrollView
+    style="@style/SyncLayout" >
+  <LinearLayout
+    style="@style/SyncLayout" >
+
   <TextView
     style="@style/SyncTextTitle"
     android:text="@string/sync_title_connect" />
@@ -27,12 +32,14 @@
     android:hint="@string/sync_input_key" />
 
   <CheckBox android:id="@+id/checkbox_server"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="left"
     android:text="@string/sync_checkbox_server" />
 
   <EditText android:id="@+id/serverInput"
     style="@style/SyncEditItem"
-    android:enabled="false"
-    android:clickable="false"
+    android:visibility="gone"
     android:hint="@string/sync_input_server" />
 
   <LinearLayout
@@ -54,5 +61,6 @@
       android:text="@string/sync_button_connect" />
 
   </LinearLayout>
-
+  </LinearLayout>
+</ScrollView>
 </TableLayout>

--- a/res/layout/sync_account.xml
+++ b/res/layout/sync_account.xml
@@ -4,63 +4,64 @@
 
   <ScrollView
     style="@style/SyncLayout" >
-  <LinearLayout
-    style="@style/SyncLayout" >
-
-  <TextView
-    style="@style/SyncTextTitle"
-    android:text="@string/sync_title_connect" />
-
-  <View
-    style="@style/SyncViewLine" />
-
-  <TextView
-    style="@style/SyncTextItem"
-    android:text="@string/sync_subtitle_account" />
-
-  <EditText android:id="@+id/usernameInput"
-    style="@style/SyncEditItem"
-    android:hint="@string/sync_input_username" />
-
-  <EditText android:id="@+id/passwordInput"
-    style="@style/SyncEditItem"
-    android:password="true"
-    android:hint="@string/sync_input_password" />
-
-  <EditText android:id="@+id/keyInput"
-    style="@style/SyncEditItem"
-    android:hint="@string/sync_input_key" />
-
-  <CheckBox android:id="@+id/checkbox_server"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_gravity="left"
-    android:text="@string/sync_checkbox_server" />
-
-  <EditText android:id="@+id/serverInput"
-    style="@style/SyncEditItem"
-    android:visibility="gone"
-    android:hint="@string/sync_input_server" />
-
-  <LinearLayout
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
-    android:orientation="horizontal" >
-
-    <Button
-      style="@style/SyncButtonCommon"
-      android:onClick="cancelClickHandler"
-      android:text="@string/sync_button_cancel" />
-
-    <Button
-      android:id="@+id/accountConnectButton"
-      style="@style/SyncButtonCommon"
-      android:onClick="connectClickHandler"
-      android:clickable="false"
-      android:enabled="false"
-      android:text="@string/sync_button_connect" />
-
-  </LinearLayout>
-  </LinearLayout>
-</ScrollView>
+    
+	<LinearLayout
+	    style="@style/SyncLayout" >
+	
+	  <TextView
+	    style="@style/SyncTextTitle"
+	    android:text="@string/sync_title_connect" />
+	
+	  <View
+	    style="@style/SyncViewLine" />
+	
+	  <TextView
+	    style="@style/SyncTextItem"
+	    android:text="@string/sync_subtitle_account" />
+	
+	  <EditText android:id="@+id/usernameInput"
+	    style="@style/SyncEditItem"
+	    android:hint="@string/sync_input_username" />
+	
+	  <EditText android:id="@+id/passwordInput"
+	    style="@style/SyncEditItem"
+	    android:password="true"
+	    android:hint="@string/sync_input_password" />
+	
+	  <EditText android:id="@+id/keyInput"
+	    style="@style/SyncEditItem"
+	    android:hint="@string/sync_input_key" />
+	
+	  <CheckBox android:id="@+id/checkbox_server"
+	    android:layout_width="wrap_content"
+	    android:layout_height="wrap_content"
+	    android:layout_gravity="left"
+	    android:text="@string/sync_checkbox_server" />
+	
+	  <EditText android:id="@+id/serverInput"
+	    style="@style/SyncEditItem"
+	    android:visibility="gone"
+	    android:hint="@string/sync_input_server" />
+	
+	  <LinearLayout
+	    android:layout_width="fill_parent"
+	    android:layout_height="fill_parent"
+	    android:orientation="horizontal" >
+	
+	    <Button
+	      style="@style/SyncButtonCommon"
+	      android:onClick="cancelClickHandler"
+	      android:text="@string/sync_button_cancel" />
+	
+	    <Button
+	      android:id="@+id/accountConnectButton"
+	      style="@style/SyncButtonCommon"
+	      android:onClick="connectClickHandler"
+	      android:clickable="false"
+	      android:enabled="false"
+	      android:text="@string/sync_button_connect" />
+	
+	  </LinearLayout>
+	</LinearLayout>
+  </ScrollView>
 </TableLayout>

--- a/res/layout/sync_setup.xml
+++ b/res/layout/sync_setup.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <TableLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    style="@style/SyncTextFrame" >
+  style="@style/SyncTextFrame" >
+
+  <ScrollView
+    style="@style/SyncLayout" >
+
+    <LinearLayout
+      style="@style/SyncLayout" >
 
     <TextView
         android:id="@+id/setup_title"
@@ -53,5 +59,6 @@
             android:onClick="cancelClickHandler"
             android:text="@string/sync_button_cancel" />
     </LinearLayout>
-
+    </LinearLayout>
+  </ScrollView>
 </TableLayout>

--- a/res/layout/sync_setup.xml
+++ b/res/layout/sync_setup.xml
@@ -8,57 +8,58 @@
     <LinearLayout
       style="@style/SyncLayout" >
 
-    <TextView
-        android:id="@+id/setup_title"
-        style="@style/SyncTextTitle"
-        android:text="@string/sync_title_connect" />
+      <TextView
+          android:id="@+id/setup_title"
+          style="@style/SyncTextTitle"
+          android:text="@string/sync_title_connect" />
 
-    <View
-        android:layout_width="wrap_content"
-        android:layout_height="2dp"
-        android:background="#FFFFFF" />
+      <View
+          android:layout_width="wrap_content"
+          android:layout_height="2dp"
+          android:background="#FFFFFF" />
 
-    <TextView
-        android:id="@+id/setup_subtitle"
-        style="@style/SyncTextItem"
-        android:layout_marginTop="10dp"
-        android:layout_marginBottom="10dp"
-        android:text="@string/sync_subtitle_pair" />
+      <TextView
+          android:id="@+id/setup_subtitle"
+          style="@style/SyncTextItem"
+          android:layout_marginTop="10dp"
+          android:layout_marginBottom="10dp"
+          android:text="@string/sync_subtitle_pair" />
 
-    <TextView
-        style="@style/SyncLinkItem"
-        android:onClick="showClickHandler"
-        android:text="@string/sync_link_show" />
+      <TextView
+          style="@style/SyncLinkItem"
+          android:onClick="showClickHandler"
+          android:text="@string/sync_link_show" />
 
-    <LinearLayout
-        style="@style/SyncTextItem"
-        android:orientation="vertical" >
+      <LinearLayout
+          style="@style/SyncTextItem"
+          android:orientation="vertical" >
 
-        <TextView
-            android:id="@+id/text_pin"
-            style="@style/SyncTextItem"
-            android:text="@string/sync_pin_default"
-            android:textSize="40dp" />
-    </LinearLayout>
+          <TextView
+              android:id="@+id/text_pin"
+              style="@style/SyncTextItem"
+              android:text="@string/sync_pin_default"
+              android:textSize="40dp" />
+      </LinearLayout>
 
-    <TextView
-        android:id="@+id/link_nodevice"
-        style="@style/SyncLinkItem"
-        android:onClick="manualClickHandler"
-        android:text="@string/sync_link_nodevice" />
+      <TextView
+          android:id="@+id/link_nodevice"
+          style="@style/SyncLinkItem"
+          android:onClick="manualClickHandler"
+          android:text="@string/sync_link_nodevice" />
 
-    <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:orientation="horizontal" >
+      <LinearLayout
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:gravity="center"
+          android:orientation="horizontal" >
 
-        <Button
-            style="@style/SyncButtonCommon"
-            android:layout_marginTop="10dp"
-            android:onClick="cancelClickHandler"
-            android:text="@string/sync_button_cancel" />
-    </LinearLayout>
+          <Button
+              style="@style/SyncButtonCommon"
+              android:layout_marginTop="10dp"
+              android:onClick="cancelClickHandler"
+              android:text="@string/sync_button_cancel" />
+
+      </LinearLayout>
     </LinearLayout>
   </ScrollView>
 </TableLayout>

--- a/res/layout/sync_setup_pair.xml
+++ b/res/layout/sync_setup_pair.xml
@@ -1,46 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <TableLayout xmlns:android="http://schemas.android.com/apk/res/android"
     style="@style/SyncTextFrame" >
-<ScrollView
+  <ScrollView
     style="@style/SyncLayout" >
-  <LinearLayout
-    style="@style/SyncLayout" >
-    <TextView
+
+    <LinearLayout
+      style="@style/SyncLayout" >
+
+      <TextView
         android:id="@+id/setup_title"
         style="@style/SyncTextTitle"
         android:text="@string/sync_title_pair" />
 
-    <View
-       style="@style/SyncViewLine" />
+      <View
+        style="@style/SyncViewLine" />
 
-    <TextView
+      <TextView
         android:id="@+id/setup_subtitle"
         style="@style/SyncTextItem"
         android:layout_marginBottom="10dp"
         android:text="@string/sync_subtitle_connect" />
 
-    <TextView
+      <TextView
         style="@style/SyncLinkItem"
         android:onClick="showClickHandler"
         android:text="@string/sync_link_show" />
 
-    <LinearLayout
+      <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:gravity="center"
         android:orientation="vertical" >
 
-        <EditText
+          <EditText
             android:id="@+id/pair_row1"
             style="@style/SyncEditPin" />
-        <EditText
+          <EditText
             android:id="@+id/pair_row2"
             style="@style/SyncEditPin" />
-        <EditText
+          <EditText
             android:id="@+id/pair_row3"
             style="@style/SyncEditPin" />
-    </LinearLayout>
-    <LinearLayout
+      </LinearLayout>
+
+      <LinearLayout
         android:id="@+id/pair_error"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -49,32 +52,32 @@
         android:visibility="invisible" >
 
         <TextView
-            style="@style/SyncTextItem"
-            android:layout_marginTop="10dp"
-            android:layout_marginBottom="10dp"
-            android:text="@string/sync_pair_tryagain"
-            android:textSize="10dp" />
-    </LinearLayout>
+          style="@style/SyncTextItem"
+          android:layout_marginTop="10dp"
+          android:layout_marginBottom="10dp"
+          android:text="@string/sync_pair_tryagain"
+          android:textSize="10dp" />
+      </LinearLayout>
 
-    <LinearLayout
+      <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:gravity="center"
         android:orientation="horizontal" >
 
         <Button
-            style="@style/SyncButtonCommon"
-            android:onClick="cancelClickHandler"
-            android:text="@string/sync_button_cancel" />
+          style="@style/SyncButtonCommon"
+          android:onClick="cancelClickHandler"
+          android:text="@string/sync_button_cancel" />
 
         <Button
-            android:id="@+id/pair_button_connect"
-            style="@style/SyncButtonCommon"
-            android:onClick="connectClickHandler"
-            android:clickable="false"
-            android:enabled="false"
-            android:text="@string/sync_button_connect" />
+          android:id="@+id/pair_button_connect"
+          style="@style/SyncButtonCommon"
+          android:onClick="connectClickHandler"
+          android:clickable="false"
+          android:enabled="false"
+          android:text="@string/sync_button_connect" />
+      </LinearLayout>
     </LinearLayout>
-</LinearLayout>
-</ScrollView>
+  </ScrollView>
 </TableLayout>

--- a/res/layout/sync_setup_pair.xml
+++ b/res/layout/sync_setup_pair.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <TableLayout xmlns:android="http://schemas.android.com/apk/res/android"
     style="@style/SyncTextFrame" >
-
+<ScrollView
+    style="@style/SyncLayout" >
+  <LinearLayout
+    style="@style/SyncLayout" >
     <TextView
         android:id="@+id/setup_title"
         style="@style/SyncTextTitle"
@@ -72,5 +75,6 @@
             android:enabled="false"
             android:text="@string/sync_button_connect" />
     </LinearLayout>
-
+</LinearLayout>
+</ScrollView>
 </TableLayout>

--- a/res/values/sync_styles.xml
+++ b/res/values/sync_styles.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+  <style name="SyncLayout" parent="@android:style/Widget">
+    <item name="android:layout_width">wrap_content</item>
+    <item name="android:layout_height">fill_parent</item>
+    <item name="android:gravity">center</item>
+    <item name="android:orientation">vertical</item>
+  </style>
   <!-- TextView Styles -->
   <style name="SyncTextFrame" parent="@android:style/TextAppearance">
     <item name="android:layout_width">wrap_content</item>

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
@@ -108,9 +108,12 @@ public class AccountActivity extends AccountAuthenticatorActivity {
       @Override
       public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
         Log.i(LOG_TAG, "Toggling checkbox: " + isChecked);
-        activateView(serverInput, isChecked);
+        // Hack for pre-3.0 Android: can enter text into disabled EditText.
         if (!isChecked) { // Clear server input.
+          serverInput.setVisibility(View.GONE);
           serverInput.setText("");
+        } else {
+          serverInput.setVisibility(View.VISIBLE);
         }
         // Activate connectButton if necessary.
         activateView(connectButton, validateInputs());

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSyncActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSyncActivity.java
@@ -246,9 +246,8 @@ public class SetupSyncActivity extends AccountAuthenticatorActivity {
       runOnUiThread(new Runnable() {
         @Override
         public void run() {
-          Intent intent = new Intent(mContext, SetupFailureActivity.class);
-          intent.setFlags(Constants.FLAG_ACTIVITY_REORDER_TO_FRONT_NO_ANIMATION);
-          startActivity(intent);
+          displayReceiveNoPin();
+          jClient.receiveNoPin();
         }
       });
     }


### PR DESCRIPTION
Manual setup can be scrolled, allowing landscape. Killed portrait in J-PAKE for now; even with scrolling enabled, some ugly in landscape PIN entry needs more consideration. Simplified activity flow for errors, after chatting with philikon - just display a new pin.
