### PR TITLE
Nalexander/bug 722430 make hmac hasher null

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/crypto/CryptoInfo.java
+++ b/src/main/java/org/mozilla/gecko/sync/crypto/CryptoInfo.java
@@ -44,59 +44,58 @@ package org.mozilla.gecko.sync.crypto;
  */
 public class CryptoInfo {
 
-	private byte[] message;
-	private byte[] iv;
-	private byte[] hmac;
-	private KeyBundle keys;
+  private byte[] message;
+  private byte[] iv;
+  private byte[] hmac;
+  private KeyBundle keys;
 
-	/*
-	 * Constructor typically used when encrypting
-	 */
-	public CryptoInfo(byte[] message, KeyBundle keys) {
-	    this.setMessage(message);
-	    this.setKeys(keys);
-	}
+  /*
+   * Constructor typically used when encrypting
+   */
+  public CryptoInfo(byte[] message, KeyBundle keys) {
+    this.setMessage(message);
+    this.setKeys(keys);
+  }
 
-	/*
-	 * Constructor typically used when decrypting
-	 */
-	public CryptoInfo(byte[] message, byte[] iv, byte[] hmac, KeyBundle keys) {
-	    this.setMessage(message);
-	    this.setIV(iv);
-	    this.setHMAC(hmac);
-	    this.setKeys(keys);
-	}
+  /*
+   * Constructor typically used when decrypting
+   */
+  public CryptoInfo(byte[] message, byte[] iv, byte[] hmac, KeyBundle keys) {
+    this.setMessage(message);
+    this.setIV(iv);
+    this.setHMAC(hmac);
+    this.setKeys(keys);
+  }
 
-    public byte[] getMessage() {
-        return message;
-    }
+  public byte[] getMessage() {
+    return message;
+  }
 
-    public void setMessage(byte[] message) {
-        this.message = message;
-    }
+  public void setMessage(byte[] message) {
+    this.message = message;
+  }
 
-    public byte[] getIV() {
-        return iv;
-    }
+  public byte[] getIV() {
+    return iv;
+  }
 
-    public void setIV(byte[] iv) {
-        this.iv = iv;
-    }
+  public void setIV(byte[] iv) {
+    this.iv = iv;
+  }
 
-    public byte[] getHMAC() {
-        return hmac;
-    }
+  public byte[] getHMAC() {
+    return hmac;
+  }
 
-    public void setHMAC(byte[] hmac) {
-        this.hmac = hmac;
-    }
+  public void setHMAC(byte[] hmac) {
+    this.hmac = hmac;
+  }
 
-    public KeyBundle getKeys() {
-        return keys;
-    }
+  public KeyBundle getKeys() {
+    return keys;
+  }
 
-    public void setKeys(KeyBundle keys) {
-        this.keys = keys;
-    }
-
+  public void setKeys(KeyBundle keys) {
+    this.keys = keys;
+  }
 }

