### PR TITLE
Nalexander/test global session

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
+++ b/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
@@ -185,8 +185,7 @@ public class GlobalSession implements CredentialsSource, PrefsSource {
     config.syncKeyBundle = syncKeyBundle;
     // clusterURL and syncID are set through `persisted`, or fetched from the server.
 
-    // TODO: populate saved configurations. We'll amend these after processing meta/global.
-    this.synchronizerConfigurations = new SynchronizerConfigurations(persisted);
+    assert(null == persisted);
     prepareStages();
   }
 
@@ -695,24 +694,5 @@ public class GlobalSession implements CredentialsSource, PrefsSource {
       throw new MetaGlobalMissingEnginesException();
     }
     return this.config.metaGlobal.engines.get(engineName) != null;
-  }
-
-  /**
-   * Return enough information to be able to reconstruct a Synchronizer.
-   *
-   * @param engineName
-   * @return
-   */
-  public SynchronizerConfiguration configForEngine(String engineName) {
-    // TODO: we need an altogether better way of handling empty configs.
-    SynchronizerConfiguration stored = this.getSynchronizerConfigurations().forEngine(engineName);
-    if (stored == null) {
-      return new SynchronizerConfiguration(engineName, new RepositorySessionBundle(0), new RepositorySessionBundle(0));
-    }
-    return stored;
-  }
-  private SynchronizerConfigurations synchronizerConfigurations;
-  private SynchronizerConfigurations getSynchronizerConfigurations() {
-    return this.synchronizerConfigurations;
   }
 }

--- a/src/main/java/org/mozilla/gecko/sync/SynchronizerConfigurations.java
+++ b/src/main/java/org/mozilla/gecko/sync/SynchronizerConfigurations.java
@@ -91,15 +91,6 @@ public class SynchronizerConfigurations {
     engines = new HashMap<String, SynchronizerConfiguration>();
   }
 
-  public void fillBundle(Bundle bundle) {
-    Bundle contents = new Bundle();
-    for (Entry<String, SynchronizerConfiguration> entry : engines.entrySet()) {
-      contents.putStringArray(entry.getKey(), entry.getValue().toStringValues());
-    }
-    contents.putInt("version", CONFIGURATION_VERSION);
-    bundle.putBundle("engines", contents);
-  }
-
   public SynchronizerConfiguration forEngine(String engineName) {
     return engines.get(engineName);
   }

--- a/src/test/java/org/mozilla/android/sync/net/test/TestBackoff.java
+++ b/src/test/java/org/mozilla/android/sync/net/test/TestBackoff.java
@@ -36,8 +36,7 @@ public class TestBackoff {
       final GlobalSession session = new MockGlobalSession(TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD,
         new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY), callback);
 
