### PR TITLE
Maven reporting improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,20 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>cobertura-maven-plugin</artifactId>
+        <version>2.5.1</version>
+        <configuration>
+          <instrumentation>
+            <excludes>
+              <exclude>**/ch/boye/**</exclude>
+              <exclude>**/org/json/**</exclude>
+              <exclude>**/org/mozilla/apache/**</exclude>
+            </excludes>
+          </instrumentation>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
         <version>3.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,7 @@
               <version>2.4</version>
               <reports>
                 <report>index</report>
+                <report>dependencies</report>
               </reports>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,13 @@
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-jxr-plugin</artifactId>
               <version>2.3</version>
+              <configuration>
+                <excludes>
+                  <exclude>**/org/mozilla/apache/**</exclude>
+                  <exclude>**/ch/boye/**</exclude>
+                  <exclude>**/org/json/simple/**</exclude>
+                </excludes>
+              </configuration>
             </plugin>
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This excludes external files from some of the Maven reports. It also enables dependency generation on the site's project page, which is pretty handy.
