### PR TITLE
Bug 722541 - always reseed with 8 random bytes.

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/Utils.java
+++ b/src/main/java/org/mozilla/gecko/sync/Utils.java
@@ -133,8 +133,7 @@ public class Utils {
    * Helper to reseed the shared secure random number generator.
    */
   public static void reseedSharedRandom() {
-    int seed = (int)(System.nanoTime() % java.lang.Integer.MAX_VALUE);
-    sharedSecureRandom.setSeed(sharedSecureRandom.generateSeed(seed));
+    sharedSecureRandom.setSeed(sharedSecureRandom.generateSeed(8));
   }
 
   /*


### PR DESCRIPTION
I confused the number of bytes to seed from with the seed itself.  This prevents massive memory allocation as reported by liuche.