-      final HttpResponse response;
-      response = new BasicHttpResponse(
+      final HttpResponse response = new BasicHttpResponse(
           new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK"));
       response.addHeader("X-Weave-Backoff", Integer.toString(TEST_BACKOFF_IN_SECONDS)); // Backoff given in seconds.
 
@@ -65,8 +64,7 @@ public class TestBackoff {
       final GlobalSession session = new MockGlobalSession(TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD,
         new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY), callback);
 
-      final HttpResponse response;
-      response = new BasicHttpResponse(
+      final HttpResponse response = new BasicHttpResponse(
           new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK"));
 
       session.interpretHTTPFailure(response);
@@ -93,8 +91,7 @@ public class TestBackoff {
       final GlobalSession session = new MockGlobalSession(TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD,
         new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY), callback);
 
-      final HttpResponse response;
-      response = new BasicHttpResponse(
+      final HttpResponse response = new BasicHttpResponse(
           new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK"));
       response.addHeader("Retry-After", Integer.toString(TEST_BACKOFF_IN_SECONDS)); // Backoff given in seconds.
       response.addHeader("X-Weave-Backoff", Integer.toString(TEST_BACKOFF_IN_SECONDS + 1)); // If we now add a second header, the larger should be returned.

--- a/src/test/java/org/mozilla/android/sync/net/test/TestBackoff.java
+++ b/src/test/java/org/mozilla/android/sync/net/test/TestBackoff.java
@@ -19,11 +19,11 @@ import org.mozilla.android.sync.test.helpers.MockGlobalSession;
 import org.mozilla.android.sync.test.helpers.MockGlobalSessionCallback;
 
 public class TestBackoff {
-  private final String TEST_CLUSTER_URL		= "http://localhost:8080/";
-  private final String TEST_USERNAME		= "johndoe";
-  private final String TEST_PASSWORD		= "password";
-  private final String TEST_SYNC_KEY		= "abcdeabcdeabcdeabcdeabcdea";
-  private final int    TEST_BACKOFF_IN_SECONDS	= 1201;
+  private final String TEST_CLUSTER_URL         = "http://localhost:8080/";
+  private final String TEST_USERNAME            = "johndoe";
+  private final String TEST_PASSWORD            = "password";
+  private final String TEST_SYNC_KEY            = "abcdeabcdeabcdeabcdeabcdea";
+  private final long   TEST_BACKOFF_IN_SECONDS  = 1201;
 
   /**
    * Test that interpretHTTPFailure calls requestBackoff if
@@ -38,7 +38,7 @@ public class TestBackoff {
 
       final HttpResponse response = new BasicHttpResponse(
         new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK"));
-      response.addHeader("X-Weave-Backoff", Integer.toString(TEST_BACKOFF_IN_SECONDS)); // Backoff given in seconds.
+      response.addHeader("X-Weave-Backoff", Long.toString(TEST_BACKOFF_IN_SECONDS)); // Backoff given in seconds.
 
       session.interpretHTTPFailure(response); // This is synchronous...
 
@@ -93,8 +93,8 @@ public class TestBackoff {
 
       final HttpResponse response = new BasicHttpResponse(
         new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK"));
-      response.addHeader("Retry-After", Integer.toString(TEST_BACKOFF_IN_SECONDS)); // Backoff given in seconds.
-      response.addHeader("X-Weave-Backoff", Integer.toString(TEST_BACKOFF_IN_SECONDS + 1)); // If we now add a second header, the larger should be returned.
+      response.addHeader("Retry-After", Long.toString(TEST_BACKOFF_IN_SECONDS)); // Backoff given in seconds.
+      response.addHeader("X-Weave-Backoff", Long.toString(TEST_BACKOFF_IN_SECONDS + 1)); // If we now add a second header, the larger should be returned.
 
       session.interpretHTTPFailure(response); // This is synchronous...
 

--- a/src/test/java/org/mozilla/android/sync/net/test/TestBackoff.java
+++ b/src/test/java/org/mozilla/android/sync/net/test/TestBackoff.java
@@ -6,28 +6,15 @@ package org.mozilla.android.sync.net.test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-import java.io.IOException;
-
-import org.json.simple.parser.ParseException;
 import org.junit.Test;
 import org.mozilla.gecko.sync.GlobalSession;
-import org.mozilla.gecko.sync.NonObjectJSONException;
-import org.mozilla.gecko.sync.SyncConfiguration;
-import org.mozilla.gecko.sync.SyncConfigurationException;
 import org.mozilla.gecko.sync.crypto.KeyBundle;
-import org.mozilla.gecko.sync.delegates.GlobalSessionCallback;
-import org.mozilla.gecko.sync.repositories.RecordFactory;
-import org.mozilla.gecko.sync.repositories.Repository;
-import org.mozilla.gecko.sync.net.SyncStorageResponse;
 
 import ch.boye.httpclientandroidlib.HttpResponse;
 import ch.boye.httpclientandroidlib.ProtocolVersion;
 import ch.boye.httpclientandroidlib.message.BasicHttpResponse;
 import ch.boye.httpclientandroidlib.message.BasicStatusLine;
 
-import android.content.Context;
-import android.content.SharedPreferences;
-import org.mozilla.android.sync.test.helpers.MockSharedPreferences;
 import org.mozilla.android.sync.test.helpers.MockGlobalSession;
 import org.mozilla.android.sync.test.helpers.MockGlobalSessionCallback;
 

--- a/src/test/java/org/mozilla/android/sync/net/test/TestBackoff.java
+++ b/src/test/java/org/mozilla/android/sync/net/test/TestBackoff.java
@@ -37,13 +37,13 @@ public class TestBackoff {
         new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY), callback);
 
       final HttpResponse response = new BasicHttpResponse(
-          new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK"));
+        new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK"));
       response.addHeader("X-Weave-Backoff", Integer.toString(TEST_BACKOFF_IN_SECONDS)); // Backoff given in seconds.
 
       session.interpretHTTPFailure(response); // This is synchronous...
 
       assertEquals(false, callback.calledSuccess); // ... so we can test immediately.
-      assertEquals(false,  callback.calledError);
+      assertEquals(false, callback.calledError);
       assertEquals(false, callback.calledAborted);
       assertEquals(true,  callback.calledRequestBackoff);
       assertEquals(TEST_BACKOFF_IN_SECONDS * 1000, callback.weaveBackoff); // Backoff returned in milliseconds.
@@ -65,9 +65,9 @@ public class TestBackoff {
         new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY), callback);
 
       final HttpResponse response = new BasicHttpResponse(
-          new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK"));
+	new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK"));
 
-      session.interpretHTTPFailure(response);
+      session.interpretHTTPFailure(response); // This is synchronous...
 
       assertEquals(false, callback.calledSuccess); // ... so we can test immediately.
       assertEquals(false, callback.calledError);
@@ -92,7 +92,7 @@ public class TestBackoff {
         new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY), callback);
 
       final HttpResponse response = new BasicHttpResponse(
-          new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK"));
+        new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK"));
       response.addHeader("Retry-After", Integer.toString(TEST_BACKOFF_IN_SECONDS)); // Backoff given in seconds.
       response.addHeader("X-Weave-Backoff", Integer.toString(TEST_BACKOFF_IN_SECONDS + 1)); // If we now add a second header, the larger should be returned.
 

--- a/src/test/java/org/mozilla/android/sync/net/test/TestBackoff.java
+++ b/src/test/java/org/mozilla/android/sync/net/test/TestBackoff.java
@@ -35,10 +35,10 @@ public class TestBackoff {
       final MockGlobalSessionCallback callback = new MockGlobalSessionCallback();
       final GlobalSession session = new MockGlobalSession(TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD,
         new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY), callback);
-      
+
       final HttpResponse response;
       response = new BasicHttpResponse(
-          new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK"));       
+          new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK"));
       response.addHeader("X-Weave-Backoff", Integer.toString(TEST_BACKOFF_IN_SECONDS)); // Backoff given in seconds.
 
       session.interpretHTTPFailure(response); // This is synchronous...
@@ -53,7 +53,7 @@ public class TestBackoff {
       fail("Got exception.");
     }
   }
-  
+
   /**
    * Test that interpretHTTPFailure does not call requestBackoff if
    * X-Weave-Backoff is not present.
@@ -67,10 +67,10 @@ public class TestBackoff {
 
       final HttpResponse response;
       response = new BasicHttpResponse(
-          new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK"));       
+          new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK"));
 
       session.interpretHTTPFailure(response);
-      
+
       assertEquals(false, callback.calledSuccess); // ... so we can test immediately.
       assertEquals(false, callback.calledError);
       assertEquals(false, callback.calledAborted);
@@ -80,7 +80,7 @@ public class TestBackoff {
       fail("Got exception.");
     }
   }
-  
+
   /**
    * Test that interpretHTTPFailure calls requestBackoff with the
    * largest specified value if X-Weave-Backoff and Retry-After are
@@ -92,13 +92,13 @@ public class TestBackoff {
       final MockGlobalSessionCallback callback = new MockGlobalSessionCallback();
       final GlobalSession session = new MockGlobalSession(TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD,
         new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY), callback);
-      
+
       final HttpResponse response;
       response = new BasicHttpResponse(
-          new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK"));       
+          new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK"));
       response.addHeader("Retry-After", Integer.toString(TEST_BACKOFF_IN_SECONDS)); // Backoff given in seconds.
       response.addHeader("X-Weave-Backoff", Integer.toString(TEST_BACKOFF_IN_SECONDS + 1)); // If we now add a second header, the larger should be returned.
-      
+
       session.interpretHTTPFailure(response); // This is synchronous...
 
       assertEquals(false, callback.calledSuccess); // ... so we can test immediately.

--- a/src/test/java/org/mozilla/android/sync/net/test/TestBackoff.java
+++ b/src/test/java/org/mozilla/android/sync/net/test/TestBackoff.java
@@ -1,0 +1,135 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+package org.mozilla.android.sync.net.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+
+import org.json.simple.parser.ParseException;
+import org.junit.Test;
+import org.mozilla.gecko.sync.GlobalSession;
+import org.mozilla.gecko.sync.NonObjectJSONException;
+import org.mozilla.gecko.sync.SyncConfiguration;
+import org.mozilla.gecko.sync.SyncConfigurationException;
+import org.mozilla.gecko.sync.crypto.KeyBundle;
+import org.mozilla.gecko.sync.delegates.GlobalSessionCallback;
+import org.mozilla.gecko.sync.repositories.RecordFactory;
+import org.mozilla.gecko.sync.repositories.Repository;
+import org.mozilla.gecko.sync.net.SyncStorageResponse;
+
+import ch.boye.httpclientandroidlib.HttpResponse;
+import ch.boye.httpclientandroidlib.ProtocolVersion;
+import ch.boye.httpclientandroidlib.message.BasicHttpResponse;
+import ch.boye.httpclientandroidlib.message.BasicStatusLine;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import org.mozilla.android.sync.test.helpers.MockSharedPreferences;
+import org.mozilla.android.sync.test.helpers.MockGlobalSession;
+import org.mozilla.android.sync.test.helpers.MockGlobalSessionCallback;
+
+public class TestBackoff {
+  private final String TEST_CLUSTER_URL		= "http://localhost:8080/";
+  private final String TEST_USERNAME		= "johndoe";
+  private final String TEST_PASSWORD		= "password";
+  private final String TEST_SYNC_KEY		= "abcdeabcdeabcdeabcdeabcdea";
+  private final int    TEST_BACKOFF_IN_SECONDS	= 1201;
+
+  /**
+   * A callback that records if requestBackoff has been called.
+   */
+  public class MockBackoffCallback extends MockGlobalSessionCallback {
+    public boolean calledBackoff = false;
+    public long weaveBackoff = -1;
+    
+    @Override
+    public void requestBackoff(long backoff) {
+      this.calledBackoff = true;
+      this.weaveBackoff = backoff;
+    }
+    
+    @Override
+    public void handleSuccess(GlobalSession globalSession) {
+      fail("No success should occur.");
+    }
+  }
+
+  /**
+   * Test that interpretHTTPFailure calls requestBackoff if
+   * X-Weave-Backoff is present.
+   */
+  @Test
+  public void testBackoffCalledIfBackoffHeaderPresent() {
+    try {
+      MockBackoffCallback callback = new MockBackoffCallback();
+      GlobalSession session = new MockGlobalSession(TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD,
+        new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY), callback);
+      HttpResponse response;
+      response = new BasicHttpResponse(
+          new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK"));       
+
+      response.addHeader("X-Weave-Backoff", Integer.toString(TEST_BACKOFF_IN_SECONDS)); // Backoff given in seconds.
+
+      session.interpretHTTPFailure(response); // This is synchronous...
+
+      assertEquals(true, callback.calledBackoff); // ... so we can test immediately.
+      assertEquals(TEST_BACKOFF_IN_SECONDS * 1000, callback.weaveBackoff); // Backoff returned in milliseconds.
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail("Got exception.");
+    }
+  }
+  
+  /**
+   * Test that interpretHTTPFailure does not call requestBackoff if
+   * X-Weave-Backoff is not present.
+   */
+  @Test
+  public void testBackoffNotCalledIfBackoffHeaderNotPresent() {
+    try {
+      MockBackoffCallback callback = new MockBackoffCallback();
+      GlobalSession session = new MockGlobalSession(TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD,
+        new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY), callback);
+      HttpResponse response;
+      response = new BasicHttpResponse(
+          new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK"));       
+
+      session.interpretHTTPFailure(response);
+      assertEquals(false, callback.calledBackoff);
+      assertEquals(-1, callback.weaveBackoff);
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail("Got exception.");
+    }
+  }
+  
+  /**
+   * Test that interpretHTTPFailure calls requestBackoff with the
+   * largest specified value if X-Weave-Backoff and Retry-After are
+   * present.
+   */
+  @Test
+  public void testBackoffCalledIfMultipleBackoffHeadersPresent() {
+    try {
+      MockBackoffCallback callback = new MockBackoffCallback();
+      GlobalSession session = new MockGlobalSession(TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD,
+        new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY), callback);
+      HttpResponse response;
+      response = new BasicHttpResponse(
+          new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK"));       
+
+      response.addHeader("Retry-After", Integer.toString(TEST_BACKOFF_IN_SECONDS)); // Backoff given in seconds.
+      response.addHeader("X-Weave-Backoff", Integer.toString(TEST_BACKOFF_IN_SECONDS + 1)); // If we now add a second header, the larger should be returned.
+      session.interpretHTTPFailure(response); // This is synchronous...
+
+      assertEquals(true, callback.calledBackoff); // ... so we can test immediately.
+      assertEquals((TEST_BACKOFF_IN_SECONDS + 1) * 1000, callback.weaveBackoff); // Backoff returned in milliseconds.
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail("Got exception.");
+    }
+  }
+}

--- a/src/test/java/org/mozilla/android/sync/net/test/TestGlobalSession.java
+++ b/src/test/java/org/mozilla/android/sync/net/test/TestGlobalSession.java
@@ -15,9 +15,6 @@ import org.mozilla.gecko.sync.NonObjectJSONException;
 import org.mozilla.gecko.sync.SyncConfigurationException;
 import org.mozilla.gecko.sync.crypto.KeyBundle;
 import org.mozilla.gecko.sync.delegates.GlobalSessionCallback;
-import org.mozilla.gecko.sync.repositories.NoStoreDelegateException;
-import org.mozilla.gecko.sync.repositories.RepositorySession;
-import org.mozilla.gecko.sync.repositories.domain.Record;
 import org.mozilla.gecko.sync.stage.FetchInfoCollectionsStage;
 import org.mozilla.gecko.sync.stage.GlobalSyncStage.Stage;
 import org.mozilla.gecko.sync.net.SyncStorageResponse;
@@ -27,10 +24,10 @@ import ch.boye.httpclientandroidlib.ProtocolVersion;
 import ch.boye.httpclientandroidlib.message.BasicHttpResponse;
 import ch.boye.httpclientandroidlib.message.BasicStatusLine;
 
-import org.mozilla.android.sync.test.helpers.DefaultStoreDelegate;
 import org.mozilla.android.sync.test.helpers.MockSharedPreferences;
 import org.mozilla.android.sync.test.helpers.MockGlobalSession;
 import org.mozilla.android.sync.test.helpers.MockGlobalSessionCallback;
+import org.mozilla.android.sync.test.helpers.WaitHelper;
 
 public class TestGlobalSession {
   private final String TEST_CLUSTER_URL		= "http://localhost:8080/";
@@ -38,36 +35,7 @@ public class TestGlobalSession {
   private final String TEST_PASSWORD		= "password";
   private final String TEST_SYNC_KEY		= "abcdeabcdeabcdeabcdeabcdea";
   private final long   TEST_BACKOFF_IN_SECONDS	= 2401;
-
-  public class MockErrorCallback extends MockGlobalSessionCallback {
-    public boolean calledError = false;
-    public boolean calledBackoff = false;
-    public long backoffInSeconds = -1;
-    public long weaveBackoff = -1;
-
-    public MockErrorCallback(long backoffInSeconds) {
-      this.backoffInSeconds = backoffInSeconds;
-    }
-
-    @Override
-    public void requestBackoff(long backoff) {
-      this.calledBackoff = true;
-      this.weaveBackoff = backoff;
-      assertEquals(backoffInSeconds * 1000, this.weaveBackoff); // Backoff returned in milliseconds.
-    }
-    
-    @Override
-    public void handleSuccess(GlobalSession globalSession) {
-      fail("No success should occur.");
-    }
-
-    @Override
-    public void handleError(GlobalSession globalSession, Exception ex) {
-      this.calledError = true;
-      assertEquals(true, this.calledBackoff);
-    }
-  }
-
+  
   /**
    * A mock GlobalSession that fakes a 503 on info/collections and
    * sets X-Weave-Backoff header to the specified number of seconds.
@@ -103,32 +71,39 @@ public class TestGlobalSession {
       stages.put(Stage.fetchInfoCollections, new MockBackoffFetchInfoCollectionsStage());
     }
   }
-
+  
   /**
    * Test that handleHTTPError does in fact backoff.
    */
   @Test
   public void testBackoffCalledByHandleHTTPError() {
     try {
-      MockErrorCallback callback = new MockErrorCallback(TEST_BACKOFF_IN_SECONDS);
-      GlobalSession session = new MockGlobalSession(TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD,
+      final MockGlobalSessionCallback callback = new MockGlobalSessionCallback();
+      final GlobalSession session = new MockGlobalSession(TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD,
         new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY), callback);
       
-      HttpResponse response;
+      final HttpResponse response;
       response = new BasicHttpResponse(
-          new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 503, "Illegal method/protocol"));       
-      
+          new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 503, "Illegal method/protocol"));             
       response.addHeader("X-Weave-Backoff", Long.toString(TEST_BACKOFF_IN_SECONDS)); // Backoff given in seconds.
-      session.handleHTTPError(new SyncStorageResponse(response), "Illegal method/protocol"); // This is synchronous...
-
-      assertEquals(true, callback.calledBackoff); // ... so we can test immediately.
-      assertEquals(true, callback.calledError);      
+      
+      WaitHelper.getTestWaiter().performWaitAfterSpawningThread(new Runnable() {
+        public void run() {
+          session.handleHTTPError(new SyncStorageResponse(response), "Illegal method/protocol");
+        }
+      });
+      
+      assertEquals(false, callback.calledSuccess);
+      assertEquals(true,  callback.calledError);
+      assertEquals(false, callback.calledAborted);
+      assertEquals(true, callback.calledRequestBackoff);
       assertEquals(TEST_BACKOFF_IN_SECONDS * 1000, callback.weaveBackoff); // Backoff returned in milliseconds.
     } catch (Exception e) {
       e.printStackTrace();
       fail("Got exception.");
     }
   }
+  
 
   /**
    * Test that a trivially successful GlobalSession does not fail or backoff.
@@ -136,39 +111,55 @@ public class TestGlobalSession {
   @Test
   public void testSuccessCalledAfterStages() {
     try {
-      MockGlobalSessionCallback callback = new MockGlobalSessionCallback();
-      GlobalSession session = new MockGlobalSession(TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD,
+      final MockGlobalSessionCallback callback = new MockGlobalSessionCallback();
+      final GlobalSession session = new MockGlobalSession(TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD,
         new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY), callback);
 
-      this.performWait(new Runnable() {
-          @Override
-          public void run() {
+      WaitHelper.getTestWaiter().performWaitAfterSpawningThread(new Runnable() {
+        public void run() {
+          try {
             session.start();
-            /*session.setStoreDelegate(delegate);
-            try {
-              session.store(record);
-            } catch (NoStoreDelegateException e) {
-              fail("NoStoreDelegateException should not occur.");
-            }*/
+          } catch(Exception e) {
+            WaitHelper.getTestWaiter().performNotify(new AssertionError(e));
           }
-        });
+        }
+      });      
+      
+      assertEquals(true,  callback.calledSuccess);
+      assertEquals(false, callback.calledError);
+      assertEquals(false, callback.calledAborted);
+      assertEquals(false, callback.calledRequestBackoff);
     } catch (Exception e) {
       e.printStackTrace();
       fail("Got exception.");
     }
   }
