### PR TITLE
Bug 705767: Validate credentials before completing classic setup (+feedback on http error)

### DIFF
--- a/res/layout/sync_account.xml
+++ b/res/layout/sync_account.xml
@@ -61,6 +61,7 @@
     android:orientation="horizontal" >
 
     <Button
+      android:id="@+id/accountCancelButton"
       style="@style/SyncButton"
       android:onClick="cancelClickHandler"
       android:text="@string/sync_button_cancel" />

--- a/res/layout/sync_setup.xml
+++ b/res/layout/sync_setup.xml
@@ -79,8 +79,7 @@
     style="@style/SyncBottom"
     android:orientation="horizontal" >
     <Button
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
+      style="@style/SyncButton"
       android:onClick="cancelClickHandler"
       android:text="@string/sync_button_cancel" />
   </LinearLayout>

--- a/res/layout/sync_setup_failure.xml
+++ b/res/layout/sync_setup_failure.xml
@@ -23,22 +23,17 @@
     android:orientation="horizontal" >
 
     <Button
-      android:layout_width="fill_parent"
-      android:layout_height="wrap_content"
-      android:layout_weight="1"
+      style="@style/SyncButton"
       android:onClick="tryAgainClickHandler"
       android:text="@string/sync_button_tryagain" />
 
     <Button
-      android:layout_width="fill_parent"
-      android:layout_height="wrap_content"
-      android:layout_weight="1"
+      style="@style/SyncButton"
       android:onClick="manualClickHandler"
       android:text="@string/sync_button_manual" />
+
      <Button
-      android:layout_width="fill_parent"
-      android:layout_height="wrap_content"
-      android:layout_weight="1"
+      style="@style/SyncButton"
       android:onClick="cancelClickHandler"
       android:text="@string/sync_button_cancel" />
   </LinearLayout>

--- a/res/values/sync_styles.xml
+++ b/res/values/sync_styles.xml
@@ -63,6 +63,7 @@
     <style name="SyncBottom">
     <item name="android:layout_width">fill_parent</item>
     <item name="android:layout_height">wrap_content</item>
+    <item name="android:layout_gravity">center</item>
     <item name="android:gravity">center</item>
     <item name="android:layout_alignParentBottom">true</item>
     <item name="android:background">@android:drawable/bottom_bar</item>

--- a/res/values/sync_styles.xml
+++ b/res/values/sync_styles.xml
@@ -39,6 +39,7 @@
     <item name="android:layout_width">fill_parent</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:singleLine">true</item>
+    <item name="android:inputType">textNoSuggestions</item>
   </style>
   <style name="SyncEditPin" parent="@style/SyncEditItem">
     <item name="android:layout_width">wrap_content</item>

