### PR TITLE
Bug 724200 - SyncStorageRequest.delete() results in NullPointerException.

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/net/SyncStorageRequest.java
+++ b/src/main/java/org/mozilla/gecko/sync/net/SyncStorageRequest.java
@@ -170,6 +170,9 @@ public class SyncStorageRequest implements Resource {
       if (ifUnmodifiedSince != null) {
         request.setHeader("x-weave-if-unmodified-since", ifUnmodifiedSince);
       }
+      if (request.getMethod().equalsIgnoreCase("DELETE")) {
+        request.addHeader("x-confirm-delete", "1");
+      }
     }
   }
 
@@ -192,7 +195,6 @@ public class SyncStorageRequest implements Resource {
   }
 
   public void delete() {
-    this.resource.request.addHeader("x-confirm-delete", "1");
     this.resource.delete();
   }
 

--- a/src/test/java/org/mozilla/android/sync/net/test/TestSyncStorageRequest.java
+++ b/src/test/java/org/mozilla/android/sync/net/test/TestSyncStorageRequest.java
@@ -220,4 +220,25 @@ public class TestSyncStorageRequest {
     r.post(new JSONObject());
     // Server is stopped in the callback.
   }
+
+  public class DeleteMockServer extends MockServer {
+    @Override
+    public void handle(Request request, Response response) {
+      assertTrue(request.contains("x-confirm-delete"));
+      assertEquals("1", request.getValue("x-confirm-delete"));
+      super.handle(request, response);
+    }
+  }
+
+  @Test
+  public void testDelete() throws URISyntaxException {
+    BaseResource.rewriteLocalhost = false;
+    data.startHTTPServer(new DeleteMockServer());
+    SyncStorageRecordRequest r = new SyncStorageRecordRequest(new URI(LOCAL_META_URL)); // URL re-used -- we need any successful response
+    TestSyncStorageRequestDelegate delegate = new TestSyncStorageRequestDelegate();
+    delegate._credentials = USER_PASS;
+    r.delegate = delegate;
+    r.delete();
+    // Server is stopped in the callback.
+  }
 }


### PR DESCRIPTION
Tested it in my clients engine tests and it works. But wanted to get this in sooner.