-
+  
   /**
    * Test that a failing GlobalSession does in fact fail and back off.
    */
   @Test
   public void testBackoffCalledInStages() {
     try {
-      MockErrorCallback callback = new MockErrorCallback(TEST_BACKOFF_IN_SECONDS);
-      GlobalSession session = new MockBackoffGlobalSession(TEST_BACKOFF_IN_SECONDS, TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD,
+      final MockGlobalSessionCallback callback = new MockGlobalSessionCallback();
+      final GlobalSession session = new MockBackoffGlobalSession(TEST_BACKOFF_IN_SECONDS, TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD,
         new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY), callback);
 
-      session.start();
+      WaitHelper.getTestWaiter().performWaitAfterSpawningThread(new Runnable() {
+        public void run() {
+          try {
+            session.start();
+          } catch(Exception e) {
+            WaitHelper.getTestWaiter().performNotify(new AssertionError(e));
+          }
+        }
+      });
+      
+      assertEquals(false, callback.calledSuccess);
+      assertEquals(true,  callback.calledError);
+      assertEquals(false, callback.calledAborted);
+      assertEquals(true,  callback.calledRequestBackoff);
+      assertEquals(TEST_BACKOFF_IN_SECONDS * 1000, callback.weaveBackoff); // Backoff returned in milliseconds.
     } catch (Exception e) {
       e.printStackTrace();
       fail("Got exception.");

--- a/src/test/java/org/mozilla/android/sync/net/test/TestGlobalSession.java
+++ b/src/test/java/org/mozilla/android/sync/net/test/TestGlobalSession.java
@@ -56,8 +56,7 @@ public class TestGlobalSession {
     public class MockBackoffFetchInfoCollectionsStage extends FetchInfoCollectionsStage {
       @Override
       public void execute(GlobalSession session) {
-        HttpResponse response;
-        response = new BasicHttpResponse(
+        final HttpResponse response = new BasicHttpResponse(
             new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 503, "Illegal method/protocol"));
 
         response.addHeader("X-Weave-Backoff", Long.toString(backoffInSeconds)); // Backoff given in seconds.
@@ -82,8 +81,7 @@ public class TestGlobalSession {
       final GlobalSession session = new MockGlobalSession(TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD,
         new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY), callback);
 
-      final HttpResponse response;
-      response = new BasicHttpResponse(
+      final HttpResponse response = new BasicHttpResponse(
           new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 503, "Illegal method/protocol"));
       response.addHeader("X-Weave-Backoff", Long.toString(TEST_BACKOFF_IN_SECONDS)); // Backoff given in seconds.
 

--- a/src/test/java/org/mozilla/android/sync/net/test/TestGlobalSession.java
+++ b/src/test/java/org/mozilla/android/sync/net/test/TestGlobalSession.java
@@ -1,0 +1,168 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+package org.mozilla.android.sync.net.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+
+import org.json.simple.parser.ParseException;
+import org.junit.Test;
+import org.mozilla.gecko.sync.GlobalSession;
+import org.mozilla.gecko.sync.NonObjectJSONException;
+import org.mozilla.gecko.sync.SyncConfiguration;
+import org.mozilla.gecko.sync.SyncConfigurationException;
+import org.mozilla.gecko.sync.crypto.KeyBundle;
+import org.mozilla.gecko.sync.delegates.GlobalSessionCallback;
+import org.mozilla.gecko.sync.repositories.RecordFactory;
+import org.mozilla.gecko.sync.repositories.Repository;
+import org.mozilla.gecko.sync.stage.FetchInfoCollectionsStage;
+import org.mozilla.gecko.sync.stage.ServerSyncStage;
+import org.mozilla.gecko.sync.stage.GlobalSyncStage.Stage;
+import org.mozilla.gecko.sync.net.SyncStorageResponse;
+
+import ch.boye.httpclientandroidlib.HttpResponse;
+import ch.boye.httpclientandroidlib.ProtocolVersion;
+import ch.boye.httpclientandroidlib.message.BasicHttpResponse;
+import ch.boye.httpclientandroidlib.message.BasicStatusLine;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import org.mozilla.android.sync.test.helpers.MockSharedPreferences;
+import org.mozilla.android.sync.test.helpers.MockGlobalSession;
+import org.mozilla.android.sync.test.helpers.MockGlobalSessionCallback;
+
+public class TestGlobalSession {
+  private final String TEST_CLUSTER_URL		= "http://localhost:8080/";
+  private final String TEST_USERNAME		= "johndoe";
+  private final String TEST_PASSWORD		= "password";
+  private final String TEST_SYNC_KEY		= "abcdeabcdeabcdeabcdeabcdea";
+  private final long   TEST_BACKOFF_IN_SECONDS	= 2401;
+
+  public class MockErrorCallback extends MockGlobalSessionCallback {
+    public boolean calledError = false;
+    public boolean calledBackoff = false;
+    public long backoffInSeconds = -1;
+    public long weaveBackoff = -1;
+
+    public MockErrorCallback(long backoffInSeconds) {
+      this.backoffInSeconds = backoffInSeconds;
+    }
+
+    @Override
+    public void requestBackoff(long backoff) {
+      this.calledBackoff = true;
+      this.weaveBackoff = backoff;
+      assertEquals(backoffInSeconds * 1000, this.weaveBackoff); // Backoff returned in milliseconds.
+    }
+    
+    @Override
+    public void handleSuccess(GlobalSession globalSession) {
+      fail("No success should occur.");
+    }
+
+    @Override
+    public void handleError(GlobalSession globalSession, Exception ex) {
+      this.calledError = true;
+      assertEquals(true, this.calledBackoff);
+    }
+  }
+
+  /**
+   * A mock GlobalSession that fakes a 503 on info/collections and
+   * sets X-Weave-Backoff header to the specified number of seconds.
+   */
+  public class MockBackoffGlobalSession extends MockGlobalSession {
+
+    public MockSharedPreferences prefs;
+    public long backoffInSeconds = -1;
+    
+    public MockBackoffGlobalSession(long backoffInSeconds,
+				    String clusterURL, String username, String password,
+				    KeyBundle syncKeyBundle, GlobalSessionCallback callback)
+      throws SyncConfigurationException, IllegalArgumentException, IOException, ParseException, NonObjectJSONException {
+      super(clusterURL, username, password, syncKeyBundle, callback);
+      this.backoffInSeconds = backoffInSeconds;
+    }
+
+    public class MockBackoffFetchInfoCollectionsStage extends FetchInfoCollectionsStage {
+      @Override
+      public void execute(GlobalSession session) {
+	HttpResponse response;
+	response = new BasicHttpResponse(
+	  new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 503, "Illegal method/protocol"));       
+        
+	response.addHeader("X-Weave-Backoff", Long.toString(backoffInSeconds)); // Backoff given in seconds.        
+	session.handleHTTPError(new SyncStorageResponse(response), "Failure fetching info/collections.");
+      }
+    }
+
+    @Override
+    protected void prepareStages() {
+      super.prepareStages();
+      stages.put(Stage.fetchInfoCollections, new MockBackoffFetchInfoCollectionsStage());
+    }
+  }
+
+  /**
+   * Test that handleHTTPError does in fact backoff.
+   */
+  @Test
+  public void testBackoffCalledByHandleHTTPError() {
+    try {
+      MockErrorCallback callback = new MockErrorCallback(TEST_BACKOFF_IN_SECONDS);
+      GlobalSession session = new MockGlobalSession(TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD,
+        new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY), callback);
+      
+      HttpResponse response;
+      response = new BasicHttpResponse(
+          new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 503, "Illegal method/protocol"));       
+      
+      response.addHeader("X-Weave-Backoff", Long.toString(TEST_BACKOFF_IN_SECONDS)); // Backoff given in seconds.
+      session.handleHTTPError(new SyncStorageResponse(response), "Illegal method/protocol"); // This is synchronous...
+
+      assertEquals(true, callback.calledBackoff); // ... so we can test immediately.
+      assertEquals(true, callback.calledError);      
+      assertEquals(TEST_BACKOFF_IN_SECONDS * 1000, callback.weaveBackoff); // Backoff returned in milliseconds.
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail("Got exception.");
+    }
+  }
+
+  /**
+   * Test that a trivially successful GlobalSession does not fail or backoff.
+   */
+  @Test
+  public void testSuccessCalledAfterStages() {
+    try {
+      MockGlobalSessionCallback callback = new MockGlobalSessionCallback();
+      GlobalSession session = new MockGlobalSession(TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD,
+        new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY), callback);
+
+      session.start();
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail("Got exception.");
+    }
+  }
+
+  /**
+   * Test that a failing GlobalSession does in fact fail and back off.
+   */
+  @Test
+  public void testBackoffCalledInStages() {
+    try {
+      MockErrorCallback callback = new MockErrorCallback(TEST_BACKOFF_IN_SECONDS);
+      GlobalSession session = new MockBackoffGlobalSession(TEST_BACKOFF_IN_SECONDS, TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD,
+        new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY), callback);
+
+      session.start();
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail("Got exception.");
+    }
+  }
+}

