### PR TITLE
Bug 723235 - Request history items sorted by sortindex/frecency.

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/repositories/ConstrainedServer11Repository.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/ConstrainedServer11Repository.java
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.gecko.sync.repositories;
+
+import java.net.URISyntaxException;
+
+import org.mozilla.gecko.sync.CredentialsSource;
+
+/**
+ * A kind of Server11Repository that supports explicit setting of limit and sort on operations.
+ *
+ * @author rnewman
+ *
+ */
+public class ConstrainedServer11Repository extends Server11Repository {
+
+  private String sort = null;
+  private long limit  = -1;
+
+  public ConstrainedServer11Repository(String serverURI, String username, String collection, CredentialsSource credentialsSource, long limit, String sort) throws URISyntaxException {
+    super(serverURI, username, collection, credentialsSource);
+
+    this.limit = limit;
+    this.sort  = sort;
+  }
+
+  @Override
+  protected String getDefaultSort() {
+    return sort;
+  }
+
+  @Override
+  protected long getDefaultFetchLimit() {
+    return limit;
+  }
+}

--- a/src/main/java/org/mozilla/gecko/sync/repositories/Server11Repository.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/Server11Repository.java
@@ -39,6 +39,7 @@ package org.mozilla.gecko.sync.repositories;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 
 import org.mozilla.gecko.sync.CredentialsSource;
 import org.mozilla.gecko.sync.Utils;
@@ -92,32 +93,50 @@ public class Server11Repository extends Repository {
     return this.collectionPathURI;
   }
 