--- a/src/main/java/org/mozilla/gecko/sync/crypto/HKDF.java
+++ b/src/main/java/org/mozilla/gecko/sync/crypto/HKDF.java
@@ -53,6 +53,7 @@ import org.mozilla.gecko.sync.Utils;
  * HMAC uses HMAC SHA256 standard.
  */
 public class HKDF {
+    public static String HMAC_ALGORITHM = "hmacSHA256";
 
     /**
      * Used for conversion in cases in which you *know* the encoding exists.
@@ -74,7 +75,7 @@ public class HKDF {
      * Input: salt (message), IKM (input keyring material)
      * Output: PRK (pseudorandom key)
      */
-    public static byte[] hkdfExtract(byte[] salt, byte[] IKM) {
+    public static byte[] hkdfExtract(byte[] salt, byte[] IKM) throws NoSuchAlgorithmException, InvalidKeyException {
         return digestBytes(IKM, makeHMACHasher(salt));
     }
 
@@ -83,7 +84,7 @@ public class HKDF {
      * Input: PRK from step 1, info, length.
      * Output: OKM (output keyring material).
      */
-    public static byte[] hkdfExpand(byte[] prk, byte[] info, int len) {
+    public static byte[] hkdfExpand(byte[] prk, byte[] info, int len) throws NoSuchAlgorithmException, InvalidKeyException {
 
         Mac hmacHasher = makeHMACHasher(prk);
 
@@ -111,7 +112,7 @@ public class HKDF {
         if (key.length == 0) {
             key = new byte[BLOCKSIZE];
         }
-        return new SecretKeySpec(key, "HmacSHA256");
+        return new SecretKeySpec(key, HMAC_ALGORITHM);
     }
 
     /*
@@ -119,19 +120,11 @@ public class HKDF {
      * Input: Key hmacKey
      * Ouput: An HMAC Hasher
      */
-    public static Mac makeHMACHasher(byte[] key) {
+    public static Mac makeHMACHasher(byte[] key) throws NoSuchAlgorithmException, InvalidKeyException {
         Mac hmacHasher = null;
-        try {
-            hmacHasher = Mac.getInstance("hmacSHA256");
-        } catch (NoSuchAlgorithmException e) {
-            e.printStackTrace();
-        }
-
-        try {
-            hmacHasher.init(makeHMACKey(key));
-        } catch (InvalidKeyException e) {
-            e.printStackTrace();
-        }
+        hmacHasher = Mac.getInstance(HMAC_ALGORITHM);
+        assert(hmacHasher != null); // If Mac.getInstance doesn't throw NoSuchAlgorithmException, hmacHasher is non-null.
+        hmacHasher.init(makeHMACKey(key));
 
         return hmacHasher;
     }

--- a/src/main/java/org/mozilla/gecko/sync/cryptographer/SyncCryptographer.java
+++ b/src/main/java/org/mozilla/gecko/sync/cryptographer/SyncCryptographer.java
@@ -344,7 +344,7 @@ public class SyncCryptographer {
   /*
    * Get the keys needed to encrypt the crypto/keys bundle.
    */
-  public KeyBundle getCryptoKeysBundleKeys() {
+  public KeyBundle getCryptoKeysBundleKeys() throws CryptoException {
     return new KeyBundle(username, syncKey);
   }
 

--- a/src/main/java/org/mozilla/gecko/sync/jpake/JPakeClient.java
+++ b/src/main/java/org/mozilla/gecko/sync/jpake/JPakeClient.java
@@ -74,6 +74,8 @@ import ch.boye.httpclientandroidlib.client.methods.HttpRequestBase;
 import ch.boye.httpclientandroidlib.entity.StringEntity;
 import ch.boye.httpclientandroidlib.impl.client.DefaultHttpClient;
 import ch.boye.httpclientandroidlib.message.BasicHeader;
+import java.security.NoSuchAlgorithmException;
+import java.security.InvalidKeyException;
 
 public class JPakeClient implements JPakeRequestDelegate {
   private static String       LOG_TAG                 = "JPakeClient";
@@ -473,6 +475,14 @@ public class JPakeClient implements JPakeRequestDelegate {
     } catch (IncorrectZkpException e) {
       Log.e(LOG_TAG, "ZKP mismatch");
       abort(Constants.JPAKE_ERROR_WRONGMESSAGE);
+      e.printStackTrace();
+    } catch (NoSuchAlgorithmException e) {
+      Log.e(LOG_TAG, "NoSuchAlgorithmException", e);
+      abort(Constants.JPAKE_ERROR_INTERNAL);
+      e.printStackTrace();
+    } catch (InvalidKeyException e) {
+      Log.e(LOG_TAG, "InvalidKeyException", e);
+      abort(Constants.JPAKE_ERROR_INTERNAL);
       e.printStackTrace();
     }
 

--- a/src/main/java/org/mozilla/gecko/sync/jpake/JPakeCrypto.java
+++ b/src/main/java/org/mozilla/gecko/sync/jpake/JPakeCrypto.java
@@ -51,6 +51,7 @@ import org.mozilla.gecko.sync.crypto.HKDF;
 import org.mozilla.gecko.sync.crypto.KeyBundle;
 
 import android.util.Log;
+import java.security.InvalidKeyException;
 
 public class JPakeCrypto {
   private static final String LOG_TAG = "JPakeCrypto";
@@ -174,7 +175,7 @@ public class JPakeCrypto {
    * @throws IncorrectZkpException
    */
   public static KeyBundle finalRound(String secret, JPakeParty jp)
-      throws IncorrectZkpException {
+      throws IncorrectZkpException, NoSuchAlgorithmException, InvalidKeyException {
     Log.d(LOG_TAG, "Final round started.");
     BigInteger gb = jp.gx1.multiply(jp.gx2).mod(P).multiply(jp.gx3)
         .mod(P);
@@ -321,12 +322,12 @@ public class JPakeCrypto {
   /*
    * Helper function to generate encryption key and HMAC from a byte array.
    */
-  public static void generateKeyAndHmac(BigInteger k, byte[] encOut, byte[] hmacOut) {
+  public static void generateKeyAndHmac(BigInteger k, byte[] encOut, byte[] hmacOut) throws NoSuchAlgorithmException, InvalidKeyException {
    // Generate HMAC and Encryption keys from synckey.
     byte[] zerokey = new byte[32];
     byte[] prk = HMACSHA256(BigIntegerHelper.BigIntegerToByteArrayWithoutSign(k), zerokey);
 
-    byte[] okm =  HKDF.hkdfExpand(prk, HKDF.HMAC_INPUT, 32 * 2);
+    byte[] okm = HKDF.hkdfExpand(prk, HKDF.HMAC_INPUT, 32 * 2);
     System.arraycopy(okm, 0, encOut, 0, 32);
     System.arraycopy(okm, 32, hmacOut, 0, 32);
   }

--- a/src/main/java/org/mozilla/gecko/sync/net/BaseResource.java
+++ b/src/main/java/org/mozilla/gecko/sync/net/BaseResource.java
@@ -101,7 +101,7 @@ public class BaseResource implements Resource {
   }
 
   public BaseResource(String uri, boolean rewrite) throws URISyntaxException {
-	  this(new URI(uri), rewrite);
+    this(new URI(uri), rewrite);
   }
 
   public BaseResource(URI uri, boolean rewrite) {

--- a/src/test/java/org/mozilla/android/sync/test/TestCryptoRecord.java
+++ b/src/test/java/org/mozilla/android/sync/test/TestCryptoRecord.java
@@ -20,6 +20,8 @@ import org.mozilla.gecko.sync.NonObjectJSONException;
 import org.mozilla.gecko.sync.Utils;
 import org.mozilla.gecko.sync.crypto.CryptoException;
 import org.mozilla.gecko.sync.crypto.KeyBundle;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
 
 public class TestCryptoRecord {
   String base64EncryptionKey = "9K/wLdXdw+nrTtXo4ZpECyHFNr4d7aYHqeg3KW9+m6Q=";
@@ -110,7 +112,7 @@ public class TestCryptoRecord {
   }
 
   @Test
-  public void testBaseCryptoRecordSyncKeyBundle() throws UnsupportedEncodingException {
+  public void testBaseCryptoRecordSyncKeyBundle() throws UnsupportedEncodingException, CryptoException {
     // These values pulled straight out of Firefox.
     String key  = "6m8mv8ex2brqnrmsb9fjuvfg7y";
     String user = "c6o7dvmr2c4ud2fyv6woz2u4zi22bcyd";

--- a/src/test/java/org/mozilla/android/sync/test/TestJPakeSetup.java
+++ b/src/test/java/org/mozilla/android/sync/test/TestJPakeSetup.java
@@ -24,6 +24,8 @@ import org.mozilla.gecko.sync.jpake.JPakeNumGenerator;
 import org.mozilla.gecko.sync.jpake.JPakeNumGeneratorRandom;
 import org.mozilla.gecko.sync.jpake.JPakeParty;
 import org.mozilla.gecko.sync.setup.Constants;
+import java.security.NoSuchAlgorithmException;
+import java.security.InvalidKeyException;
 
 public class TestJPakeSetup {
   // Note: will throw NullPointerException if aborts. Only use stateless public
@@ -67,8 +69,11 @@ public class TestJPakeSetup {
     byte[] encKeyBytes = new byte[32];
     byte[] hmacBytes = new byte[32];
 
-    JPakeCrypto.generateKeyAndHmac(new BigInteger(keyChars16, 16), encKeyBytes,
-        hmacBytes);
+    try {
+      JPakeCrypto.generateKeyAndHmac(new BigInteger(keyChars16, 16), encKeyBytes, hmacBytes);
+    } catch (Exception e) {
+      fail("Unexpected exception " + e);
+    }
     String encKey64 = new String(Base64.encodeBase64(encKeyBytes));
     String hmac64 = new String(Base64.encodeBase64(hmacBytes));
 
@@ -82,7 +87,7 @@ public class TestJPakeSetup {
   @Test
   public void testJPakeCorrectSecret() throws Gx4IsOneException,
       IncorrectZkpException, IOException, ParseException,
-      NonObjectJSONException, CryptoException {
+      NonObjectJSONException, CryptoException, NoSuchAlgorithmException, InvalidKeyException {
     String secret = "byubd7u75qmq";
     JPakeNumGenerator gen = new JPakeNumGeneratorRandom();
     // Keys derived should be the same.
@@ -95,7 +100,7 @@ public class TestJPakeSetup {
   @Test
   public void testJPakeIncorrectSecret() throws Gx4IsOneException,
       IncorrectZkpException, IOException, ParseException,
-      NonObjectJSONException, CryptoException {
+      NonObjectJSONException, CryptoException, NoSuchAlgorithmException, InvalidKeyException {
     String secret1 = "shareSecret1";
     String secret2 = "shareSecret2";
     JPakeNumGenerator gen = new JPakeNumGeneratorRandom();
@@ -111,7 +116,7 @@ public class TestJPakeSetup {
   public boolean jPakeDeriveSameKey(JPakeNumGenerator gen1,
       JPakeNumGenerator gen2, String secret1, String secret2)
       throws Gx4IsOneException, IncorrectZkpException, IOException,
-      ParseException, NonObjectJSONException, CryptoException {
+      ParseException, NonObjectJSONException, CryptoException, NoSuchAlgorithmException, InvalidKeyException {
 
     // Communicating parties.
     JPakeParty party1 = new JPakeParty("party1");

--- a/src/test/java/org/mozilla/android/sync/test/TestSyncCryptographer.java
+++ b/src/test/java/org/mozilla/android/sync/test/TestSyncCryptographer.java
@@ -41,9 +41,9 @@ public class TestSyncCryptographer {
                                         "\", \"id\": \"hkZYpC-BH4Xi\", \"" +
                                         "modified\": 1320183464.21}";
         String base64EncryptionKey =    "K8fV6PHG8RgugfHexGesbzTeOs2o12cr" +
-        		                        "N/G3bz0Bx1M=";
+                                        "N/G3bz0Bx1M=";
         String base64HmacKey =          "nbceuI6w1RJbBzh+iCJHEs8p4lElsOma" +
-        		                        "yUhx+OztVgM=";
+                                        "yUhx+OztVgM=";
         String username =               "b6evr62dptbxz7fvebek7btljyu322wp";
         String friendlyBase32SyncKey =  "basuxv2426eqj7frhvpcwkavdi";
         String expectedDecryptedText =  "{\"id\":\"hkZYpC-BH4Xi\",\"histU" +

--- a/src/test/java/org/mozilla/gecko/sync/crypto/test/TestHKDF.java
+++ b/src/test/java/org/mozilla/gecko/sync/crypto/test/TestHKDF.java
@@ -4,6 +4,7 @@
 package org.mozilla.gecko.sync.crypto.test;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 
@@ -12,6 +13,8 @@ import org.mozilla.apache.commons.codec.binary.Base64;
 import org.mozilla.gecko.sync.Utils;
 import org.mozilla.gecko.sync.crypto.HKDF;
 import org.mozilla.gecko.sync.crypto.KeyBundle;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
 
 
 /*
@@ -101,7 +104,12 @@ public class TestHKDF {
         String base64EncryptionKey =    "069EnS3EtDK4y1tZ1AyKX+U7WEsWRp9bRIKLdW/7aoE=";
         String base64HmacKey =          "LF2YCS1QCgSNCf0BCQvQ06SGH8jqJDi9dKj0O+b0fwI=";
 
-        KeyBundle bundle = new KeyBundle(username, friendlyBase32SyncKey);
+        KeyBundle bundle = null;
+        try {
+          bundle = new KeyBundle(username, friendlyBase32SyncKey);
+        } catch (Exception e) {
+          fail("Unexpected exception " + e);
+        }
 
         byte[] expectedEncryptionKey = Base64.decodeBase64(base64EncryptionKey);
         byte[] expectedHMACKey       = Base64.decodeBase64(base64HmacKey);
@@ -113,17 +121,27 @@ public class TestHKDF {
      * Helper to do step 1 of RFC 5869.
      */
     private boolean doStep1(String IKM, String salt, String PRK) {
-        byte[] prkResult = HKDF.hkdfExtract(Utils.hex2Byte(salt), Utils.hex2Byte(IKM));
-        byte[] prkExpect = Utils.hex2Byte(PRK);
-        return Arrays.equals(prkResult, prkExpect);
+        try {
+            byte[] prkResult = HKDF.hkdfExtract(Utils.hex2Byte(salt), Utils.hex2Byte(IKM));
+            byte[] prkExpect = Utils.hex2Byte(PRK);
+            return Arrays.equals(prkResult, prkExpect);
+        } catch (Exception e) {
+            fail("Unexpected exception " + e);
+        }
+        return false;
     }
 
     /*
      * Helper to do step 2 of RFC 5869.
      */
     private boolean doStep2(String PRK, String info, int L, String OKM) {
-        byte[] okmResult = HKDF.hkdfExpand(Utils.hex2Byte(PRK), Utils.hex2Byte(info), L);
-        byte[] okmExpect = Utils.hex2Byte(OKM);
-        return Arrays.equals(okmResult, okmExpect);
+        try {
+            byte[] okmResult = HKDF.hkdfExpand(Utils.hex2Byte(PRK), Utils.hex2Byte(info), L);
+            byte[] okmExpect = Utils.hex2Byte(OKM);
+            return Arrays.equals(okmResult, okmExpect);
+        } catch (Exception e) {
+            fail("Unexpected exception " + e);
+        }
+        return false;
     }
 }


### PR DESCRIPTION
...wrap in CryptoException higher up the call stack.

This one got pretty gnarly, but I think does what bsmith wants.  It propagates NoSuchAlgorithmException and InvalidKeyException higher up the call stack and wraps in CryptoException where appropriate.
