### PR TITLE
Bug 718149 - go somewhere useful after Firefox Sync set up, on launch.

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSuccessActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSuccessActivity.java
@@ -44,10 +44,12 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.provider.Settings;
 import android.view.View;
 import android.widget.TextView;
 
 public class SetupSuccessActivity extends Activity {
+  private final static String LOG_TAG = "SetupSuccessActivity";
   private TextView setupSubtitle;
   private Context mContext;
 
@@ -68,7 +70,7 @@ public class SetupSuccessActivity extends Activity {
 
   /* Click Handlers */
   public void settingsClickHandler(View target) {
-    Intent intent = new Intent("android.settings.SYNC_SETTINGS");
+    Intent intent = new Intent(Settings.ACTION_SYNC_SETTINGS);
     intent.setFlags(Constants.FLAG_ACTIVITY_REORDER_TO_FRONT_NO_ANIMATION);
     startActivity(intent);
     finish();

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSyncActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSyncActivity.java
@@ -53,6 +53,7 @@ import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.Uri;
 import android.os.Bundle;
+import android.provider.Settings;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.Log;
@@ -134,9 +135,14 @@ public class SetupSyncActivity extends AccountAuthenticatorActivity {
         return;
       }
     }
-    // Display toast for "Only one account supported."
+    // Display toast for "Only one account supported." and redirect to account management.
     Toast toast = Toast.makeText(mContext, R.string.sync_notification_oneaccount, Toast.LENGTH_LONG);
     toast.show();
+
+    Intent intent = new Intent(Settings.ACTION_SYNC_SETTINGS);
+    intent.setFlags(Constants.FLAG_ACTIVITY_REORDER_TO_FRONT_NO_ANIMATION);
+    startActivity(intent);
+
     finish();
   }
 


### PR DESCRIPTION
Tried different permissions, but wasn't able to get around SecurityException, and also lost reproducibility of displaying settings for specific Account.

Defaulting to launching Account Settings screen.
