### PR TITLE
Bug 709348 - equality work.

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/CryptoRecord.java
+++ b/src/main/java/org/mozilla/gecko/sync/CryptoRecord.java
@@ -130,6 +130,17 @@ public class CryptoRecord extends Record {
     super(source.guid, source.collection, source.lastModified, source.deleted);
   }
 
+  @Override
+  public Record copyWithIDs(String guid, long androidID) {
+    CryptoRecord out = new CryptoRecord(this);
+    out.guid         = guid;
+    out.androidID    = androidID;
+    out.sortIndex    = this.sortIndex;
+    out.payload      = (this.payload == null) ? null : new ExtendedJSONObject(this.payload.object);
+    out.keyBundle    = this.keyBundle;    // TODO: copy me?
+    return out;
+  }
+
   /**
    * Take a whole record as JSON -- i.e., something like
    *

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
@@ -56,7 +56,6 @@ import android.content.Context;
 import android.database.Cursor;
 import android.util.Log;
 
-
 public class AndroidBrowserBookmarksRepositorySession extends AndroidBrowserRepositorySession {
 
   // TODO: synchronization for these.

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserRepositorySession.java
@@ -41,6 +41,7 @@ package org.mozilla.gecko.sync.repositories.android;
 import java.util.ArrayList;
 import java.util.HashMap;
 
+import org.mozilla.gecko.sync.Utils;
 import org.mozilla.gecko.sync.repositories.InactiveSessionException;
 import org.mozilla.gecko.sync.repositories.InvalidRequestException;
 import org.mozilla.gecko.sync.repositories.InvalidSessionTransitionException;
@@ -340,6 +341,15 @@ public abstract class AndroidBrowserRepositorySession extends RepositorySession 
   @Override
   public void fetchAll(RepositorySessionFetchRecordsDelegate delegate) {
     this.fetchSince(0, delegate);
+  }
+
+  private void trace(String m) {
+    if (Utils.ENABLE_TRACE_LOGGING) {
+      if (Utils.LOG_TO_STDOUT) {
+        System.out.println(LOG_TAG + "::TRACE " + m);
+      }
+      Log.d(LOG_TAG, m);
+    }
   }
 
   @Override

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserRepositorySession.java
@@ -373,9 +373,11 @@ public abstract class AndroidBrowserRepositorySession extends RepositorySession 
           return;
         }
 
-        // Check that the record is a valid type
-        // TODO Currently for bookmarks we only take care of folders
-        // and bookmarks, all other types are ignored and thrown away
+        // Check that the record is a valid type.
+        // Fennec only supports bookmarks and folders. All other types of records,
+        // including livemarks and queries, are simply ignored.
+        // See Bug 708149. This might be resolved by Fennec changing its database
+        // schema, or by Sync storing non-applied records in its own private database.
         if (!checkRecordType(record)) {
           Log.d(LOG_TAG, "Ignoring record " + record.guid + " due to unknown record type.");
 

--- a/src/main/java/org/mozilla/gecko/sync/repositories/domain/BookmarkRecord.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/domain/BookmarkRecord.java
@@ -230,15 +230,14 @@ public class BookmarkRecord extends Record {
   }
 
   @Override
-  public boolean equals(Object o) {
-    trace("Calling BookmarkRecord.equals.");
-    if (!(o instanceof BookmarkRecord)) {
+  public boolean equalPayloads(Object o) {
+    trace("Calling BookmarkRecord.equalPayloads.");
+    if (o == null || !(o instanceof BookmarkRecord)) {
       return false;
     }
 
     BookmarkRecord other = (BookmarkRecord) o;
-    
-    if (!super.equals(other)) {
+    if (!super.equalPayloads(other)) {
       return false;
     }
 
@@ -281,8 +280,15 @@ public class BookmarkRecord extends Record {
         && RepoUtils.stringsEqual(this.keyword, other.keyword)
         && jsonArrayStringsEqual(this.tags, other.tags);
   }
-  
-  // Converts to JSONArrays to strings and checks if they are the same.
+
+  // TODO: two records can be congruent if their child lists are different.
+  @Override
+  public boolean congruentWith(Object o) {
+    return this.equalPayloads(o) &&
+           super.congruentWith(o);
+  }
+
+  // Converts two JSONArrays to strings and checks if they are the same.
   // This is only useful for stuff like tags where we aren't actually
   // touching the data there (and therefore ordering won't change)
   private boolean jsonArrayStringsEqual(JSONArray a, JSONArray b) {
@@ -292,7 +298,6 @@ public class BookmarkRecord extends Record {
     if (a != null && b == null) return false;
     return RepoUtils.stringsEqual(a.toJSONString(), b.toJSONString());
   }
-
 }
 
 

--- a/src/main/java/org/mozilla/gecko/sync/repositories/domain/BookmarkRecord.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/domain/BookmarkRecord.java
@@ -95,6 +95,51 @@ public class BookmarkRecord extends Record {
            parentID + "/" + androidParentID + "/" + parentName + ">";
   }
 
+  // Oh God, this is terribly thread-unsafe. These record objects should be immutable.
+  @SuppressWarnings("unchecked")
+  protected JSONArray copyChildren() {
+    if (this.children == null) {
+      return null;
+    }
+    JSONArray children = new JSONArray();
+    children.addAll(this.children);
+    return children;
+  }
+
+  @SuppressWarnings("unchecked")
+  protected JSONArray copyTags() {
+    if (this.tags == null) {
+      return null;
+    }
+    JSONArray tags = new JSONArray();
+    tags.addAll(this.tags);
+    return tags;
+  }
+
+  @Override
+  public Record copyWithIDs(String guid, long androidID) {
+    BookmarkRecord out = new BookmarkRecord(guid, this.collection, this.lastModified, this.deleted);
+    out.androidID = androidID;
+    out.sortIndex = this.sortIndex;
+
+    // Copy BookmarkRecord fields.
+    out.title           = this.title;
+    out.bookmarkURI     = this.bookmarkURI;
+    out.description     = this.description;
+    out.keyword         = this.keyword;
+    out.parentID        = this.parentID;
+    out.parentName      = this.parentName;
+    out.androidParentID = this.androidParentID;
+    out.type            = this.type;
+    out.pos             = this.pos;
+    out.androidPosition = this.androidPosition;
+
+    out.children        = this.copyChildren();
+    out.tags            = this.copyTags();
+
+    return out;
+  }
+
   @Override
   public void initFromPayload(CryptoRecord payload) {
     ExtendedJSONObject p = payload.payload;

--- a/src/main/java/org/mozilla/gecko/sync/repositories/domain/HistoryRecord.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/domain/HistoryRecord.java
@@ -175,6 +175,21 @@ public class HistoryRecord extends Record {
            checkVisitsEquals(other);
   }
 
+  @Override
+  public boolean equalAndroidIDs(Record other) {
+    return super.equalAndroidIDs(other) &&
+           this.equalFennecVisits(other);
+  }
+
+  private boolean equalFennecVisits(Record other) {
+    if (!(other instanceof HistoryRecord)) {
+      return false;
+    }
+    HistoryRecord h = (HistoryRecord) other;
+    return this.fennecDateVisited == h.fennecDateVisited &&
+           this.fennecVisitCount  == h.fennecVisitCount;
+  }
+
   private boolean checkVisitsEquals(HistoryRecord other) {
     Log.d(LOG_TAG, "Checking visits.");
     Log.d(LOG_TAG, ">> Mine:   " + this.visits == null ? "null" : this.visits.toJSONString());

--- a/src/main/java/org/mozilla/gecko/sync/repositories/domain/HistoryRecord.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/domain/HistoryRecord.java
@@ -83,6 +83,32 @@ public class HistoryRecord extends Record {
   public long      fennecDateVisited;
   public long      fennecVisitCount;
 
+  @SuppressWarnings("unchecked")
+  private JSONArray copyVisits() {
+    if (this.visits == null) {
+      return null;
+    }
+    JSONArray out = new JSONArray();
+    out.addAll(this.visits);
+    return out;
+  }
+
+  @Override
+  public Record copyWithIDs(String guid, long androidID) {
+    HistoryRecord out = new HistoryRecord(guid, this.collection, this.lastModified, this.deleted);
+    out.androidID = androidID;
+    out.sortIndex = this.sortIndex;
+
+    // Copy HistoryRecord fields.
+    out.title             = this.title;
+    out.histURI           = this.histURI;
+    out.fennecDateVisited = this.fennecDateVisited;
+    out.fennecVisitCount  = this.fennecVisitCount;
+    out.visits            = this.copyVisits();
+
+    return out;
+  }
+
   @Override
   public void initFromPayload(CryptoRecord payload) {
     ExtendedJSONObject p = payload.payload;

--- a/src/main/java/org/mozilla/gecko/sync/repositories/domain/HistoryRecord.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/domain/HistoryRecord.java
@@ -192,8 +192,10 @@ public class HistoryRecord extends Record {
 
   private boolean checkVisitsEquals(HistoryRecord other) {
     Log.d(LOG_TAG, "Checking visits.");
-    Log.d(LOG_TAG, ">> Mine:   " + this.visits == null ? "null" : this.visits.toJSONString());
-    Log.d(LOG_TAG, ">> Theirs: " + other.visits == null ? "null" : other.visits.toJSONString());
+    if (Utils.ENABLE_TRACE_LOGGING) {
+      Log.d(LOG_TAG, ">> Mine:   " + ((this.visits == null) ? "null" : this.visits.toJSONString()));
+      Log.d(LOG_TAG, ">> Theirs: " + ((other.visits == null) ? "null" : other.visits.toJSONString()));
+    }
 
     // Handle nulls.
     if (this.visits == other.visits) {

--- a/src/main/java/org/mozilla/gecko/sync/repositories/domain/HistoryRecord.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/domain/HistoryRecord.java
@@ -141,32 +141,45 @@ public class HistoryRecord extends Record {
     return rec;
   }
 
-  public boolean equalsExceptVisits(Object o) {
-    if (!(o instanceof HistoryRecord)) {
+
+  /**
+   * We consider two history records to be congruent if they represent the
+   * same history record regardless of visits.
+   */
+  @Override
+  public boolean congruentWith(Object o) {
+    if (o == null || !(o instanceof HistoryRecord)) {
       return false;
     }
     HistoryRecord other = (HistoryRecord) o;
-    return super.equals(other) &&
-           RepoUtils.stringsEqual(this.title, other.title) &&
+    if (!super.congruentWith(other)) {
+      return false;
+    }
+    return RepoUtils.stringsEqual(this.title, other.title) &&
            RepoUtils.stringsEqual(this.histURI, other.histURI);
   }
 
