### PR TITLE
Nalexander/bug 722426 android permissions

### DIFF
--- a/manifests/SyncAndroidManifest_permissions.xml.in
+++ b/manifests/SyncAndroidManifest_permissions.xml.in
@@ -5,6 +5,5 @@
     <uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS" />
     <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS" />
     <uses-permission android:name="android.permission.WRITE_SETTINGS" />
-    <uses-permission android:name="android.permission.WRITE_SECURE_SETTINGS" />
     <uses-permission android:name="android.permission.READ_SYNC_STATS" />
     <uses-permission android:name="android.permission.READ_SYNC_SETTINGS" />


### PR DESCRIPTION
...e this permission is only granted to system/firmware applications.

Tested this morning.  Clicked 'Firefox Sync' on Android home screen, entered given code into fresh Firefox Nightly 'Pair a Device' dialog.  Verified account appears in 'Firefox Sync' settings display.
