### PR TITLE
Bug 722561 - remove isSecure override.

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/net/TLSSocketFactory.java
+++ b/src/main/java/org/mozilla/gecko/sync/net/TLSSocketFactory.java
@@ -98,9 +98,4 @@ public class TLSSocketFactory extends SSLSocketFactory {
     setEnabledCipherSuites(socket);
     return socket;
   }
-
-  @Override
-  public boolean isSecure(Socket sock) throws IllegalArgumentException {
-    return true;
-  }
 }


### PR DESCRIPTION
The default from SSLSocketFactory should always return true.