-  public boolean equalsIncludingVisits(Object o) {
-    HistoryRecord other = (HistoryRecord) o;
-    return equalsExceptVisits(other) && this.checkVisitsEquals(other);
-  }
-
   @Override
-  /**
-   * We consider two history records to be equal if they represent the
-   * same history record regardless of visits.
-   */
-  public boolean equals(Object o) {
-    return equalsExceptVisits(o);
+  public boolean equalPayloads(Object o) {
+    if (o == null || !(o instanceof HistoryRecord)) {
+      Log.d(LOG_TAG, "Not a HistoryRecord: " + o);
+      return false;
+    }
+    HistoryRecord other = (HistoryRecord) o;
+    if (!super.equalPayloads(other)) {
+      Log.d(LOG_TAG, "super.equalPayloads returned false.");
+      return false;
+    }
+    return RepoUtils.stringsEqual(this.title, other.title) &&
+           RepoUtils.stringsEqual(this.histURI, other.histURI) &&
+           checkVisitsEquals(other);
   }
 
   private boolean checkVisitsEquals(HistoryRecord other) {
-    
+    Log.d(LOG_TAG, "Checking visits.");
+    Log.d(LOG_TAG, ">> Mine:   " + this.visits == null ? "null" : this.visits.toJSONString());
+    Log.d(LOG_TAG, ">> Theirs: " + other.visits == null ? "null" : other.visits.toJSONString());
+
     // Handle nulls.
     if (this.visits == other.visits) {
       return true;

--- a/src/main/java/org/mozilla/gecko/sync/repositories/domain/PasswordRecord.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/domain/PasswordRecord.java
@@ -110,10 +110,33 @@ public class PasswordRecord extends Record {
   }
   
   @Override
-  public boolean equals(Object o) {
-    if (!o.getClass().equals(PasswordRecord.class)) return false;
+  public boolean congruentWith(Object o) {
+    if (o == null || !(o instanceof PasswordRecord)) {
+      return false;
+    }
     PasswordRecord other = (PasswordRecord) o;
-    if (!super.equals(other)) return false;
+    if (!super.congruentWith(other)) {
+      return false;
+    }
+    return RepoUtils.stringsEqual(this.hostname, other.hostname)
+        && RepoUtils.stringsEqual(this.formSubmitURL, other.formSubmitURL)
+        && RepoUtils.stringsEqual(this.httpRealm, other.httpRealm)
+        && RepoUtils.stringsEqual(this.username, other.username)
+        && RepoUtils.stringsEqual(this.password, other.password)
+        && RepoUtils.stringsEqual(this.usernameField, other.usernameField)
+        && RepoUtils.stringsEqual(this.passwordField, other.passwordField)
+        && RepoUtils.stringsEqual(this.encType, other.encType);
+  }
+
+  @Override
+  public boolean equalPayloads(Object o) {
+    if (o == null || !(o instanceof PasswordRecord)) {
+      return false;
+    }
+    PasswordRecord other = (PasswordRecord) o;
+    if (!super.equalPayloads(other)) {
+      return false;
+    }
     return RepoUtils.stringsEqual(this.hostname, other.hostname)
         && RepoUtils.stringsEqual(this.formSubmitURL, other.formSubmitURL)
         && RepoUtils.stringsEqual(this.httpRealm, other.httpRealm)

--- a/src/main/java/org/mozilla/gecko/sync/repositories/domain/PasswordRecord.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/domain/PasswordRecord.java
@@ -75,6 +75,28 @@ public class PasswordRecord extends Record {
   public long   timeLastUsed;
   public long   timesUsed;
 
+
+  @Override
+  public Record copyWithIDs(String guid, long androidID) {
+    PasswordRecord out = new PasswordRecord(guid, this.collection, this.lastModified, this.deleted);
+    out.androidID = androidID;
+    out.sortIndex = this.sortIndex;
+
+    // Copy HistoryRecord fields.
+    out.hostname      = this.hostname;
+    out.formSubmitURL = this.formSubmitURL;
+    out.httpRealm     = this.httpRealm;
+    out.username      = this.username;
+    out.password      = this.password;
+    out.usernameField = this.usernameField;
+    out.passwordField = this.passwordField;
+    out.encType       = this.encType;
+    out.timeLastUsed  = this.timeLastUsed;
+    out.timesUsed     = this.timesUsed;
+
+    return out;
+  }
+
   @Override
   public void initFromPayload(CryptoRecord payload) {
     // TODO Auto-generated method stub

--- a/src/main/java/org/mozilla/gecko/sync/repositories/domain/Record.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/domain/Record.java
@@ -43,8 +43,62 @@ import java.io.UnsupportedEncodingException;
 import org.mozilla.gecko.sync.CryptoRecord;
 import org.mozilla.gecko.sync.ExtendedJSONObject;
 
+/**
+ * Record is the abstract base class for all entries that Sync processes:
+ * bookmarks, passwords, history, and such.
+ *
+ * A Record can be initialized from or serialized to a CryptoRecord for
+ * submission to an encrypted store.
+ *
+ * Records should be considered to be conventionally immutable: modifications
+ * should be completed before the new record object escapes its constructing
+ * scope. Note that this is a critically important part of equality. As Rich
+ * Hickey notes:
+ *
+ *   … the only things you can really compare for equality are immutable things,
+ *   because if you compare two things for equality that are mutable, and ever
+ *   say true, and they're ever not the same thing, you are wrong. Or you will
+ *   become wrong at some point in the future.
+ *
+ * Records have a layered definition of equality. Two records can be said to be
+ * "equal" if:
+ *
+ * * They have the same GUID and collection. Two crypto/keys records are in some
+ *   way "the same".
+ *   This is `equalIdentifiers`.
+ *
+ * * Their most significant fields are the same. That is to say, they share a
+ *   GUID, a collection, deletion, and domain-specific fields. Two copies of
+ *   crypto/keys, neither deleted, with the same encrypted data but different
+ *   modified times and sortIndex are in a stronger way "the same".
+ *   This is `equalPayloads`.
+ *
+ * * Their most significant fields are the same, and their local fields (e.g.,
+ *   the androidID to which we have decided that this record maps) are congruent.
+ *   A record with the same androidID, or one whose androidID has not been set,
+ *   can be considered "the same".
+ *   This concept can be extended by Record subclasses. The key point is that
+ *   reconciling should be applied to the contents of these records. For example,
+ *   two history records with the same URI and GUID, but different visit arrays,
+ *   can be said to be congruent.
+ *   This is `congruentWith`.
+ *
+ * * They are strictly identical. Every field that is persisted, including
+ *   lastModified and androidID, is equal.
+ *   This is `equals`.
+ *
+ * Different parts of the codebase have use for different layers of this
+ * comparison hierarchy. For instance, lastModified times change every time a
+ * record is stored; a store followed by a retrieval will return a Record that
+ * shares its most significant fields with the input, but has a later
+ * lastModified time and might not yet have values set for others. Reconciling
+ * will thus ignore the modification time of a record.
+ *
+ * @author rnewman
+ *
+ */
 public abstract class Record {
-  // TODO: consider immutability, effective immutability, and thread-safety.
+
   public String guid;
   public String collection;
   public long lastModified;
@@ -58,16 +112,22 @@ public abstract class Record {
     this.lastModified = lastModified;
     this.deleted      = deleted;
     this.sortIndex    = 0;
+    this.androidID    = -1;
   }
 
-  @Override
-  public boolean equals(Object o) {
-    if (o == null) {
+  /**
+   * Return true iff the input is a Record and has the same
+   * collection and guid as this object.
+   *
+   * @param o
+   * @return
+   */
+  public boolean equalIdentifiers(Object o) {
+    if (o == null || !(o instanceof Record)) {
       return false;
     }
 
     Record other = (Record) o;
-
     if (this.guid == null) {
       if (other.guid != null) {
         return false;
@@ -77,7 +137,6 @@ public abstract class Record {
         return false;
       }
     }
-
     if (this.collection == null) {
       if (other.collection != null) {
         return false;
@@ -87,11 +146,82 @@ public abstract class Record {
         return false;
       }
     }
+    return true;
+  }
 
-    if (this.deleted != other.deleted) {
+  /**
+   * Return true iff the input is a Record which is substantially the
+   * same as this object.
+   *
+   * @param o
+   * @return
+   */
+  public boolean equalPayloads(Object o) {
+    if (!this.equalIdentifiers(o)) {
+      return false;
+    }
+    Record other = (Record) o;
+    return this.deleted == other.deleted;
+  }
+
+  /**
+   * Return true iff the input is a Record which is substantially the
+   * same as this object, considering the ability and desire two
+   * reconcile the two objects if possible.
+   *
+   * @param o
+   * @return
+   */
+  public boolean congruentWith(Object o) {
+    if (!this.equalIdentifiers(o)) {
+      return false;
+    }
+    Record other = (Record) o;
+    return congruentAndroidIDs(other) &&
+           (this.deleted == other.deleted);
+  }
+
+  public boolean congruentAndroidIDs(Record other) {
+    // We treat -1 as "unset", and treat this as
+    // congruent with any other value.
+    if (this.androidID  != -1 &&
+        other.androidID != -1 &&
+        this.androidID  != other.androidID) {
       return false;
     }
     return true;
+  }
+
+  /**
+   * Return true iff the input is both equal in terms of payload,
+   * and also shares transient values such as timestamps.
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || !(o instanceof Record)) {
+      return false;
+    }
+
+    Record other = (Record) o;
+    return equalTimestamps(other) &&
+           equalSortIndices(other) &&
+           equalAndroidIDs(other) &&
+           equalPayloads(o);
+  }
+
+  public boolean equalAndroidIDs(Record other) {
+    return this.androidID == other.androidID;
+  }
+
+  public boolean equalSortIndices(Record other) {
+    return this.sortIndex == other.sortIndex;
+  }
+
+  public boolean equalTimestamps(Object o) {
+    if (o == null || !(o instanceof Record)) {
+      return false;
+    }
+    return ((Record) o).lastModified == this.lastModified;
   }
 
   public abstract void initFromPayload(CryptoRecord payload);

--- a/src/main/java/org/mozilla/gecko/sync/repositories/domain/Record.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/domain/Record.java
@@ -122,4 +122,15 @@ public abstract class Record {
       throw new IllegalStateException(detailMessage);
     }
   }
+
+  /**
+   * Return an identical copy of this record with the provided two values.
+   *
+   * Oh for persistent data structures.
+   *
+   * @param guid
+   * @param androidID
+   * @return
+   */
+  public abstract Record copyWithIDs(String guid, long androidID);
 }

--- a/src/test/java/org/mozilla/android/sync/test/TestRecord.java
+++ b/src/test/java/org/mozilla/android/sync/test/TestRecord.java
@@ -4,9 +4,14 @@
 package org.mozilla.android.sync.test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
 import org.junit.Test;
 import org.mozilla.gecko.sync.CryptoRecord;
+import org.mozilla.gecko.sync.repositories.domain.BookmarkRecord;
 import org.mozilla.gecko.sync.repositories.domain.HistoryRecord;
 
 public class TestRecord {
@@ -20,4 +25,115 @@ public class TestRecord {
     }
   }
 
+  @Test
+  public void testRecordEquality() {
+    long now = System.currentTimeMillis();
+    BookmarkRecord bOne = new BookmarkRecord("abcdefghijkl", "bookmarks", now , false);
+    BookmarkRecord bTwo = new BookmarkRecord("abcdefghijkl", "bookmarks", now , false);
+    HistoryRecord hOne = new HistoryRecord("mbcdefghijkm", "history", now , false);
+    HistoryRecord hTwo = new HistoryRecord("mbcdefghijkm", "history", now , false);
+
+    // Identical records.
+    assertFalse(bOne == bTwo);
+    assertTrue(bOne.equals(bTwo));
+    assertTrue(bOne.equalPayloads(bTwo));
+    assertTrue(bOne.congruentWith(bTwo));
+    assertTrue(bTwo.equals(bOne));
+    assertTrue(bTwo.equalPayloads(bOne));
+    assertTrue(bTwo.congruentWith(bOne));
+
+    // Null checking.
+    assertFalse(bOne.equals(null));
+    assertFalse(bOne.equalPayloads(null));
+    assertFalse(bOne.congruentWith(null));
+
+    // Different types.
+    hOne.guid = bOne.guid;
+    assertFalse(bOne.equals(hOne));
+    assertFalse(bOne.equalPayloads(hOne));
+    assertFalse(bOne.congruentWith(hOne));
+    hOne.guid = hTwo.guid;
+
+    // Congruent androidID.
+    bOne.androidID = 1;
+    assertFalse(bOne.equals(bTwo));
+    assertTrue(bOne.equalPayloads(bTwo));
+    assertTrue(bOne.congruentWith(bTwo));
+    assertFalse(bTwo.equals(bOne));
+    assertTrue(bTwo.equalPayloads(bOne));
+    assertTrue(bTwo.congruentWith(bOne));
+
+    // Non-congruent androidID.
+    bTwo.androidID = 2;
+    assertFalse(bOne.equals(bTwo));
+    assertTrue(bOne.equalPayloads(bTwo));
+    assertFalse(bOne.congruentWith(bTwo));
+    assertFalse(bTwo.equals(bOne));
+    assertTrue(bTwo.equalPayloads(bOne));
+    assertFalse(bTwo.congruentWith(bOne));
+
+    // Identical androidID.
+    bOne.androidID = 2;
+    assertTrue(bOne.equals(bTwo));
+    assertTrue(bOne.equalPayloads(bTwo));
+    assertTrue(bOne.congruentWith(bTwo));
+    assertTrue(bTwo.equals(bOne));
+    assertTrue(bTwo.equalPayloads(bOne));
+    assertTrue(bTwo.congruentWith(bOne));
+
+    // Different times.
+    bTwo.lastModified += 1000;
+    assertFalse(bOne.equals(bTwo));
+    assertTrue(bOne.equalPayloads(bTwo));
+    assertTrue(bOne.congruentWith(bTwo));
+    assertFalse(bTwo.equals(bOne));
+    assertTrue(bTwo.equalPayloads(bOne));
+    assertTrue(bTwo.congruentWith(bOne));
+
+    // Add some visits.
+    JSONObject v1 = fakeVisit(now - 1000);
+    JSONObject v2 = fakeVisit(now - 500);
+
+    hOne.fennecDateVisited = now + 2000;
+    hOne.fennecVisitCount  = 1;
+    assertFalse(hOne.equals(hTwo));
+    assertTrue(hOne.equalPayloads(hTwo));
+    assertTrue(hOne.congruentWith(hTwo));
+    addVisit(hOne, v1);
+    assertFalse(hOne.equals(hTwo));
+    assertFalse(hOne.equalPayloads(hTwo));
+    assertTrue(hOne.congruentWith(hTwo));
+    addVisit(hTwo, v2);
+    assertFalse(hOne.equals(hTwo));
+    assertFalse(hOne.equalPayloads(hTwo));
+    assertTrue(hOne.congruentWith(hTwo));
+
+    // Now merge the visits.
+    addVisit(hTwo, v1);
+    addVisit(hOne, v2);
+    assertFalse(hOne.equals(hTwo));
+    assertTrue(hOne.equalPayloads(hTwo));
+    assertTrue(hOne.congruentWith(hTwo));
+    hTwo.fennecDateVisited = hOne.fennecDateVisited;
+    hTwo.fennecVisitCount = hOne.fennecVisitCount = 2;
+    assertTrue(hOne.equals(hTwo));
+    assertTrue(hOne.equalPayloads(hTwo));
+    assertTrue(hOne.congruentWith(hTwo));
+  }
+
+  @SuppressWarnings("unchecked")
+  private void addVisit(HistoryRecord r, JSONObject visit) {
+    if (r.visits == null) {
+      r.visits = new JSONArray();
+    }
+    r.visits.add(visit);
+  }
+
+  @SuppressWarnings("unchecked")
+  private JSONObject fakeVisit(long time) {
+    JSONObject object = new JSONObject();
+    object.put("type", 1L);
+    object.put("date", time * 1000);
+    return object;
+  }
 }

--- a/src/test/java/org/mozilla/android/sync/test/TestServer11RepositorySession.java
+++ b/src/test/java/org/mozilla/android/sync/test/TestServer11RepositorySession.java
@@ -74,6 +74,11 @@ public class TestServer11RepositorySession {
     public String toJSONString() {
       return "{\"id\":\"" + guid + "\", \"payload\": \"foo\"}";
     }
+
+    @Override
+    public Record copyWithIDs(String guid, long androidID) {
+      return new MockRecord(guid, this.collection, this.lastModified, this.deleted);
+    }
   }
 
   public class MockServer11RepositorySession extends Server11RepositorySession {


### PR DESCRIPTION
These patches introduce a layered definition of equality between records, allowing us to write more sane tests and reconciling code.

These patches don't change the existing reconciling code (that will come shortly), but they do expose and fix a data-loss bug when handling deleted records. Test code wasn't checking the visits of a history record, which meant that the data loss was ignored.

Hooray for sane primitives!