--- a/src/test/java/org/mozilla/android/sync/net/test/TestGlobalSession.java
+++ b/src/test/java/org/mozilla/android/sync/net/test/TestGlobalSession.java
@@ -30,11 +30,11 @@ import org.mozilla.android.sync.test.helpers.MockGlobalSessionCallback;
 import org.mozilla.android.sync.test.helpers.WaitHelper;
 
 public class TestGlobalSession {
-  private final String TEST_CLUSTER_URL		= "http://localhost:8080/";
-  private final String TEST_USERNAME		= "johndoe";
-  private final String TEST_PASSWORD		= "password";
-  private final String TEST_SYNC_KEY		= "abcdeabcdeabcdeabcdeabcdea";
-  private final long   TEST_BACKOFF_IN_SECONDS	= 2401;
+  private final String TEST_CLUSTER_URL         = "http://localhost:8080/";
+  private final String TEST_USERNAME            = "johndoe";
+  private final String TEST_PASSWORD            = "password";
+  private final String TEST_SYNC_KEY            = "abcdeabcdeabcdeabcdeabcdea";
+  private final long   TEST_BACKOFF_IN_SECONDS  = 2401;
 
   /**
    * A mock GlobalSession that fakes a 503 on info/collections and

--- a/src/test/java/org/mozilla/android/sync/net/test/TestGlobalSession.java
+++ b/src/test/java/org/mozilla/android/sync/net/test/TestGlobalSession.java
@@ -35,7 +35,7 @@ public class TestGlobalSession {
   private final String TEST_PASSWORD		= "password";
   private final String TEST_SYNC_KEY		= "abcdeabcdeabcdeabcdeabcdea";
   private final long   TEST_BACKOFF_IN_SECONDS	= 2401;
-  
+
   /**
    * A mock GlobalSession that fakes a 503 on info/collections and
    * sets X-Weave-Backoff header to the specified number of seconds.
@@ -44,7 +44,7 @@ public class TestGlobalSession {
 
     public MockSharedPreferences prefs;
     public long backoffInSeconds = -1;
-    
+
     public MockBackoffGlobalSession(long backoffInSeconds,
 				    String clusterURL, String username, String password,
 				    KeyBundle syncKeyBundle, GlobalSessionCallback callback)
@@ -58,9 +58,9 @@ public class TestGlobalSession {
       public void execute(GlobalSession session) {
         HttpResponse response;
         response = new BasicHttpResponse(
-            new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 503, "Illegal method/protocol"));       
+            new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 503, "Illegal method/protocol"));
 
-        response.addHeader("X-Weave-Backoff", Long.toString(backoffInSeconds)); // Backoff given in seconds.        
+        response.addHeader("X-Weave-Backoff", Long.toString(backoffInSeconds)); // Backoff given in seconds.
         session.handleHTTPError(new SyncStorageResponse(response), "Failure fetching info/collections.");
       }
     }
@@ -71,7 +71,7 @@ public class TestGlobalSession {
       stages.put(Stage.fetchInfoCollections, new MockBackoffFetchInfoCollectionsStage());
     }
   }
-  
+
   /**
    * Test that handleHTTPError does in fact backoff.
    */
@@ -81,18 +81,18 @@ public class TestGlobalSession {
       final MockGlobalSessionCallback callback = new MockGlobalSessionCallback();
       final GlobalSession session = new MockGlobalSession(TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD,
         new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY), callback);
-      
+
       final HttpResponse response;
       response = new BasicHttpResponse(
-          new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 503, "Illegal method/protocol"));             
+          new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 503, "Illegal method/protocol"));
       response.addHeader("X-Weave-Backoff", Long.toString(TEST_BACKOFF_IN_SECONDS)); // Backoff given in seconds.