-  public URI collectionURI(boolean full, long newer, String ids) throws URISyntaxException {
-    // Do it this way to make it easier to add more params later.
-    // It's pretty ugly, I'll grant.
-    // I can't believe Java doesn't have a good way to do this.
-    boolean anyParams = full;
-    String  uriParams = "";
-    if (anyParams) {
-      StringBuilder params = new StringBuilder("?");
-      if (full) {
-        params.append("full=1");
-      }
-      if (newer >= 0) {
-        // Translate local millisecond timestamps into server decimal seconds.
-        String newerString = Utils.millisecondsToDecimalSecondsString(newer);
-        params.append((full ? "&newer=" : "newer=") + newerString);
-      }
-      if (ids != null) {
-        params.append(((full || newer >= 0) ? "&ids=" : "ids=") + ids);
-      }
-      uriParams = params.toString();
+  public URI collectionURI(boolean full, long newer, long limit, String sort, String ids) throws URISyntaxException {
+    ArrayList<String> params = new ArrayList<String>();
+    if (full) {
+      params.add("full=1");
     }
-    String uri = this.collectionPath + uriParams;
+    if (newer >= 0) {
+      // Translate local millisecond timestamps into server decimal seconds.
+      String newerString = Utils.millisecondsToDecimalSecondsString(newer);
+      params.add("newer=" + newerString);
+    }
+    if (limit > 0) {
+      params.add("limit=" + limit);
+    }
+    if (sort != null) {
+      params.add("sort=" + sort);       // We trust these values.
+    }
+    if (ids != null) {
+      params.add("ids=" + ids);         // We trust these values.
+    }
+
+    if (params.size() == 0) {
+      return this.collectionPathURI;
+    }
+
+    StringBuilder out = new StringBuilder();
+    char indicator = '?';
+    for (String param : params) {
+      out.append(indicator);
+      indicator = '&';
+      out.append(param);
+    }
+    String uri = this.collectionPath + out.toString();
     return new URI(uri);
   }
 
   public URI wboURI(String id) throws URISyntaxException {
     return new URI(this.collectionPath + "/" + id);
+  }
+
+  // Override these.
+  protected long getDefaultFetchLimit() {
+    return -1;
+  }
+  protected String getDefaultSort() {
+    return null;
   }
 }

--- a/src/main/java/org/mozilla/gecko/sync/stage/AndroidBrowserBookmarksServerSyncStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/AndroidBrowserBookmarksServerSyncStage.java
@@ -37,12 +37,21 @@
 
 package org.mozilla.gecko.sync.stage;
 
+import java.net.URISyntaxException;
+
+import org.mozilla.gecko.sync.repositories.ConstrainedServer11Repository;
 import org.mozilla.gecko.sync.repositories.RecordFactory;
 import org.mozilla.gecko.sync.repositories.Repository;
 import org.mozilla.gecko.sync.repositories.android.AndroidBrowserBookmarksRepository;
 import org.mozilla.gecko.sync.repositories.domain.BookmarkRecordFactory;
 
 public class AndroidBrowserBookmarksServerSyncStage extends ServerSyncStage {
+
+  // Eventually this kind of sync stage will be data-driven,
+  // and all this hard-coding can go away.
+  private static final String BOOKMARKS_SORT          = "index";
+  private static final long   BOOKMARKS_REQUEST_LIMIT = 5000;         // Sanity limit.
+
   @Override
   public void execute(org.mozilla.gecko.sync.GlobalSession session) throws NoSuchStageException {
     super.execute(session);
@@ -55,6 +64,16 @@ public class AndroidBrowserBookmarksServerSyncStage extends ServerSyncStage {
   @Override
   protected String getEngineName() {
     return "bookmarks";
+  }
+
+  @Override
+  protected Repository getRemoteRepository() throws URISyntaxException {
+    return new ConstrainedServer11Repository(session.config.getClusterURLString(),
+                                             session.config.username,
+                                             getCollection(),
+                                             session,
+                                             BOOKMARKS_REQUEST_LIMIT,
+                                             BOOKMARKS_SORT);
   }
 
   @Override

--- a/src/main/java/org/mozilla/gecko/sync/stage/AndroidBrowserHistoryServerSyncStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/AndroidBrowserHistoryServerSyncStage.java
@@ -37,12 +37,21 @@
 
 package org.mozilla.gecko.sync.stage;
 
+import java.net.URISyntaxException;
+
+import org.mozilla.gecko.sync.repositories.ConstrainedServer11Repository;
 import org.mozilla.gecko.sync.repositories.RecordFactory;
 import org.mozilla.gecko.sync.repositories.Repository;
 import org.mozilla.gecko.sync.repositories.android.AndroidBrowserHistoryRepository;
 import org.mozilla.gecko.sync.repositories.domain.HistoryRecordFactory;
 
 public class AndroidBrowserHistoryServerSyncStage extends ServerSyncStage {
+
+  // Eventually this kind of sync stage will be data-driven,
+  // and all this hard-coding can go away.
+  private static final String HISTORY_SORT          = "index";
+  private static final long   HISTORY_REQUEST_LIMIT = 500;
+
   @Override
   public void execute(org.mozilla.gecko.sync.GlobalSession session) throws NoSuchStageException {
     super.execute(session);
@@ -60,6 +69,16 @@ public class AndroidBrowserHistoryServerSyncStage extends ServerSyncStage {
   @Override
   protected Repository getLocalRepository() {
     return new AndroidBrowserHistoryRepository();
+  }
+
+  @Override
+  protected Repository getRemoteRepository() throws URISyntaxException {
+    return new ConstrainedServer11Repository(session.config.getClusterURLString(),
+                                             session.config.username,
+                                             getCollection(),
+                                             session,
+                                             HISTORY_REQUEST_LIMIT,
+                                             HISTORY_SORT);
   }
 
   @Override

--- a/src/main/java/org/mozilla/gecko/sync/stage/ServerSyncStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/ServerSyncStage.java
@@ -84,6 +84,14 @@ public abstract class ServerSyncStage implements
   protected abstract Repository getLocalRepository();
   protected abstract RecordFactory getRecordFactory();
 
+  // Override this in subclasses.
+  protected Repository getRemoteRepository() throws URISyntaxException {
+    return new Server11Repository(session.config.getClusterURLString(),
+                                  session.config.username,
+                                  getCollection(),
+                                  session);
+  }
+
   /**
    * Return a Crypto5Middleware-wrapped Server11Repository.
    *
@@ -97,11 +105,7 @@ public abstract class ServerSyncStage implements
   protected Repository wrappedServerRepo() throws NoCollectionKeysSetException, URISyntaxException {
     String collection = this.getCollection();
     KeyBundle collectionKey = session.keyForCollection(collection);
-    Server11Repository serverRepo = new Server11Repository(session.config.getClusterURLString(),
-                                                           session.config.username,
-                                                           collection,
-                                                           session);
-    Crypto5MiddlewareRepository cryptoRepo = new Crypto5MiddlewareRepository(serverRepo, collectionKey);
+    Crypto5MiddlewareRepository cryptoRepo = new Crypto5MiddlewareRepository(getRemoteRepository(), collectionKey);
     cryptoRepo.recordFactory = getRecordFactory();
     return cryptoRepo;
   }

--- a/src/test/java/org/mozilla/android/sync/net/test/TestServer11Repository.java
+++ b/src/test/java/org/mozilla/android/sync/net/test/TestServer11Repository.java
@@ -1,0 +1,31 @@
+package org.mozilla.android.sync.net.test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.junit.Test;
+import org.mozilla.gecko.sync.repositories.Server11Repository;
+
+public class TestServer11Repository {
+
+  private static final String SERVER_URI = "http://foo.com/";
+  private static final String USERNAME   = "johndoe";
+  private static final String COLLECTION = "bookmarks";
+
+  public static void assertQueryEquals(String expected, URI u) {
+    assertEquals(expected, u.getRawQuery());
+  }
+
+  @Test
+  public void testCollectionURI() throws URISyntaxException {
+    Server11Repository r = new Server11Repository(SERVER_URI, USERNAME, COLLECTION, null);
+    assertQueryEquals("full=1&newer=5000.000",              r.collectionURI(true,  5000000L, -1,    null, null));
+    assertQueryEquals("newer=1230.000",                     r.collectionURI(false, 1230000L, -1,    null, null));
+    assertQueryEquals("newer=5000.000&limit=10",            r.collectionURI(false, 5000000L, 10,    null, null));
+    assertQueryEquals("full=1&newer=5000.000&sort=index",   r.collectionURI(true,  5000000L,  0, "index", null));
+    assertQueryEquals("full=1&ids=123,abc",                 r.collectionURI(true,       -1L, -1,    null, "123,abc"));
+  }
+
+}


### PR DESCRIPTION
Also covers:

• Bug 720304, with a hard limit of 500 history items per request.
• Bug 723240, requesting bookmarks sorted by frecency.

and imposes a sanity limit of 5,000 bookmarks per fetch.

(Note that batching is outside the scope of these bugs.)
