### PR TITLE
Feedback: Bug 718703 - Pair a Device Crashing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ AndroidManifest.xml
 R.java
 src/main/java/org/mozilla/gecko/sync/repositories/android/Authorities.java
 res/xml/sync_syncadapter.xml
+res/xml/sync_preferences.xml
 res/values/strings.xml
 .metadata
 *.pyc

--- a/README
+++ b/README
@@ -24,7 +24,7 @@
   popd
   ./fennec-code-drop.sh $MC
   pushd $MC
-  # hg qadd any files that have been added. Removing files that have been
+  # hg add any files that have been added. Removing files that have been
   # removed is an exercise for the reader.
   hg qref
 

--- a/fennec-code-drop.sh
+++ b/fennec-code-drop.sh
@@ -21,6 +21,7 @@ fi
 
 echo "Preprocessing."
 ./preprocess.sh
+./preprocess-fennec.sh
 
 echo "Running tests."
 mvn clean test

--- a/fennec-copy-code.sh
+++ b/fennec-copy-code.sh
@@ -47,6 +47,9 @@ cp $SOURCEDIR/repositories/android/Authorities.java.in $ANDROID/base/sync/reposi
 echo "Copying preprocessed sync_syncadapter.xml."
 cp sync_syncadapter.xml.template $ANDROID/base/resources/xml/sync_syncadapter.xml.in
 
+echo "Copying preprocessed sync_preferences.xml."
+cp sync_preferences.xml.template $ANDROID/base/resources/xml/sync_preferences.xml.in
+
 echo "Copying internal dependency sources."
 APACHEDIR="src/main/java/org/mozilla/apache"
 APACHEFILES=$(find "$APACHEDIR" -name '*.java' | sed "s,$APACHEDIR/,apache/,")
@@ -64,6 +67,7 @@ rsync --include "*.java" -C -a $JSONLIB/ $ANDROID/base/json-simple/
 # These seem to get copied anyway.
 rm $ANDROID/base/sync/repositories/android/Authorities.java
 rm $ANDROID/base/resources/xml/sync_syncadapter.xml
+rm $ANDROID/base/resources/xml/sync_preferences.xml
 
 echo $PREPROCESS_FILES > $SYNC/preprocess-sources.mn
 echo $WARNING > $ANDROID/base/sync/README.txt

--- a/manifests/SyncAndroidManifest_activities.xml.in
+++ b/manifests/SyncAndroidManifest_activities.xml.in
@@ -1,7 +1,6 @@
         <activity
             android:icon="@drawable/sync_ic_launcher"
             android:label="@string/sync_app_name"
-            android:launchMode="singleTask"
             android:screenOrientation="portrait"
             android:configChanges="orientation"
             android:windowSoftInputMode="adjustResize|stateHidden"
@@ -18,11 +17,9 @@
         </activity>
         <activity
             android:clearTaskOnLaunch="true"
-            android:launchMode="singleTask"
             android:name="org.mozilla.gecko.sync.setup.activities.AccountActivity"
             android:windowSoftInputMode="adjustPan|stateHidden"/>
         <activity
             android:name="org.mozilla.gecko.sync.setup.activities.SetupFailureActivity" />
         <activity
-            android:name="org.mozilla.gecko.sync.setup.activities.SetupSuccessActivity"
-            android:launchMode="singleTask" />
+            android:name="org.mozilla.gecko.sync.setup.activities.SetupSuccessActivity" />

--- a/manifests/SyncAndroidManifest_activities.xml.in
+++ b/manifests/SyncAndroidManifest_activities.xml.in
@@ -11,8 +11,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
             <intent-filter>
-                <category android:name="android.intent.category.DEFAULT" />
-                <data android:scheme="sync" android:host="org.mozilla.android" android:path="/setup"/>
+                <action android:name="android.intent.action.MAIN" />
             </intent-filter>
         </activity>
         <activity

--- a/preprocess-fennec.sh
+++ b/preprocess-fennec.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Substitute package names for bundling with Fennec.
+USERNAME=$(whoami)
+PREPROCESSOR="python tools/Preprocessor.py"
+
+ANDROID_PACKAGE_NAME=$($PREPROCESSOR -Fsubstitution -DUSERNAME=$USERNAME package-name.txt)
+DEFINITIONS="-DANDROID_PACKAGE_NAME=$ANDROID_PACKAGE_NAME"
+
+SYNC_PREFERENCES=res/xml/sync_preferences.xml
+
+$PREPROCESSOR $DEFINITIONS sync_preferences.xml.template > $SYNC_PREFERENCES