-      
+
       WaitHelper.getTestWaiter().performWaitAfterSpawningThread(new Runnable() {
         public void run() {
           session.handleHTTPError(new SyncStorageResponse(response), "Illegal method/protocol");
         }
       });
-      
+
       assertEquals(false, callback.calledSuccess);
       assertEquals(true,  callback.calledError);
       assertEquals(false, callback.calledAborted);
@@ -103,7 +103,7 @@ public class TestGlobalSession {
       fail("Got exception.");
     }
   }
-  
+
 
   /**
    * Test that a trivially successful GlobalSession does not fail or backoff.
@@ -123,8 +123,8 @@ public class TestGlobalSession {
             WaitHelper.getTestWaiter().performNotify(new AssertionError(e));
           }
         }
-      });      
-      
+      });
+
       assertEquals(true,  callback.calledSuccess);
       assertEquals(false, callback.calledError);
       assertEquals(false, callback.calledAborted);
@@ -134,7 +134,7 @@ public class TestGlobalSession {
       fail("Got exception.");
     }
   }
-  
+
   /**
    * Test that a failing GlobalSession does in fact fail and back off.
    */
@@ -154,7 +154,7 @@ public class TestGlobalSession {
           }
         }
       });
-      
+
       assertEquals(false, callback.calledSuccess);
       assertEquals(true,  callback.calledError);
       assertEquals(false, callback.calledAborted);

--- a/src/test/java/org/mozilla/android/sync/net/test/TestGlobalSession.java
+++ b/src/test/java/org/mozilla/android/sync/net/test/TestGlobalSession.java
@@ -57,7 +57,7 @@ public class TestGlobalSession {
       @Override
       public void execute(GlobalSession session) {
         final HttpResponse response = new BasicHttpResponse(
-            new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 503, "Illegal method/protocol"));
+          new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 503, "Illegal method/protocol"));
 
         response.addHeader("X-Weave-Backoff", Long.toString(backoffInSeconds)); // Backoff given in seconds.
         session.handleHTTPError(new SyncStorageResponse(response), "Failure fetching info/collections.");
