### PR TITLE
Nalexander/wait helper

### DIFF
--- a/test/src/org/mozilla/android/sync/test/WaitHelperTest.java
+++ b/test/src/org/mozilla/android/sync/test/WaitHelperTest.java
@@ -1,0 +1,293 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+package org.mozilla.android.sync.test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import junit.framework.AssertionFailedError;
+
+import org.mozilla.android.sync.test.helpers.WaitHelper;
+import org.mozilla.android.sync.test.helpers.WaitHelper.TimeoutError;
+import org.mozilla.gecko.sync.StubActivity;
+import org.mozilla.gecko.sync.ThreadPool;
+
+import android.test.ActivityInstrumentationTestCase2;
+
+public class WaitHelperTest extends ActivityInstrumentationTestCase2<StubActivity> {
+  public static int NO_WAIT = 1; // Milliseconds.
+  public static int SHORT_WAIT = 100; // Milliseconds.
+  public static int LONG_WAIT = 3*SHORT_WAIT;
+
+  public AtomicBoolean performNotifyCalled = new AtomicBoolean(false);
+  public AtomicBoolean performNotifyErrorCalled = new AtomicBoolean(false);
+  public WaitHelper waitHelper;
+
+  public WaitHelperTest() {
+    super(StubActivity.class);
+  }
+
+  public void setUp() {
+    WaitHelper.resetTestWaiter();
+    waitHelper = WaitHelper.getTestWaiter();
+
+    performNotifyCalled.set(false);
+    performNotifyErrorCalled.set(false);
+  }
+
+  public Runnable performNothingRunnable() {
+    return new Runnable() {
+      public void run() {
+      }
+    };
+  }
+
+  public Runnable performNotifyRunnable() {
+    return new Runnable() {
+      public void run() {
+        performNotifyCalled.set(true);
+        waitHelper.performNotify();
+      }
+    };
+  }
+
+  public Runnable performNotifyAfterDelayRunnable(final int delayInMillis) {
+    return new Runnable() {
+      public void run() {
+        try {
+          Thread.sleep(delayInMillis);
+        } catch (InterruptedException e) {
+          e.printStackTrace();
+          assert(false);
+        }
+
+        performNotifyCalled.set(true);
+        waitHelper.performNotify();
+      }
+    };
+  }
+
+  public Runnable performNotifyErrorRunnable() {
+    return new Runnable() {
+      public void run() {
+        performNotifyCalled.set(true);
+        waitHelper.performNotify(new AssertionError("error unique identifier"));
+      }
+    };
+  }
+
+  public Runnable inThreadPool(final Runnable runnable) {
+    return new Runnable() {
+      @Override
+      public void run() {
+        ThreadPool.run(runnable);
+      }
+    };
+  }
+
+  public Runnable inThread(final Runnable runnable) {
+    return new Runnable() {
+      @Override
+      public void run() {
+        new Thread(runnable).start();
+      }
+    };
+  }
+
+  public void testPerformWait() {
+    waitHelper.performWait(performNotifyRunnable());
+    assertTrue(performNotifyCalled.get());
+  }
+
+  public void testPerformWaitInThread() {
+    waitHelper.performWait(inThread(performNotifyRunnable()));
+    assertTrue(performNotifyCalled.get());
+  }
+
+  public void testPerformWaitInThreadPool() {
+    waitHelper.performWait(inThreadPool(performNotifyRunnable()));
+    assertTrue(performNotifyCalled.get());
+  }
+
+  public void testPerformTimeoutWait() {
+    waitHelper.performWait(SHORT_WAIT, performNotifyRunnable());
+    assertTrue(performNotifyCalled.get());
+  }
+
+  public void testPerformTimeoutWaitInThread() {
+    waitHelper.performWait(SHORT_WAIT, inThread(performNotifyRunnable()));
+    assertTrue(performNotifyCalled.get());
+  }
+
+  public void testPerformTimeoutWaitInThreadPool() {
+    waitHelper.performWait(SHORT_WAIT, inThreadPool(performNotifyRunnable()));
+    assertTrue(performNotifyCalled.get());
+  }
+
+  public void testPerformErrorWaitInThread() {
+    try {
+      waitHelper.performWait(inThread(performNotifyErrorRunnable()));
+    } catch (AssertionError e) {
+      performNotifyErrorCalled.set(true);
+      assertTrue("Expected '" + e.getMessage() + "' to contain 'error unique identifer'",
+          e.getMessage().contains("error unique identifier"));
+    }
+    assertTrue(performNotifyCalled.get());
+    assertTrue(performNotifyErrorCalled.get());
+  }
+
+  public void testPerformErrorWaitInThreadPool() {
+    try {
+      waitHelper.performWait(inThreadPool(performNotifyErrorRunnable()));
+    } catch (AssertionError e) {
+      performNotifyErrorCalled.set(true);
+      assertTrue("Expected '" + e.getMessage() + "' to contain 'error unique identifer'",
+          e.getMessage().contains("error unique identifier"));
+    }
+    assertTrue(performNotifyCalled.get());
+    assertTrue(performNotifyErrorCalled.get());
+  }
+
+  public void testPerformErrorTimeoutWaitInThread() {
+    try {
+      waitHelper.performWait(SHORT_WAIT, inThread(performNotifyErrorRunnable()));
+    } catch (AssertionError e) {
+      performNotifyErrorCalled.set(true);
+      assertTrue("Expected '" + e.getMessage() + "' to contain 'error unique identifer'",
+          e.getMessage().contains("error unique identifier"));
+    }
+    assertTrue(performNotifyCalled.get());
+    assertTrue(performNotifyErrorCalled.get());
+  }
+
+  public void testPerformErrorTimeoutWaitInThreadPool() {
+    try {
+      waitHelper.performWait(SHORT_WAIT, inThreadPool(performNotifyErrorRunnable()));
+    } catch (AssertionError e) {
+      performNotifyErrorCalled.set(true);
+      assertTrue("Expected '" + e.getMessage() + "' to contain 'error unique identifer'",
+          e.getMessage().contains("error unique identifier"));
+    }
+    assertTrue(performNotifyCalled.get());
+    assertTrue(performNotifyErrorCalled.get());
+  }
+
+  public void testTimeout() {
+    try {
+      waitHelper.performWait(SHORT_WAIT, performNothingRunnable());
+    } catch (TimeoutError e) {
+      performNotifyErrorCalled.set(true);
+      assertEquals(SHORT_WAIT, e.waitTimeInMillis);
+    }
+    assertTrue(performNotifyErrorCalled.get());
+  }
+
+  /**
+   * This will pass.  The sequence in the main thread is:
+   * - A short delay.
+   * - performNotify is called.
+   * - performWait is called and immediately finds that performNotify was called before.
+   */
+  public void testDelay() {
+    try {
+      waitHelper.performWait(1, performNotifyAfterDelayRunnable(SHORT_WAIT));
+    } catch (AssertionError e) {
+      performNotifyErrorCalled.set(true);
+      assertTrue(e.getMessage(), e.getMessage().contains("TIMEOUT"));
+    }
+    assertTrue(performNotifyCalled.get());
+    assertFalse(performNotifyErrorCalled.get());
+  }
+
+  public Runnable performNotifyMultipleTimesRunnable() {
+    return new Runnable() {
+      public void run() {
+        waitHelper.performNotify();
+        performNotifyCalled.set(true);
+        waitHelper.performNotify();
+      }
+    };
+  }
+
+  public void testPerformNotifyMultipleTimesFails() {
+    try {
+      waitHelper.performWait(NO_WAIT, performNotifyMultipleTimesRunnable());
+    } catch (WaitHelper.MultipleNotificationsError e) {
+      performNotifyErrorCalled.set(true);
+    }
+    assertTrue(performNotifyCalled.get());
+    assertTrue(performNotifyErrorCalled.get());
+  }
+
+  public void testAssertIsReported() {
+    try {
+      waitHelper.performWait(1, new Runnable() {
+        @Override
+        public void run() {
+          assertTrue("unique identifier", false);
+        }
+      });
+    } catch (AssertionFailedError e) {
+      performNotifyErrorCalled.set(true);
+      assertTrue(e.getMessage(), e.getMessage().contains("unique identifier"));
+    }
+    assertFalse(performNotifyCalled.get());
+    assertTrue(performNotifyErrorCalled.get());
+  }
+
+  /**
+   * This will timeout.  The sequence in the helper thread is:
+   * - A short delay.
+   * - performNotify is called.
+   *
+   * The sequence in the main thread is:
+   * - performWait is called and times out because the helper thread does not call
+   *   performNotify quickly enough.
+   */
+  public void testDelayInThread() throws InterruptedException {
+    try {
+      waitHelper.performWait(NO_WAIT, inThread(performNotifyAfterDelayRunnable(SHORT_WAIT)));
+    } catch (WaitHelper.TimeoutError e) {
+      performNotifyErrorCalled.set(true);
+      assertEquals(NO_WAIT, e.waitTimeInMillis);
+    }
+    assertFalse(performNotifyCalled.get());
+    assertTrue(performNotifyErrorCalled.get());
+
+    // The spawned thread should have called performNotify() by now.
+    Thread.sleep(LONG_WAIT);
+    try {
+      waitHelper.performWait(1, this.performNothingRunnable());
+    } catch (AssertionError e) {
+      fail("Should not have thrown!");
+    }
+  }
+
+  /**
+   * This will timeout.  The sequence in the helper thread is:
+   * - A short delay.
+   * - performNotify is called.
+   *
+   * The sequence in the main thread is:
+   * - performWait is called and times out because the helper thread does not call
+   *   performNotify quickly enough.
+   */
+  public void testDelayInThreadPool() throws InterruptedException {
+    try {
+      waitHelper.performWait(NO_WAIT, inThreadPool(performNotifyAfterDelayRunnable(SHORT_WAIT)));
+    } catch (WaitHelper.TimeoutError e) {
+      performNotifyErrorCalled.set(true);
+      assertEquals(NO_WAIT, e.waitTimeInMillis);
+    }
+    assertFalse(performNotifyCalled.get());
+    assertTrue(performNotifyErrorCalled.get());
+
+    // The spawned thread should have called performNotify() by now.
+    Thread.sleep(LONG_WAIT);
+    try {
+      waitHelper.performWait(NO_WAIT, this.performNothingRunnable());
+    } catch (AssertionError e) {
+      fail("Should not have thrown!");
+    }
+  }
+}