--- a/src/main/java/org/mozilla/gecko/sync/jpake/JPakeClient.java
+++ b/src/main/java/org/mozilla/gecko/sync/jpake/JPakeClient.java
@@ -897,7 +897,7 @@ public class JPakeClient implements JPakeRequestDelegate {
 
     @Override
     public String getCredentials() {
-      // Jpake setup has no credentials
+      // J-PAKE setup has no credentials.
       return null;
     }
 

--- a/src/main/java/org/mozilla/gecko/sync/net/SyncResourceDelegate.java
+++ b/src/main/java/org/mozilla/gecko/sync/net/SyncResourceDelegate.java
@@ -39,6 +39,7 @@ package org.mozilla.gecko.sync.net;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.net.URISyntaxException;
 
 import ch.boye.httpclientandroidlib.HttpEntity;
 import ch.boye.httpclientandroidlib.client.methods.HttpRequestBase;

--- a/src/main/java/org/mozilla/gecko/sync/setup/AccountCreator.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/AccountCreator.java
@@ -1,0 +1,68 @@
+package org.mozilla.gecko.sync.setup;
+
+import org.mozilla.gecko.sync.Utils;
+import org.mozilla.gecko.sync.repositories.android.Authorities;
+
+import android.accounts.Account;
+import android.accounts.AccountManager;
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+
+public class AccountCreator {
+  private static final String LOG_TAG = "AccountCreator";
+
+  public static Intent createAccount(Context context,
+      AccountManager accountManager, String username, String syncKey,
+      String password, String serverURL) {
+
+    final Account account = new Account(username, Constants.ACCOUNTTYPE_SYNC);
+    final Bundle userbundle = new Bundle();
+
+    // Add sync key and server URL.
+    userbundle.putString(Constants.OPTION_SYNCKEY, syncKey);
+    if (serverURL != null) {
+      Log.i(LOG_TAG, "Setting explicit server URL: " + serverURL);
+      userbundle.putString(Constants.OPTION_SERVER, serverURL);
+    } else {
+      userbundle.putString(Constants.OPTION_SERVER, Constants.AUTH_DEFAULT_SERVER);
+    }
+    Log.d(LOG_TAG, "Adding account for " + Constants.ACCOUNTTYPE_SYNC);
+    boolean result = accountManager.addAccountExplicitly(account, password,
+        userbundle);
+
+    Log.d(LOG_TAG, "Account: " + account.toString() + " added successfully? "
+        + result);
+    if (!result) {
+      Log.e(LOG_TAG, "Error adding account!");
+    }
+
+    // Set components to sync (default: all).
+    ContentResolver.setMasterSyncAutomatically(true);
+    ContentResolver.setSyncAutomatically(account,
+        Authorities.BROWSER_AUTHORITY, true);
+
+    // TODO: add other ContentProviders as needed (e.g. passwords)
+    // TODO: for each, also add to res/xml to make visible in account settings
+    Log.d(LOG_TAG, "Finished setting syncables.");
+
+    // TODO: correctly implement Sync Options.
+    Log.i(LOG_TAG, "Clearing preferences for this account.");
+    try {
+      Utils.getSharedPreferences(context, username, serverURL).edit().clear()
+          .commit();
+    } catch (Exception e) {
+      Log.e(LOG_TAG, "Could not clear prefs path!", e);
+    }
+
+    final Intent intent = new Intent();
+    intent.putExtra(AccountManager.KEY_ACCOUNT_NAME, username);
+    intent
+        .putExtra(AccountManager.KEY_ACCOUNT_TYPE, Constants.ACCOUNTTYPE_SYNC);
+    intent.putExtra(AccountManager.KEY_AUTHTOKEN, Constants.ACCOUNTTYPE_SYNC);
+    return intent;
+  }
+
+}

--- a/src/main/java/org/mozilla/gecko/sync/setup/AccountCreator.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/AccountCreator.java
@@ -27,7 +27,7 @@ public class AccountCreator {
       Log.i(LOG_TAG, "Setting explicit server URL: " + serverURL);
       userbundle.putString(Constants.OPTION_SERVER, serverURL);
     } else {
-      userbundle.putString(Constants.OPTION_SERVER, Constants.AUTH_DEFAULT_SERVER);
+      userbundle.putString(Constants.OPTION_SERVER, Constants.AUTH_NODE_DEFAULT);
     }
     Log.d(LOG_TAG, "Adding account for " + Constants.ACCOUNTTYPE_SYNC);
     boolean result = accountManager.addAccountExplicitly(account, password,

--- a/src/main/java/org/mozilla/gecko/sync/setup/Constants.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/Constants.java
@@ -57,7 +57,7 @@ public class Constants {
     Intent.FLAG_ACTIVITY_NO_ANIMATION;
 
   // Constants for Account Authentication.
-  public static final String AUTH_NODE_DEFAULT  = "auth.services.mozilla.com/";
+  public static final String AUTH_NODE_DEFAULT  = "https://auth.services.mozilla.com/";
   public static final String AUTH_NODE_PATHNAME   = "user/";
   public static final String AUTH_NODE_VERSION    = "1.0/";
   public static final String AUTH_NODE_SUFFIX     = "node/weave";

--- a/src/main/java/org/mozilla/gecko/sync/setup/Constants.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/Constants.java
@@ -57,10 +57,15 @@ public class Constants {
     Intent.FLAG_ACTIVITY_NO_ANIMATION;
 
   // Constants for Account Authentication.
-  public static final String AUTH_DEFAULT_SERVER  = "auth.services.mozilla.com/";
-  public static final String AUTH_USER_PATHNAME   = "user/";
-  public static final String AUTH_USER_VERSION    = "1.0/";
-  public static final String AUTH_NODE            = "node/weave";
+  public static final String AUTH_NODE_DEFAULT  = "auth.services.mozilla.com/";
+  public static final String AUTH_NODE_PATHNAME   = "user/";
+  public static final String AUTH_NODE_VERSION    = "1.0/";
+  public static final String AUTH_NODE_SUFFIX     = "node/weave";
+  public static final String AUTH_SERVER_VERSION  = "1.1/";
+  public static final String AUTH_SERVER_SUFFIX   = "info/collections/";
+
+  // Account Authentication Errors.
+  public static final String AUTH_ERROR_NOUSER    = "auth.error.badcredentials";
 
   // Links for J-PAKE setup help pages.
   public static final String LINK_FIND_CODE       = "https://support.mozilla.org/kb/find-code-to-add-device-to-firefox-sync";

--- a/src/main/java/org/mozilla/gecko/sync/setup/Constants.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/Constants.java
@@ -56,6 +56,12 @@ public class Constants {
     Intent.FLAG_ACTIVITY_REORDER_TO_FRONT |
     Intent.FLAG_ACTIVITY_NO_ANIMATION;
 
+  // Constants for Account Authentication.
+  public static final String AUTH_DEFAULT_SERVER  = "auth.services.mozilla.com/";
+  public static final String AUTH_USER_PATHNAME   = "user/";
+  public static final String AUTH_USER_VERSION    = "1.0/";
+  public static final String AUTH_NODE            = "node/weave";
+
   // Links for J-PAKE setup help pages.
   public static final String LINK_FIND_CODE       = "https://support.mozilla.org/kb/find-code-to-add-device-to-firefox-sync";
   public static final String LINK_FIND_ADD_DEVICE = "https://support.mozilla.org/kb/add-a-device-to-firefox-sync";

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
@@ -171,7 +171,7 @@ public class AccountActivity extends AccountAuthenticatorActivity {
     password = passwordInput.getText().toString();
     key = synckeyInput.getText().toString();
     if (serverCheckbox.isChecked()) {
-      server = serverInput.getText().toString();
+      server = "https://" + serverInput.getText().toString();
     }
     enableCredEntry(false);
     activateView(connectButton, false);

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
@@ -232,30 +232,37 @@ public class AccountActivity extends AccountAuthenticatorActivity {
    * Callback that handles auth based on success/failure
    */
   public void authCallback(boolean isSuccess) {
-    if (!isSuccess) {
-      Log.d(LOG_TAG, "not successful");
-      runOnUiThread(new Runnable() {
-        @Override
-        public void run() {
-          authFailure();
-        }
-      });
-      return;
+    if (isSuccess) {
+      // Successful authentication. Create and add account to AccountManager.
+      // Note: Sync key may incorrect!
+      Log.d(LOG_TAG, "Using account manager " + mAccountManager);
+      final Intent intent = AccountCreator.createAccount(mContext,
+          mAccountManager, username, key, password, server);
+      if (intent != null) {
+        setAccountAuthenticatorResult(intent.getExtras());
+        setResult(RESULT_OK, intent);
+
+        runOnUiThread(new Runnable() {
+          @Override
+          public void run() {
+            authSuccess();
+          }
+        });
+        return;
+      }
+      // TODO: Display error to user, probably will require new strings.
+      // For now, display default failure screen.
     }
 
-    // Successful authentication. Create and add account to AccountManager.
-    // Note: Sync key may incorrect!
-    Log.d(LOG_TAG, "Using account manager " + mAccountManager);
-    final Intent intent = AccountCreator.createAccount(mContext, mAccountManager,
-                                        username,
-                                        key, password, server);
-    setAccountAuthenticatorResult(intent.getExtras());
-    setResult(RESULT_OK, intent);
+    if (!isSuccess) {
+      Log.d(LOG_TAG, "Authentication failure.");
+    }
 
+    // Display default failure screen to user.
     runOnUiThread(new Runnable() {
       @Override
       public void run() {
-        authSuccess();
+        authFailure();
       }
     });
   }

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
@@ -41,6 +41,7 @@ package org.mozilla.gecko.sync.setup.activities;
 import org.mozilla.gecko.R;
 import org.mozilla.gecko.sync.setup.AccountCreator;
 import org.mozilla.gecko.sync.setup.Constants;
+import org.mozilla.gecko.sync.setup.auth.AccountAuthenticator;
 
 import android.accounts.AccountAuthenticatorActivity;
 import android.accounts.AccountManager;
@@ -65,7 +66,7 @@ public class AccountActivity extends AccountAuthenticatorActivity {
   private String              username;
   private String              password;
   private String              key;
-  private String              server;
+  private String              server = Constants.AUTH_NODE_DEFAULT;
 
   // UI elements.
   private EditText            serverInput;
@@ -144,11 +145,10 @@ public class AccountActivity extends AccountAuthenticatorActivity {
       server = serverInput.getText().toString();
     }
     enableCredEntry(false);
+    activateView(connectButton, false);
 
-    // TODO : Authenticate with Sync Service, once implemented, with
-    // onAuthSuccess as callback
-
-    authCallback();
+    AccountAuthenticator accountAuth = new AccountAuthenticator(this);
+    accountAuth.authenticate(server, username, password);
   }
 
   /* Helper UI functions */
@@ -194,19 +194,25 @@ public class AccountActivity extends AccountAuthenticatorActivity {
   /*
    * Callback that handles auth based on success/failure
    */
-  private void authCallback() {
-    // Create and add account to AccountManager
-    // TODO: only allow one account to be added?
+  public void authCallback(boolean isSuccess) {
+    if (!isSuccess) {
+      Log.d(LOG_TAG, "not successful");
+      runOnUiThread(new Runnable() {
+        @Override
+        public void run() {
+          authFailure();
+        }
+      });
+      return;
+    }
+
+    // Successful authentication. Create and add account to AccountManager.
+    // Note: Sync key may incorrect!
     Log.d(LOG_TAG, "Using account manager " + mAccountManager);
     final Intent intent = AccountCreator.createAccount(mContext, mAccountManager,
                                         username,
                                         key, password, server);
     setAccountAuthenticatorResult(intent.getExtras());
-
-    // TODO: Currently, we do not actually authenticate username/pass against
-    // Moz sync server.
-
-    // Successful authentication result
     setResult(RESULT_OK, intent);
 
     runOnUiThread(new Runnable() {
@@ -217,14 +223,21 @@ public class AccountActivity extends AccountAuthenticatorActivity {
     });
   }
 
-  private void authFailure() {
+  /**
+   * Feedback to user of account setup failure.
+   */
+  public void authFailure() {
     enableCredEntry(true);
     Intent intent = new Intent(mContext, SetupFailureActivity.class);
     intent.setFlags(Constants.FLAG_ACTIVITY_REORDER_TO_FRONT_NO_ANIMATION);
     startActivity(intent);
   }
 
-  private void authSuccess() {
+  /**
+   * Feedback to user of account setup success.
+   */
+  public void authSuccess() {
+    // Display feedback of successful account setup.
     Intent intent = new Intent(mContext, SetupSuccessActivity.class);
     intent.setFlags(Constants.FLAG_ACTIVITY_REORDER_TO_FRONT_NO_ANIMATION);
     startActivity(intent);

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
@@ -39,14 +39,11 @@
 package org.mozilla.gecko.sync.setup.activities;
 
 import org.mozilla.gecko.R;
-import org.mozilla.gecko.sync.Utils;
-import org.mozilla.gecko.sync.repositories.android.Authorities;
+import org.mozilla.gecko.sync.setup.AccountCreator;
 import org.mozilla.gecko.sync.setup.Constants;
 
-import android.accounts.Account;
 import android.accounts.AccountAuthenticatorActivity;
 import android.accounts.AccountManager;
-import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
@@ -62,8 +59,6 @@ import android.widget.EditText;
 
 public class AccountActivity extends AccountAuthenticatorActivity {
   private final static String LOG_TAG        = "AccountActivity";
-
-  private final static String DEFAULT_SERVER = "https://auth.services.mozilla.com/";
 
   private AccountManager      mAccountManager;
   private Context             mContext;
@@ -203,13 +198,10 @@ public class AccountActivity extends AccountAuthenticatorActivity {
     // Create and add account to AccountManager
     // TODO: only allow one account to be added?
     Log.d(LOG_TAG, "Using account manager " + mAccountManager);
-    final Intent intent = createAccount(mContext, mAccountManager,
+    final Intent intent = AccountCreator.createAccount(mContext, mAccountManager,
                                         username,
                                         key, password, server);
     setAccountAuthenticatorResult(intent.getExtras());
-
-    // Testing out the authFailure case
-    // authFailure();
 
     // TODO: Currently, we do not actually authenticate username/pass against
     // Moz sync server.
@@ -223,55 +215,6 @@ public class AccountActivity extends AccountAuthenticatorActivity {
         authSuccess();
       }
     });
-  }
-
-  // TODO: lift this out.
-  public static Intent createAccount(Context context,
-                                     AccountManager accountManager,
-                                     String username,
-                                     String syncKey,
-                                     String password, String serverURL) {
-
-    final Account account = new Account(username, Constants.ACCOUNTTYPE_SYNC);
-    final Bundle userbundle = new Bundle();
-
-    // Add sync key and server URL.
-    userbundle.putString(Constants.OPTION_SYNCKEY, syncKey);
-    if (serverURL != null) {
-      Log.i(LOG_TAG, "Setting explicit server URL: " + serverURL);
-      userbundle.putString(Constants.OPTION_SERVER, serverURL);
-    } else {
-      userbundle.putString(Constants.OPTION_SERVER, DEFAULT_SERVER);
-    }
-    Log.d(LOG_TAG, "Adding account for " + Constants.ACCOUNTTYPE_SYNC);
-    boolean result = accountManager.addAccountExplicitly(account, password, userbundle);
-
-    Log.d(LOG_TAG, "Account: " + account.toString() + " added successfully? " + result);
-    if (!result) {
-      Log.e(LOG_TAG, "Error adding account!");
-    }
-
-    // Set components to sync (default: all).
-    ContentResolver.setMasterSyncAutomatically(true);
-    ContentResolver.setSyncAutomatically(account, Authorities.BROWSER_AUTHORITY, true);
-
-    // TODO: add other ContentProviders as needed (e.g. passwords)
-    // TODO: for each, also add to res/xml to make visible in account settings
-    Log.d(LOG_TAG, "Finished setting syncables.");
-
-    // TODO: correctly implement Sync Options.
-    Log.i(LOG_TAG, "Clearing preferences for this account.");
-    try {
-      Utils.getSharedPreferences(context, username, serverURL).edit().clear().commit();
-    } catch (Exception e) {
-      Log.e(LOG_TAG, "Could not clear prefs path!", e);
-    }
-
-    final Intent intent = new Intent();
-    intent.putExtra(AccountManager.KEY_ACCOUNT_NAME, username);
-    intent.putExtra(AccountManager.KEY_ACCOUNT_TYPE, Constants.ACCOUNTTYPE_SYNC);
-    intent.putExtra(AccountManager.KEY_AUTHTOKEN, Constants.ACCOUNTTYPE_SYNC);
-    return intent;
   }
 
   private void authFailure() {

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupFailureActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupFailureActivity.java
@@ -69,6 +69,7 @@ public class SetupFailureActivity extends Activity {
 
   public void cancelClickHandler(View target) {
     setResult(RESULT_CANCELED);
+    moveTaskToBack(true);
     finish();
   }
 }

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSyncActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSyncActivity.java
@@ -42,6 +42,7 @@ import org.json.simple.JSONObject;
 import org.mozilla.gecko.R;
 import org.mozilla.gecko.sync.jpake.JPakeClient;
 import org.mozilla.gecko.sync.jpake.JPakeNoActivePairingException;
+import org.mozilla.gecko.sync.setup.AccountCreator;
 import org.mozilla.gecko.sync.setup.Constants;
 
 import android.accounts.Account;
@@ -339,7 +340,7 @@ public class SetupSyncActivity extends AccountAuthenticatorActivity {
       String serverURL    = (String) jCreds.get(Constants.JSON_KEY_SERVER);
 
       Log.d(LOG_TAG, "Using account manager " + mAccountManager);
-      final Intent intent = AccountActivity.createAccount(mContext, mAccountManager,
+      final Intent intent = AccountCreator.createAccount(mContext, mAccountManager,
                                                           accountName,
                                                           syncKey, password, serverURL);
       setAccountAuthenticatorResult(intent.getExtras());

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/AccountAuthenticator.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/AccountAuthenticator.java
@@ -1,0 +1,92 @@
+package org.mozilla.gecko.sync.setup.auth;
+
+import java.io.UnsupportedEncodingException;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.mozilla.gecko.sync.crypto.Cryptographer;
+import org.mozilla.gecko.sync.setup.activities.AccountActivity;
+
+import android.util.Log;
+
+public class AccountAuthenticator {
+  private final String LOG_TAG = "AccountSetupAuthenticator";
+
+  private AccountActivity activityCallback;
+  private List<AuthenticatorStage> stages;
+
+  private int stageIndex = -1; // Stages not started.
+
+  // Values for authentication.
+  public String password;
+  public String usernameHash;
+
+  public String authServer;
+  public String nodeServer;
+
+  public boolean isSuccess = false;
+
+  public AccountAuthenticator(AccountActivity activity) {
+    activityCallback = activity;
+    prepareStages();
+  }
+
+  private void prepareStages() {
+    stages = new ArrayList<AuthenticatorStage>();
+    stages.add(new FetchUserNodeStage());
+    stages.add(new AuthenticateAccountStage());
+  }
+
+  public void authenticate(String server, String username, String password) {
+    // Set authentication values.
+    if (!server.endsWith("/")) {
+      server += "/";
+    }
+    nodeServer = server;
+    this.password = password;
+
+    // Calculate and save username hash.
+    try {
+      usernameHash = Cryptographer.sha1Base32(username.toLowerCase()).toLowerCase();
+    } catch (NoSuchAlgorithmException e) {
+      abort("Username hash error.", e);
+    } catch (UnsupportedEncodingException e) {
+      abort("Username hash error.", e);
+    }
+    Log.d(LOG_TAG, "usernameHash:" + usernameHash);
+
+    // Start first stage of authentication.
+    runNextStage();
+  }
+
+  /**
+   * Run next stage of authentication.
+   */
+  public void runNextStage() {
+    if (++stageIndex == stages.size()) {
+      activityCallback.authCallback(isSuccess);
+      return;
+    }
+    try {
+      stages.get(stageIndex).execute(this);
+    } catch (Exception e) {
+      Log.w(LOG_TAG, "Exception in stage " + stages.get(stageIndex));
+      abort("Stage exception.", e);
+    }
+  }
+
+  /**
+   * Abort authentication.
+   *
+   * @param e
+   *    Exception causing abort.
+   * @param reason
+   *    Reason for abort.
+   */
+  public void abort(String reason, Exception e) {
+    Log.w(LOG_TAG, reason, e);
+    activityCallback.authCallback(false);
+  }
+
+}

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/AccountAuthenticator.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/AccountAuthenticator.java
@@ -26,6 +26,7 @@ public class AccountAuthenticator {
   public String nodeServer;
 
   public boolean isSuccess = false;
+  public boolean isCanceled = false;
 
   public AccountAuthenticator(AccountActivity activity) {
     activityCallback = activity;
@@ -64,6 +65,9 @@ public class AccountAuthenticator {
    * Run next stage of authentication.
    */
   public void runNextStage() {
+    if (isCanceled) {
+      return;
+    }
     if (++stageIndex == stages.size()) {
       activityCallback.authCallback(isSuccess);
       return;
@@ -85,6 +89,9 @@ public class AccountAuthenticator {
    *    Reason for abort.
    */
   public void abort(String reason, Exception e) {
+    if (isCanceled) {
+      return;
+    }
     Log.w(LOG_TAG, reason, e);
     activityCallback.authCallback(false);
   }

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/AuthenticateAccountStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/AuthenticateAccountStage.java
@@ -1,0 +1,140 @@
+package org.mozilla.gecko.sync.setup.auth;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.GeneralSecurityException;
+
+import org.mozilla.gecko.sync.ThreadPool;
+import org.mozilla.gecko.sync.net.BaseResource;
+import org.mozilla.gecko.sync.net.SyncResourceDelegate;
+import org.mozilla.gecko.sync.net.SyncStorageRequest;
+import org.mozilla.gecko.sync.setup.Constants;
+
+import android.util.Base64;
+import android.util.Log;
+import ch.boye.httpclientandroidlib.HeaderIterator;
+import ch.boye.httpclientandroidlib.HttpResponse;
+import ch.boye.httpclientandroidlib.client.ClientProtocolException;
+import ch.boye.httpclientandroidlib.client.methods.HttpRequestBase;
+import ch.boye.httpclientandroidlib.conn.params.ConnConnectionPNames;
+import ch.boye.httpclientandroidlib.impl.client.DefaultHttpClient;
+import ch.boye.httpclientandroidlib.message.BasicHeader;
+
+public class AuthenticateAccountStage implements AuthenticatorStage {
+  private final String LOG_TAG = "AuthenticateAccountStage";
+
+  public interface AuthenticateAccountStageDelegate {
+    public void handleSuccess(boolean isSuccess);
+    public void handleFailure(HttpResponse response);
+    public void handleError(Exception e);
+  }
+
+  @Override
+  public void execute(final AccountAuthenticator aa) throws URISyntaxException, UnsupportedEncodingException {
+    AuthenticateAccountStageDelegate callbackDelegate = new AuthenticateAccountStageDelegate() {
+
+      @Override
+      public void handleSuccess(boolean isSuccess) {
+        aa.isSuccess = isSuccess;
+        aa.runNextStage();
+      }
+
+      @Override
+      public void handleFailure(HttpResponse response) {
+        Log.d(LOG_TAG, "handleFailure");
+        aa.abort(response.toString(), new Exception(response.getStatusLine().getStatusCode() + " error."));
+        try {
+          BufferedReader reader = new BufferedReader(new InputStreamReader(response.getEntity().getContent(), "UTF-8"));
+          Log.w(LOG_TAG, "content: " + reader.readLine());
+          SyncResourceDelegate.consumeReader(reader);
+          reader.close();
+          SyncResourceDelegate.consumeEntity(response.getEntity());
+        } catch (IllegalStateException e) {
+          Log.d(LOG_TAG, "Error reading content.", e);
+        } catch (IOException e) {
+          Log.d(LOG_TAG, "Error reading content.", e);
+        }
+      }
+
+      @Override
+      public void handleError(Exception e) {
+        Log.d(LOG_TAG, "handleError");
+        aa.abort("HTTP failure.", e);
+      }
+    };
+
+    // Calculate BasicAuth hash of username/password.
+    String authHash = Base64.encodeToString((aa.usernameHash + ":" + aa.password).getBytes(), Base64.DEFAULT);
+    String authRequestUrl = aa.authServer + Constants.AUTH_SERVER_VERSION + aa.usernameHash + "/" + Constants.AUTH_SERVER_SUFFIX;
+    authenticateAccount(callbackDelegate, authRequestUrl, authHash);
+  }
+
+  private void authenticateAccount(final AuthenticateAccountStageDelegate callbackDelegate, final String authRequestUrl, final String authHeader) throws URISyntaxException {
+    final BaseResource httpResource = new BaseResource(authRequestUrl);
+    httpResource.delegate = new SyncResourceDelegate(httpResource) {
+
+      @Override
+      public void addHeaders(HttpRequestBase request, DefaultHttpClient client) {
+
+        client.log.enableDebug(true);
+        request.setHeader(new BasicHeader("User-Agent", SyncStorageRequest.USER_AGENT));
+        // Host header is not set for some reason, so do it explicitly.
+        try {
+          URI authServerUri = new URI(authRequestUrl);
+          request.setHeader(new BasicHeader("Host", authServerUri.getHost()));
+        } catch (URISyntaxException e) {
+          Log.e(LOG_TAG, "Malformed uri, will be caught elsewhere.", e);
+        }
+        request.setHeader(new BasicHeader("Authorization", "Basic " + authHeader));
+      }
+
+      @Override
+      public void handleHttpResponse(HttpResponse response) {
+        int statusCode = response.getStatusLine().getStatusCode();
+        switch(statusCode) {
+        case 200:
+          callbackDelegate.handleSuccess(true);
+          SyncResourceDelegate.consumeEntity(response.getEntity());
+          break;
+        case 401:
+          callbackDelegate.handleSuccess(false);
+          SyncResourceDelegate.consumeEntity(response.getEntity());
+          break;
+        default:
+          callbackDelegate.handleFailure(response);
+        }
+      }
+
+      @Override
+      public void handleHttpProtocolException(ClientProtocolException e) {
+        Log.e(LOG_TAG, "Client protocol error.");
+        callbackDelegate.handleError(e);
+      }
+
+      @Override
+      public void handleHttpIOException(IOException e) {
+        callbackDelegate.handleError(e);
+      }
+
+      @Override
+      public void handleTransportException(GeneralSecurityException e) {
+        callbackDelegate.handleError(e);
+      }
+    };
+
+    runOnThread(new Runnable() {
+      @Override
+      public void run() {
+        httpResource.get();
+      }
+    });
+  }
+
+  private static void runOnThread(Runnable run) {
+    ThreadPool.run(run);
+  }
+}

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/AuthenticateAccountStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/AuthenticateAccountStage.java
@@ -16,11 +16,9 @@ import org.mozilla.gecko.sync.setup.Constants;
 
 import android.util.Base64;
 import android.util.Log;
-import ch.boye.httpclientandroidlib.HeaderIterator;
 import ch.boye.httpclientandroidlib.HttpResponse;
 import ch.boye.httpclientandroidlib.client.ClientProtocolException;
 import ch.boye.httpclientandroidlib.client.methods.HttpRequestBase;
-import ch.boye.httpclientandroidlib.conn.params.ConnConnectionPNames;
 import ch.boye.httpclientandroidlib.impl.client.DefaultHttpClient;
 import ch.boye.httpclientandroidlib.message.BasicHeader;
 

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/AuthenticatorStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/AuthenticatorStage.java
@@ -1,0 +1,8 @@
+package org.mozilla.gecko.sync.setup.auth;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URISyntaxException;
+
+public interface AuthenticatorStage {
+  public void execute(AccountAuthenticator aa) throws URISyntaxException, UnsupportedEncodingException;
+}

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/FetchUserNodeStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/FetchUserNodeStage.java
@@ -1,0 +1,119 @@
+package org.mozilla.gecko.sync.setup.auth;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URISyntaxException;
+import java.security.GeneralSecurityException;
+
+import org.mozilla.gecko.sync.ThreadPool;
+import org.mozilla.gecko.sync.net.BaseResource;
+import org.mozilla.gecko.sync.net.SyncResourceDelegate;
+import org.mozilla.gecko.sync.setup.Constants;
+
+import android.util.Log;
+import ch.boye.httpclientandroidlib.HttpResponse;
+import ch.boye.httpclientandroidlib.client.ClientProtocolException;
+
+public class FetchUserNodeStage implements AuthenticatorStage {
+  private final String LOG_TAG = "FetchUserNodeStage";
+
+  public interface FetchNodeStageDelegate {
+    public void handleSuccess(String url);
+    public void handleFailure(HttpResponse response);
+    public void handleError(Exception e);
+  }
+
+  @Override
+  public void execute(final AccountAuthenticator aa) throws URISyntaxException {
+
+    FetchNodeStageDelegate callbackDelegate = new FetchNodeStageDelegate() {
+
+      @Override
+      public void handleSuccess(String server) {
+        if (!server.endsWith("/")) {
+          server += "/";
+        }
+        aa.authServer = server;
+        aa.runNextStage();
+      }
+
+      @Override
+      public void handleFailure(HttpResponse response) {
+        if (response.getStatusLine().getStatusCode() == 404) {
+          aa.abort(response.toString(), new Exception(LOG_TAG + " 404 no such user."));
+        } else {
+          aa.abort(response.toString(), new Exception(response.getStatusLine().getStatusCode() + " error."));
+        }
+      }
+
+      @Override
+      public void handleError(Exception e) {
+        aa.abort("HTTP failure.", e);
+      }
+    };
+    String nodeRequestUrl = "https://" + aa.nodeServer + Constants.AUTH_NODE_PATHNAME + Constants.AUTH_NODE_VERSION + aa.usernameHash + "/" + Constants.AUTH_NODE_SUFFIX;
+    Log.d(LOG_TAG, "nodeUrl: " + nodeRequestUrl);
+    makeFetchNodeRequest(callbackDelegate, nodeRequestUrl);
+  }
+
+  private void makeFetchNodeRequest(final FetchNodeStageDelegate callbackDelegate, String fetchNodeUrl) throws URISyntaxException {
+    // Fetch node containing user.
+    final BaseResource httpResource = new BaseResource(fetchNodeUrl);
+    httpResource.delegate = new SyncResourceDelegate(httpResource) {
+
+      @Override
+      public void handleHttpResponse(HttpResponse response) {
+        int statusCode = response.getStatusLine().getStatusCode();
+        switch(statusCode) {
+        case 200:
+          try {
+            InputStream content = response.getEntity().getContent();
+            BufferedReader reader = new BufferedReader(new InputStreamReader(content, "UTF-8"), 1024);
+            String server = reader.readLine();
+            callbackDelegate.handleSuccess(server);
+            SyncResourceDelegate.consumeReader(reader);
+            reader.close();
+          } catch (IllegalStateException e) {
+            callbackDelegate.handleError(e);
+          } catch (IOException e) {
+            callbackDelegate.handleError(e);
+          }
+          break;
+        default:
+          // No other acceptable states.
+          callbackDelegate.handleFailure(response);
+        }
+        SyncResourceDelegate.consumeEntity(response.getEntity());
+      }
+
+      @Override
+      public void handleHttpProtocolException(ClientProtocolException e) {
+        callbackDelegate.handleError(e);
+      }
+
+      @Override
+      public void handleHttpIOException(IOException e) {
+        callbackDelegate.handleError(e);
+      }
+
+      @Override
+      public void handleTransportException(GeneralSecurityException e) {
+        callbackDelegate.handleError(e);
+      }
+
+    };
+    runOnThread(new Runnable() {
+
+      @Override
+      public void run() {
+        httpResource.get();
+      }
+    });
+  }
+
+  private static void runOnThread(Runnable run) {
+    ThreadPool.run(run);
+  }
+}

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/FetchUserNodeStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/FetchUserNodeStage.java
@@ -53,7 +53,7 @@ public class FetchUserNodeStage implements AuthenticatorStage {
         aa.abort("HTTP failure.", e);
       }
     };
-    String nodeRequestUrl = "https://" + aa.nodeServer + Constants.AUTH_NODE_PATHNAME + Constants.AUTH_NODE_VERSION + aa.usernameHash + "/" + Constants.AUTH_NODE_SUFFIX;
+    String nodeRequestUrl = aa.nodeServer + Constants.AUTH_NODE_PATHNAME + Constants.AUTH_NODE_VERSION + aa.usernameHash + "/" + Constants.AUTH_NODE_SUFFIX;
     Log.d(LOG_TAG, "nodeUrl: " + nodeRequestUrl);
     makeFetchNodeRequest(callbackDelegate, nodeRequestUrl);
   }


### PR DESCRIPTION
Also lifted out account creation and made some setup UI changes. We may want to validate the sync key length, because that is not checked against anything before being added to an account.

HTTP error: after a 401 unauthorized credential validation against the sync server, the next request will always fail with a ClientProtocolError. (throw ProtocolException in http://dxr.mozilla.org/mozilla/mozilla-central/mobile/android/base/httpclientandroidlib/impl/conn/DefaultResponseParser.java.html)
Not consuming the resource after use will make this problem disappear, but also exhausts the thread pool. Some detail about the Java HttpClient that I'm missing? 