@@ -82,7 +82,7 @@ public class TestGlobalSession {
         new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY), callback);
 
       final HttpResponse response = new BasicHttpResponse(
-          new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 503, "Illegal method/protocol"));
+        new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 503, "Illegal method/protocol"));
       response.addHeader("X-Weave-Backoff", Long.toString(TEST_BACKOFF_IN_SECONDS)); // Backoff given in seconds.
 
       WaitHelper.getTestWaiter().performWaitAfterSpawningThread(new Runnable() {
@@ -94,7 +94,7 @@ public class TestGlobalSession {
       assertEquals(false, callback.calledSuccess);
       assertEquals(true,  callback.calledError);
       assertEquals(false, callback.calledAborted);
-      assertEquals(true, callback.calledRequestBackoff);
+      assertEquals(true,  callback.calledRequestBackoff);
       assertEquals(TEST_BACKOFF_IN_SECONDS * 1000, callback.weaveBackoff); // Backoff returned in milliseconds.
     } catch (Exception e) {
       e.printStackTrace();

--- a/src/test/java/org/mozilla/android/sync/test/helpers/DefaultDelegate.java
+++ b/src/test/java/org/mozilla/android/sync/test/helpers/DefaultDelegate.java
@@ -1,0 +1,26 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+package org.mozilla.android.sync.test.helpers;
+
+import static junit.framework.Assert.fail;
+
+import java.util.concurrent.ExecutorService;
+
+public abstract class DefaultDelegate {
+
+  protected ExecutorService executor;
+
+  protected WaitHelper testWaiter() {
+    return WaitHelper.getTestWaiter();
+  }
+  
+  protected void sharedFail(String message) {
+    try {
+      fail(message);
+    } catch (AssertionError e) {
+      testWaiter().performNotify(e);
+    }
+  }
+  
+}

--- a/src/test/java/org/mozilla/android/sync/test/helpers/DefaultDelegate.java
+++ b/src/test/java/org/mozilla/android/sync/test/helpers/DefaultDelegate.java
@@ -14,7 +14,7 @@ public abstract class DefaultDelegate {
   protected WaitHelper testWaiter() {
     return WaitHelper.getTestWaiter();
   }
-  
+
   protected void sharedFail(String message) {
     try {
       fail(message);
@@ -22,5 +22,5 @@ public abstract class DefaultDelegate {
       testWaiter().performNotify(e);
     }
   }
-  
+
 }

--- a/src/test/java/org/mozilla/android/sync/test/helpers/MockGlobalSession.java
+++ b/src/test/java/org/mozilla/android/sync/test/helpers/MockGlobalSession.java
@@ -20,14 +20,14 @@ import org.mozilla.android.sync.test.helpers.MockSharedPreferences;
 
 public class MockGlobalSession extends GlobalSession {
 
-  public MockSharedPreferences prefs; 
-    
+  public MockSharedPreferences prefs;
+
   public MockGlobalSession(String clusterURL, String username, String password,
 				  KeyBundle syncKeyBundle, GlobalSessionCallback callback)
     throws SyncConfigurationException, IllegalArgumentException, IOException, ParseException, NonObjectJSONException {
     super(SyncConfiguration.DEFAULT_USER_API, clusterURL, username, password, null, syncKeyBundle, callback, /* context */ null, null);
   }
-    
+
   /*
    * PrefsSource methods.
    */

--- a/src/test/java/org/mozilla/android/sync/test/helpers/MockGlobalSession.java
+++ b/src/test/java/org/mozilla/android/sync/test/helpers/MockGlobalSession.java
@@ -12,20 +12,7 @@ import org.mozilla.gecko.sync.SyncConfiguration;
 import org.mozilla.gecko.sync.SyncConfigurationException;
 import org.mozilla.gecko.sync.crypto.KeyBundle;
 import org.mozilla.gecko.sync.delegates.GlobalSessionCallback;
-import org.mozilla.gecko.sync.repositories.RecordFactory;
-import org.mozilla.gecko.sync.repositories.Repository;
-import org.mozilla.gecko.sync.stage.EnsureClusterURLStage;
-import org.mozilla.gecko.sync.stage.EnsureKeysStage;
-import org.mozilla.gecko.sync.stage.FetchInfoCollectionsStage;
-import org.mozilla.gecko.sync.stage.FetchMetaGlobalStage;
-import org.mozilla.gecko.sync.stage.ServerSyncStage;
 import org.mozilla.gecko.sync.stage.GlobalSyncStage.Stage;
-import org.mozilla.gecko.sync.net.SyncStorageResponse;
-
-import ch.boye.httpclientandroidlib.HttpResponse;
-import ch.boye.httpclientandroidlib.ProtocolVersion;
-import ch.boye.httpclientandroidlib.message.BasicHttpResponse;
-import ch.boye.httpclientandroidlib.message.BasicStatusLine;
 
 import android.content.Context;
 import android.content.SharedPreferences;

--- a/src/test/java/org/mozilla/android/sync/test/helpers/MockGlobalSession.java
+++ b/src/test/java/org/mozilla/android/sync/test/helpers/MockGlobalSession.java
@@ -1,0 +1,71 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+package org.mozilla.android.sync.test.helpers;
+
+import java.io.IOException;
+
+import org.json.simple.parser.ParseException;
+import org.mozilla.gecko.sync.GlobalSession;
+import org.mozilla.gecko.sync.NonObjectJSONException;
+import org.mozilla.gecko.sync.SyncConfiguration;
+import org.mozilla.gecko.sync.SyncConfigurationException;
+import org.mozilla.gecko.sync.crypto.KeyBundle;
+import org.mozilla.gecko.sync.delegates.GlobalSessionCallback;
+import org.mozilla.gecko.sync.repositories.RecordFactory;
+import org.mozilla.gecko.sync.repositories.Repository;
+import org.mozilla.gecko.sync.stage.EnsureClusterURLStage;
+import org.mozilla.gecko.sync.stage.EnsureKeysStage;
+import org.mozilla.gecko.sync.stage.FetchInfoCollectionsStage;
+import org.mozilla.gecko.sync.stage.FetchMetaGlobalStage;
+import org.mozilla.gecko.sync.stage.ServerSyncStage;
+import org.mozilla.gecko.sync.stage.GlobalSyncStage.Stage;
+import org.mozilla.gecko.sync.net.SyncStorageResponse;
+
+import ch.boye.httpclientandroidlib.HttpResponse;
+import ch.boye.httpclientandroidlib.ProtocolVersion;
+import ch.boye.httpclientandroidlib.message.BasicHttpResponse;
+import ch.boye.httpclientandroidlib.message.BasicStatusLine;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import org.mozilla.android.sync.test.helpers.MockSharedPreferences;
+
+public class MockGlobalSession extends GlobalSession {
+
+  public MockSharedPreferences prefs; 
+    
+  public MockGlobalSession(String clusterURL, String username, String password,
+				  KeyBundle syncKeyBundle, GlobalSessionCallback callback)
+    throws SyncConfigurationException, IllegalArgumentException, IOException, ParseException, NonObjectJSONException {
+    super(SyncConfiguration.DEFAULT_USER_API, clusterURL, username, password, null, syncKeyBundle, callback, /* context */ null, null);
+  }
+    
+  /*
+   * PrefsSource methods.
+   */
+  @Override
+  public SharedPreferences getPrefs(String name, int mode) {
+    if (prefs == null) {
+      prefs = new MockSharedPreferences();
+    }
+    return prefs;
+  }
+
+  @Override
+  public Context getContext() {
+    return null;
+  }
+
+  @Override
+  protected void prepareStages() {
+    super.prepareStages();
+    // Fake whatever stages we don't want to run.
+    stages.put(Stage.syncBookmarks,           new MockServerSyncStage());
+    stages.put(Stage.syncHistory,             new MockServerSyncStage());
+    stages.put(Stage.fetchInfoCollections,    new MockServerSyncStage());
+    stages.put(Stage.fetchMetaGlobal,         new MockServerSyncStage());
+    stages.put(Stage.ensureKeysStage,         new MockServerSyncStage());
+    stages.put(Stage.ensureClusterURL,        new MockServerSyncStage());
+  }
+}

--- a/src/test/java/org/mozilla/android/sync/test/helpers/MockGlobalSessionCallback.java
+++ b/src/test/java/org/mozilla/android/sync/test/helpers/MockGlobalSessionCallback.java
@@ -13,7 +13,7 @@ import org.mozilla.android.sync.test.helpers.DefaultDelegate;
 /**
  * A callback for use with a GlobalSession that records what happens for later
  * inspection.
- * 
+ *
  * This callback is expected to be used from within the friendly confines of a
  * WaitHelper performWait.
  */
@@ -23,7 +23,7 @@ public class MockGlobalSessionCallback extends DefaultDelegate implements Global
   public boolean calledError = false;
   public boolean calledAborted = false;
   public boolean calledRequestBackoff = false;
-  public long weaveBackoff = -1; 
+  public long weaveBackoff = -1;
 
   @Override
   public void handleSuccess(GlobalSession globalSession) {

--- a/src/test/java/org/mozilla/android/sync/test/helpers/MockGlobalSessionCallback.java
+++ b/src/test/java/org/mozilla/android/sync/test/helpers/MockGlobalSessionCallback.java
@@ -6,28 +6,9 @@ package org.mozilla.android.sync.test.helpers;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-import java.io.IOException;
-
-import org.json.simple.parser.ParseException;
 import org.mozilla.gecko.sync.GlobalSession;
-import org.mozilla.gecko.sync.NonObjectJSONException;
-import org.mozilla.gecko.sync.SyncConfiguration;
-import org.mozilla.gecko.sync.SyncConfigurationException;
-import org.mozilla.gecko.sync.crypto.KeyBundle;
 import org.mozilla.gecko.sync.delegates.GlobalSessionCallback;
-import org.mozilla.gecko.sync.repositories.RecordFactory;
-import org.mozilla.gecko.sync.repositories.Repository;
 import org.mozilla.gecko.sync.stage.GlobalSyncStage.Stage;
-import org.mozilla.gecko.sync.net.SyncStorageResponse;
-
-import ch.boye.httpclientandroidlib.HttpResponse;
-import ch.boye.httpclientandroidlib.ProtocolVersion;
-import ch.boye.httpclientandroidlib.message.BasicHttpResponse;
-import ch.boye.httpclientandroidlib.message.BasicStatusLine;
-
-import android.content.Context;
-import android.content.SharedPreferences;
-import org.mozilla.android.sync.test.helpers.MockSharedPreferences;
 
 /**
  * A callback for use with a GlobalSession that ensures that

--- a/src/test/java/org/mozilla/android/sync/test/helpers/MockGlobalSessionCallback.java
+++ b/src/test/java/org/mozilla/android/sync/test/helpers/MockGlobalSessionCallback.java
@@ -1,0 +1,69 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+package org.mozilla.android.sync.test.helpers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+
+import org.json.simple.parser.ParseException;
+import org.mozilla.gecko.sync.GlobalSession;
+import org.mozilla.gecko.sync.NonObjectJSONException;
+import org.mozilla.gecko.sync.SyncConfiguration;
+import org.mozilla.gecko.sync.SyncConfigurationException;
+import org.mozilla.gecko.sync.crypto.KeyBundle;
+import org.mozilla.gecko.sync.delegates.GlobalSessionCallback;
+import org.mozilla.gecko.sync.repositories.RecordFactory;
+import org.mozilla.gecko.sync.repositories.Repository;
+import org.mozilla.gecko.sync.stage.GlobalSyncStage.Stage;
+import org.mozilla.gecko.sync.net.SyncStorageResponse;
+
+import ch.boye.httpclientandroidlib.HttpResponse;
+import ch.boye.httpclientandroidlib.ProtocolVersion;
+import ch.boye.httpclientandroidlib.message.BasicHttpResponse;
+import ch.boye.httpclientandroidlib.message.BasicStatusLine;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import org.mozilla.android.sync.test.helpers.MockSharedPreferences;
+
+/**
+ * A callback for use with a GlobalSession that ensures that
+ * handleSuccess is called after the final stage is completed.
+ */
+public class MockGlobalSessionCallback implements GlobalSessionCallback {
+  int stageCounter = Stage.values().length - 1; // Exclude starting state.
+  public boolean calledSuccess = false;
+    
+  public void handleError(GlobalSession globalSession, Exception ex) {
+    ex.printStackTrace();
+    fail("No error should occur.");
+  }
+
+  public void handleSuccess(GlobalSession globalSession) {
+    assertEquals(0, stageCounter);
+    calledSuccess = true;
+  }
+
+  public void handleStageCompleted(Stage currentState,
+				   GlobalSession globalSession) {
+    stageCounter--;
+  }
+
+  @Override
+  public void requestBackoff(long backoff) {
+    fail("Not expecting backoff.");
+  }
+
+  @Override
+  public void handleAborted(GlobalSession globalSession, String reason) {
+    fail("Not expecting abort.");
+  }
+
+  @Override
+  public boolean shouldBackOff() {
+    return false;
+  }
+}

--- a/src/test/java/org/mozilla/android/sync/test/helpers/MockServerSyncStage.java
+++ b/src/test/java/org/mozilla/android/sync/test/helpers/MockServerSyncStage.java
@@ -1,0 +1,63 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+package org.mozilla.android.sync.test.helpers;
+
+import java.io.IOException;
+
+import org.mozilla.gecko.sync.GlobalSession;
+import org.mozilla.gecko.sync.NonObjectJSONException;
+import org.mozilla.gecko.sync.SyncConfiguration;
+import org.mozilla.gecko.sync.SyncConfigurationException;
+import org.mozilla.gecko.sync.crypto.KeyBundle;
+import org.mozilla.gecko.sync.delegates.GlobalSessionCallback;
+import org.mozilla.gecko.sync.repositories.RecordFactory;
+import org.mozilla.gecko.sync.repositories.Repository;
+import org.mozilla.gecko.sync.stage.EnsureClusterURLStage;
+import org.mozilla.gecko.sync.stage.EnsureKeysStage;
+import org.mozilla.gecko.sync.stage.FetchInfoCollectionsStage;
+import org.mozilla.gecko.sync.stage.FetchMetaGlobalStage;
+import org.mozilla.gecko.sync.stage.ServerSyncStage;
+import org.mozilla.gecko.sync.stage.GlobalSyncStage.Stage;
+import org.mozilla.gecko.sync.net.SyncStorageResponse;
+
+import ch.boye.httpclientandroidlib.HttpResponse;
+import ch.boye.httpclientandroidlib.ProtocolVersion;
+import ch.boye.httpclientandroidlib.message.BasicHttpResponse;
+import ch.boye.httpclientandroidlib.message.BasicStatusLine;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import org.mozilla.android.sync.test.helpers.MockSharedPreferences;
+
+public class MockServerSyncStage extends ServerSyncStage {
+  @Override
+  public boolean isEnabled() {
+    return false;
+  }
+
+  @Override
+  protected String getCollection() {
+    return null;
+  }
+
+  @Override
+  protected Repository getLocalRepository() {
+    return null;
+  }
+
+  @Override
+  protected String getEngineName() {
+    return null;
+  }
+
+  @Override
+  protected RecordFactory getRecordFactory() {
+    return null;
+  }
+
+  @Override
+  public void execute(GlobalSession session) {
+    session.advance();
+  }
+}

--- a/src/test/java/org/mozilla/android/sync/test/helpers/MockServerSyncStage.java
+++ b/src/test/java/org/mozilla/android/sync/test/helpers/MockServerSyncStage.java
@@ -3,32 +3,10 @@
 
 package org.mozilla.android.sync.test.helpers;
 
-import java.io.IOException;
-
 import org.mozilla.gecko.sync.GlobalSession;
-import org.mozilla.gecko.sync.NonObjectJSONException;
-import org.mozilla.gecko.sync.SyncConfiguration;
-import org.mozilla.gecko.sync.SyncConfigurationException;
-import org.mozilla.gecko.sync.crypto.KeyBundle;
-import org.mozilla.gecko.sync.delegates.GlobalSessionCallback;
 import org.mozilla.gecko.sync.repositories.RecordFactory;
 import org.mozilla.gecko.sync.repositories.Repository;
-import org.mozilla.gecko.sync.stage.EnsureClusterURLStage;
-import org.mozilla.gecko.sync.stage.EnsureKeysStage;
-import org.mozilla.gecko.sync.stage.FetchInfoCollectionsStage;
-import org.mozilla.gecko.sync.stage.FetchMetaGlobalStage;
 import org.mozilla.gecko.sync.stage.ServerSyncStage;
-import org.mozilla.gecko.sync.stage.GlobalSyncStage.Stage;
-import org.mozilla.gecko.sync.net.SyncStorageResponse;
-
-import ch.boye.httpclientandroidlib.HttpResponse;
-import ch.boye.httpclientandroidlib.ProtocolVersion;
-import ch.boye.httpclientandroidlib.message.BasicHttpResponse;
-import ch.boye.httpclientandroidlib.message.BasicStatusLine;
-
-import android.content.Context;
-import android.content.SharedPreferences;
-import org.mozilla.android.sync.test.helpers.MockSharedPreferences;
 
 public class MockServerSyncStage extends ServerSyncStage {
   @Override

--- a/src/test/java/org/mozilla/android/sync/test/helpers/MockSharedPreferences.java
+++ b/src/test/java/org/mozilla/android/sync/test/helpers/MockSharedPreferences.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2010 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mozilla.android.sync.test.helpers;
+
+import android.content.SharedPreferences;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A programmable mock content provider.
+ */
+public class MockSharedPreferences implements SharedPreferences, SharedPreferences.Editor {
+  private HashMap<String, Object> mValues;
+  private HashMap<String, Object> mTempValues;
+
+  public MockSharedPreferences() {
+    mValues = new HashMap<String, Object>();
+    mTempValues = new HashMap<String, Object>();
+  }
+  
+  public Editor edit() {
+    return this;
+  }
+
+  public boolean contains(String key) {
+    return mValues.containsKey(key);
+  }
+
+  public Map<String, ?> getAll() {
+    return new HashMap<String, Object>(mValues);
+  }
+
+  public boolean getBoolean(String key, boolean defValue) {
+    if (mValues.containsKey(key)) {
+      return ((Boolean)mValues.get(key)).booleanValue();
+    }
+    return defValue;
+  }
+
+  public float getFloat(String key, float defValue) {
+    if (mValues.containsKey(key)) {
+      return ((Float)mValues.get(key)).floatValue();
+    }
+    return defValue;
+  }
+
+  public int getInt(String key, int defValue) {
+    if (mValues.containsKey(key)) {
+      return ((Integer)mValues.get(key)).intValue();
+    }
+    return defValue;
+  }
+
+  public long getLong(String key, long defValue) {
+    if (mValues.containsKey(key)) {
+      return ((Long)mValues.get(key)).longValue();
+    }
+    return defValue;
+  }
+
+  public String getString(String key, String defValue) {
+    if (mValues.containsKey(key))
+      return (String)mValues.get(key);
+    return defValue;
+  }
+
+  @SuppressWarnings("unchecked")
+  public Set<String> getStringSet(String key, Set<String> defValues) {
+    if (mValues.containsKey(key)) {
+      return (Set<String>) mValues.get(key);
+    }
+    return defValues;
+  }
+
+  public void registerOnSharedPreferenceChangeListener(
+    OnSharedPreferenceChangeListener listener) {
+    throw new UnsupportedOperationException();
+  }
+
+  public void unregisterOnSharedPreferenceChangeListener(
+    OnSharedPreferenceChangeListener listener) {
+    throw new UnsupportedOperationException();
+  }
+
+  public Editor putBoolean(String key, boolean value) {
+    mTempValues.put(key, Boolean.valueOf(value));
+    return this;
+  }
+
+  public Editor putFloat(String key, float value) {
+    mTempValues.put(key, value);
+    return this;
+  }
+
+  public Editor putInt(String key, int value) {
+    mTempValues.put(key, value);
+    return this;
+  }
+
+  public Editor putLong(String key, long value) {
+    mTempValues.put(key, value);
+    return this;
+  }
+
+  public Editor putString(String key, String value) {
+    mTempValues.put(key, value);
+    return this;
+  }
+
+  public Editor putStringSet(String key, Set<String> values) {
+    mTempValues.put(key, values);
+    return this;
+  }
+
+  public Editor remove(String key) {
+    mTempValues.remove(key);
+    return this;
+  }
+
+  public Editor clear() {
+    mTempValues.clear();
+    return this;
+  }
+
+  @SuppressWarnings("unchecked")
+  public boolean commit() {
+    mValues = (HashMap<String, Object>)mTempValues.clone();
+    return true;
+  }
+
+  public void apply() {
+    commit();
+  }
+}

--- a/src/test/java/org/mozilla/android/sync/test/helpers/MockSharedPreferences.java
+++ b/src/test/java/org/mozilla/android/sync/test/helpers/MockSharedPreferences.java
@@ -33,7 +33,7 @@ public class MockSharedPreferences implements SharedPreferences, SharedPreferenc
     mValues = new HashMap<String, Object>();
     mTempValues = new HashMap<String, Object>();
   }
-  
+
   public Editor edit() {
     return this;
   }

--- a/src/test/java/org/mozilla/android/sync/test/helpers/WaitHelper.java
+++ b/src/test/java/org/mozilla/android/sync/test/helpers/WaitHelper.java
@@ -56,7 +56,7 @@ public class WaitHelper {
    * Some things need to be tested asynchronously, and in order to wait
    * properly, a separate thread must be spawned -- see the class comment. This
    * helper function spawns that separate thread.
-   * 
+   *
    * @param runnable
    *          A Runnable to be executed in it's own thread.
    */
@@ -69,7 +69,7 @@ public class WaitHelper {
         }
       });
   }
-  
+
   public synchronized void performNotify(AssertionError e) {
     if (e != null) {
       Log.i("WaitHelper", "performNotify called with AssertionError " + e);

--- a/src/test/java/org/mozilla/android/sync/test/helpers/WaitHelper.java
+++ b/src/test/java/org/mozilla/android/sync/test/helpers/WaitHelper.java
@@ -1,0 +1,93 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+package org.mozilla.android.sync.test.helpers;
+
+import org.mozilla.gecko.sync.ThreadPool;
+
+import android.util.Log;
+
+/**
+ * Implements waiting for asynchronous test events.
+ * @author rnewman
+ *
+ */
+public class WaitHelper {
+  AssertionError lastAssertion = null;
+
+  /**
+   * We take a Runnable as a parameter so that it'll be invoked inside the
+   * synchronized session, which allows us to be waiting by the time the
+   * Runnable executes.
+   *
+   * action *must* start a new thread before attempting to wait or notify
+   * this helper, otherwise this trick doesn't work!
+   *
+   * @param action
+   * @throws AssertionError
+   */
+  public synchronized void performWait(Runnable action) throws AssertionError {
+    Log.i("WaitHelper", "performWait called.");
+    try {
+      if (action != null) {
+        try {
+          action.run();
+        } catch (Exception ex) {
+          throw new AssertionError(ex);
+        }
+      }
+      WaitHelper.this.wait();
+      // Rethrow any assertion with which we were notified.
+      if (this.lastAssertion != null) {
+        AssertionError e = this.lastAssertion;
+        this.lastAssertion = null;
+        throw e;
+      }
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+
+  public synchronized void performWait() throws AssertionError {
+    this.performWait(null);
+  }
+
+  /**
+   * Some things need to be tested asynchronously, and in order to wait
+   * properly, a separate thread must be spawned -- see the class comment. This
+   * helper function spawns that separate thread.
+   * 
+   * @param runnable
+   *          A Runnable to be executed in it's own thread.
+   */
+  public void performWaitAfterSpawningThread(final Runnable runnable) {
+    Log.i("WaitHelper", "performWaitAfterSpawningThread called with Runnable " + runnable);
+    this.performWait(
+      new Runnable() {
+        public void run() {
+          ThreadPool.run(runnable);
+        }
+      });
+  }
+  
+  public synchronized void performNotify(AssertionError e) {
+    if (e != null) {
+      Log.i("WaitHelper", "performNotify called with AssertionError " + e);
+    }
+    this.lastAssertion = e;
+    WaitHelper.this.notify();
+  }
+
+  public void performNotify() {
+    Log.i("WaitHelper", "performNotify called.");
+    this.performNotify(null);
+  }
+
+  private static WaitHelper singleWaiter;
+  public static WaitHelper getTestWaiter() {
+    if (singleWaiter == null) {
+      singleWaiter = new WaitHelper();
+    }
+    return singleWaiter;
+  }
+}


### PR DESCRIPTION
Address rnewman's feedback from https://github.com/mozilla-services/android-sync/commit/b11b5782f804f996ed30189a60d18a5536f3daeb#commitcomment-884685.

I addressed all nits.  I addressed the synchronous concerns in GlobalSesson.start -- this is done incorrectly in the test-android-sync git repo as well (patch to follow).

I did NOT split exactly as rnewman suggested.  I factored out various Mocks for re-use, but I split based on the callback's behaviour instead of on the async behaviour.  This reduced code duplication better.