--- a/test/src/org/mozilla/android/sync/test/helpers/WaitHelper.java
+++ b/test/src/org/mozilla/android/sync/test/helpers/WaitHelper.java
@@ -3,30 +3,75 @@
 
 package org.mozilla.android.sync.test.helpers;
 
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import junit.framework.AssertionFailedError;
+
 import android.util.Log;
 
 /**
  * Implements waiting for asynchronous test events.
- * @author rnewman
  *
+ * Call WaitHelper.getTestWaiter() to get the unique instance.
+ *
+ * Call performWait(runnable) to execute runnable synchronously.
+ * runnable *must* call performNotify() on all exit paths to signal to
+ * the TestWaiter that the runnable has completed.
+ *
+ * @author rnewman
+ * @author nalexander
  */
 public class WaitHelper {
-  Object lastAssertionMonitor = new Object();
-  AssertionError lastAssertion = null;
+
+  public class Result {
+    public AssertionError error;
+    public Result() {
+      error = null;
+    }
+
+    public Result(AssertionError error) {
+      this.error = error;
+    }
+  }
+
+  public class TimeoutError extends AssertionError {
+    private static final long serialVersionUID = 8591672555848651736L;
+    public int waitTimeInMillis = -1;
+
+    public TimeoutError(int waitTimeInMillis) {
+      this.waitTimeInMillis = waitTimeInMillis;
+    }
+  }
+
+  public class MultipleNotificationsError extends AssertionError {
+    private static final long serialVersionUID = -9072736521571635495L;
+  }
+
+  public BlockingQueue<Result> queue = new ArrayBlockingQueue<Result>(1);
+
+  public static final String LOG_TAG = "WaitHelper";
 
   /**
-   * We take a Runnable as a parameter so that it'll be invoked inside the
-   * synchronized session, which allows us to be waiting by the time the
-   * Runnable executes.
-   *
-   * action *must* start a new thread before attempting to wait or notify
-   * this helper, otherwise this trick doesn't work!
-   *
-   * @param action
-   * @throws AssertionError
+   * How long performWait should wait for, in milliseconds, with the
+   * convention that a negative value means "wait forever".
    */
-  public synchronized void performWait(Runnable action) throws AssertionError {
-    Log.i("WaitHelper", "performWait called.");
+  public static int defaultWaitTimeoutInMillis = -1;
+
+  public void trace(String message) {
+    Log.i(LOG_TAG, message);
+  }
+
+  public void performWait(Runnable action) throws AssertionError {
+    this.performWait(defaultWaitTimeoutInMillis, action);
+  }
+
+  public void performWait(int waitTimeoutInMillis, Runnable action) throws AssertionError {
+    trace("performWait called.");
+
+    Result result = null;
+
     try {
       if (action != null) {
         try {
@@ -35,44 +80,62 @@ public class WaitHelper {
           throw new AssertionError(ex);
         }
       }
-      Log.d("WaitHelper", "Waiting.");
-      WaitHelper.this.wait();
-      synchronized (lastAssertionMonitor) {
-        Log.d("WaitHelper", "Done waiting. lastAssertion is " + this.lastAssertion);
-        // Rethrow any assertion with which we were notified.
-        if (this.lastAssertion != null) {
-          AssertionError e = this.lastAssertion;
-          this.lastAssertion = null;
-          Log.d("WaitHelper", "Rethrowing.", e);
-          throw e;
-        }
+
+      if (waitTimeoutInMillis < 0) {
+        result = queue.take();
+      } else {
+        result = queue.poll(waitTimeoutInMillis, TimeUnit.MILLISECONDS);
       }
     } catch (InterruptedException e) {
-      e.printStackTrace();
+      // We were interrupted.
+      trace("performNotify interrupted with InterrupedException " + e);
+      throw new AssertionError("INTERRUPTED!");
+    }
+
+    if (result == null) {
+      // We timed out.
+      throw new TimeoutError(waitTimeoutInMillis);
+    } else if (result.error != null) {
+      // Rethrow any assertion with which we were notified.
+      throw new AssertionError(result.error);
+    } else {
+      // Success!
     }
   }
 
-  public void performWait() throws AssertionError {
-    this.performWait(null);
-  }
-
-  public synchronized void performNotify(AssertionError e) {
+  public void performNotify(final AssertionError e) {
     if (e != null) {
-      Log.i("WaitHelper", "performNotify called with AssertionError " + e);
+      trace("performNotify called with AssertionError " + e);
+    } else {
+      trace("performNotify called.");
     }
-    synchronized (lastAssertionMonitor) {
-      this.lastAssertion = e;
+
+    if (!queue.offer(new Result(e))) {
+      // This could happen if performNotify is called multiple times (which is an error).
+      throw new MultipleNotificationsError();
     }
-    WaitHelper.this.notify();
   }
 
-  public synchronized void performNotify() {
-    Log.i("WaitHelper", "performNotify called.");
-    this.performNotify(null);
+  public void performNotify(final AssertionFailedError e) {
+    AssertionError ex = null;
+
+    if (e != null) {
+      ex = new AssertionError(e);
+    }
+
+    this.performNotify(ex);
+  }
+
+  public void performNotify() {
+    this.performNotify((AssertionError)null);
   }
 
   private static WaitHelper singleWaiter = new WaitHelper();
   public static WaitHelper getTestWaiter() {
     return singleWaiter;
+  }
+
+  public static void resetTestWaiter() {
+    singleWaiter = new WaitHelper();
   }
 }


### PR DESCRIPTION
Most important: this tests WaitHelper.  I was confused by what was supposed to happen.

Next important: I made WaitHelper use a length 1 blocking queue.  This makes synchronous callbacks (that don't spawn a thread) work.  This also makes testing and reacting to various conditions a lot easier; hopefully I didn't introduce too many concurrency problems.

Next next important: I am catching more than AssertionError; I am also catching AssertionFailedError.  Something is different between JUnit 3 and JUnit 4, but now I get good stack traces (in Eclipse) without needing to crawl through logcat.

Least important: I added an optional timeout to performWait.  Handy when you are testing and probably a good thing to set globally at some point -- long tests are probably broken, after all, although the emulator does make that dicy.  JUnit 4 will do the timeouts for us.