--- a/preprocess.sh
+++ b/preprocess.sh
@@ -10,6 +10,7 @@ echo "Using ANDROID_PACKAGE_NAME $ANDROID_PACKAGE_NAME."
 
 AUTHORITIES=src/main/java/org/mozilla/gecko/sync/repositories/android/Authorities.java
 MANIFEST=AndroidManifest.xml
+SYNC_PREFERENCES=res/xml/sync_preferences.xml
 
 DEFINITIONS="-DANDROID_PACKAGE_NAME=$ANDROID_PACKAGE_NAME"
 $PREPROCESSOR $DEFINITIONS $AUTHORITIES.in > $AUTHORITIES
@@ -21,3 +22,8 @@ $PREPROCESSOR $DEFINITIONS sync_syncadapter.xml.template > res/xml/sync_syncadap
 # Now do the test project.
 TEST_MANIFEST=test/AndroidManifest.xml
 $PREPROCESSOR $DEFINITIONS $TEST_MANIFEST.in > $TEST_MANIFEST
+
+# Now preprocess package name for stand-alone Android Sync.
+# preprocess-fennec.sh will substitute for fennec-specific package naming.
+DEFINITIONS="-DANDROID_PACKAGE_NAME=org.mozilla.gecko"
+$PREPROCESSOR $DEFINITIONS sync_preferences.xml.template > $SYNC_PREFERENCES

--- a/res/xml/sync_authenticator.xml
+++ b/res/xml/sync_authenticator.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <account-authenticator xmlns:android="http://schemas.android.com/apk/res/android"
     android:accountType="org.mozilla.firefox_sync"
-    android:icon="@drawable/sync_icon"
-    android:smallIcon="@drawable/sync_icon"
+    android:icon="@drawable/sync_ic_launcher"
+    android:smallIcon="@drawable/sync_ic_launcher"
     android:label="@string/sync_account_label"
     android:accountPreferences="@xml/sync_options" />

--- a/res/xml/sync_authenticator.xml
+++ b/res/xml/sync_authenticator.xml
@@ -4,4 +4,4 @@
     android:icon="@drawable/sync_ic_launcher"
     android:smallIcon="@drawable/sync_ic_launcher"
     android:label="@string/sync_account_label"
-    android:accountPreferences="@xml/sync_options" />
+    android:accountPreferences="@xml/sync_preferences" />

--- a/strings.xml.in
+++ b/strings.xml.in
@@ -39,7 +39,7 @@
   <string name="sync_pair_tryagain">&sync.pair.tryagain.label;</string>
 
   <!-- Firefox SyncAdapter Settings Screen -->
-  <string name="sync_settings_options">&sync.settings.options.label;</string>
+  <string name="sync_settings_preferences">&sync.settings.options.label;</string>
   <string name="sync_settings_summary_pair">&sync.summary.pair.label;</string>
   <!-- Common text -->
   <string name="sync_button_cancel">&sync.button.cancel.label;</string>

--- a/sync_preferences.xml.template
+++ b/sync_preferences.xml.template
@@ -1,14 +1,15 @@
+#filter substitution
 <?xml version="1.0" encoding="UTF-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
   <PreferenceCategory
-    android:title="@string/sync_settings_options" />
+    android:title="@string/sync_settings_preferences" />
   <PreferenceScreen
-    android:key="sync_options"
+    android:key="sync_preferences"
     android:title="@string/sync_title_pair"
     android:summary="@string/sync_settings_summary_pair">
     <intent
       android:action="android.intent.action.MAIN"
-      android:targetPackage="org.mozilla.gecko"
+      android:targetPackage="@ANDROID_PACKAGE_NAME@"
       android:targetClass="org.mozilla.gecko.sync.setup.activities.SetupSyncActivity">
       <extra
         android:name="isSetup"


### PR DESCRIPTION
Problem: using org.mozilla.gecko package name in the Intent fired off by "Pair a Device" in sync settings, instead of Fennec package. Added fixes in preprocessing, to create correct package reference for both standalone Android Sync and Fennec-bundled Android Sync.

Tested hard-coding package name "org.mozilla.fennec_liuche" when bundling with Fennec, did not crash.

Also made changes to bundling scripts, but wasn't able to actually test on Fennec bundled, because of build problems.

make[6]: **\* No rule to make target `/Users/liuche/moz/code/hg/m-c/mobile/android/base/resources/xml/sync_preferences.xml', needed by`res/layout/sync_account.xml'.  Stop.
make[6]: **\* Waiting for unfinished jobs....
make[5]: **\* [libs] Error 2

rnewman: maybe for when you have time, updating the README for the places that need to be changed in order to add new resources.
