### PR TITLE
Move "Pair Device" into Firefox Sync settings, per design review.

### DIFF
--- a/manifests/SyncAndroidManifest_activities.xml.in
+++ b/manifests/SyncAndroidManifest_activities.xml.in
@@ -4,7 +4,7 @@
             android:launchMode="singleTask"
             android:screenOrientation="portrait"
             android:configChanges="orientation"
-            android:windowSoftInputMode="adjustResize"
+            android:windowSoftInputMode="adjustResize|stateHidden"
             android:name="org.mozilla.gecko.sync.setup.activities.SetupSyncActivity" >
             <!-- android:configChanges: SetupSyncActivity will handle orientation changes; no longer restarts activity (default) -->
             <intent-filter>
@@ -20,7 +20,7 @@
             android:clearTaskOnLaunch="true"
             android:launchMode="singleTask"
             android:name="org.mozilla.gecko.sync.setup.activities.AccountActivity"
-            android:windowSoftInputMode="adjustPan"/>
+            android:windowSoftInputMode="adjustPan|stateHidden"/>
         <activity
             android:name="org.mozilla.gecko.sync.setup.activities.SetupFailureActivity" />
         <activity

--- a/res/layout/sync_account.xml
+++ b/res/layout/sync_account.xml
@@ -36,6 +36,7 @@
 	    android:layout_width="wrap_content"
 	    android:layout_height="wrap_content"
 	    android:layout_gravity="left"
+	    android:imeOptions="actionDone"
 	    android:text="@string/sync_checkbox_server" />
 	
 	  <EditText android:id="@+id/serverInput"

--- a/res/layout/sync_setup_pair.xml
+++ b/res/layout/sync_setup_pair.xml
@@ -40,7 +40,8 @@
             style="@style/SyncEditPin" />
           <EditText
             android:id="@+id/pair_row3"
-            style="@style/SyncEditPin" />
+            style="@style/SyncEditPin"
+            android:imeOptions="actionDone" />
       </LinearLayout>
 
       <LinearLayout

--- a/res/xml/sync_authenticator.xml
+++ b/res/xml/sync_authenticator.xml
@@ -3,4 +3,5 @@
     android:accountType="org.mozilla.firefox_sync"
     android:icon="@drawable/sync_icon"
     android:smallIcon="@drawable/sync_icon"
-    android:label="@string/sync_account_label" />
+    android:label="@string/sync_account_label"
+    android:accountPreferences="@xml/sync_options" />

--- a/res/xml/sync_options.xml
+++ b/res/xml/sync_options.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+  <PreferenceCategory
+    android:title="@string/sync_settings_options" />
+  <PreferenceScreen
+    android:key="sync_options"
+    android:title="@string/sync_title_pair"
+    android:summary="@string/sync_settings_summary_pair">
+    <intent
+      android:action="android.intent.action.MAIN"
+      android:targetPackage="org.mozilla.gecko"
+      android:targetClass="org.mozilla.gecko.sync.setup.activities.SetupSyncActivity">
+      <extra
+        android:name="isSetup"
+        android:value="false" />
+    </intent>
+  </PreferenceScreen>
+</PreferenceScreen>

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSyncActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSyncActivity.java
@@ -61,6 +61,7 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 
 public class SetupSyncActivity extends AccountAuthenticatorActivity {
   private final static String LOG_TAG     = "SetupSync";
@@ -133,8 +134,10 @@ public class SetupSyncActivity extends AccountAuthenticatorActivity {
         return;
       }
     }
-    // Go to Settings screen for Sync management.
-    displayAccount(false);
+    // Display toast for "Only one account supported."
+    Toast toast = Toast.makeText(mContext, R.string.sync_notification_oneaccount, Toast.LENGTH_LONG);
+    toast.show();
+    finish();
   }
 
   @Override

--- a/strings.xml.in
+++ b/strings.xml.in
@@ -37,6 +37,9 @@
   <!-- Pair Device -->
   <string name="sync_pair_tryagain">&sync.pair.tryagain.label;</string>
 
+  <!-- Firefox SyncAdapter Settings Screen -->
+  <string name="sync_settings_options">&sync.settings.options.label;</string>
+  <string name="sync_settings_summary_pair">&sync.summary.pair.label;</string>
   <!-- Common text -->
   <string name="sync_button_cancel">&sync.button.cancel.label;</string>
   <string name="sync_button_connect">&sync.button.connect.label;</string>
@@ -53,3 +56,6 @@
   <string name="bookmarks_folder_unfiled">&bookmarks.folder.unfiled.label;</string>
   <string name="bookmarks_folder_desktop">&bookmarks.folder.desktop.label;</string>
   <string name="bookmarks_folder_mobile">&bookmarks.folder.mobile.label;</string>
+
+  <!-- Notification strings -->
+  <string name="sync_notification_oneaccount">&sync.notification.oneaccount.label;</string>

--- a/sync_strings.dtd.in
+++ b/sync_strings.dtd.in
@@ -42,6 +42,10 @@
 <!-- Pair Device -->
 <!ENTITY sync.pair.tryagain.label 'Please try again.'>
 
+<!-- Firefox SyncAdapter Settings Screen -->
+<!ENTITY sync.settings.options.label 'Options'>
+<!ENTITY sync.summary.pair.label 'Link another device to your &syncBrand.shortName.label; account'>
+
 <!-- Common text -->
 <!ENTITY sync.button.cancel.label 'Cancel'>
 <!ENTITY sync.button.connect.label 'Connect'>
@@ -58,3 +62,6 @@
 <!ENTITY bookmarks.folder.unfiled.label 'Unsorted Bookmarks'>
 <!ENTITY bookmarks.folder.desktop.label 'Desktop Bookmarks'>
 <!ENTITY bookmarks.folder.mobile.label 'Mobile Bookmarks'>
+
+<!-- Notification strings -->
+<!ENTITY sync.notification.oneaccount.label 'Only one &syncBrand.fullName.label; account is supported.'>


### PR DESCRIPTION
Show one-account-supported alert when attempting to add more than one Firefox Sync account. Pair Device can be accessed from Firefox Sync settings in Sync account menu. Quick fixes for VKB problems. Added some strings (will file localization bug next).
