### PR TITLE
Bug 705767: Validate credentials before completing classic setup + fixes

### DIFF
--- a/res/layout/sync_account.xml
+++ b/res/layout/sync_account.xml
@@ -61,6 +61,7 @@
     android:orientation="horizontal" >
 
     <Button
+      android:id="@+id/accountCancelButton"
       style="@style/SyncButton"
       android:onClick="cancelClickHandler"
       android:text="@string/sync_button_cancel" />

--- a/res/layout/sync_setup.xml
+++ b/res/layout/sync_setup.xml
@@ -79,8 +79,7 @@
     style="@style/SyncBottom"
     android:orientation="horizontal" >
     <Button
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
+      style="@style/SyncButton"
       android:onClick="cancelClickHandler"
       android:text="@string/sync_button_cancel" />
   </LinearLayout>

--- a/res/layout/sync_setup_failure.xml
+++ b/res/layout/sync_setup_failure.xml
@@ -23,22 +23,17 @@
     android:orientation="horizontal" >
 
     <Button
-      android:layout_width="fill_parent"
-      android:layout_height="wrap_content"
-      android:layout_weight="1"
+      style="@style/SyncButton"
       android:onClick="tryAgainClickHandler"
       android:text="@string/sync_button_tryagain" />
 
     <Button
-      android:layout_width="fill_parent"
-      android:layout_height="wrap_content"
-      android:layout_weight="1"
+      style="@style/SyncButton"
       android:onClick="manualClickHandler"
       android:text="@string/sync_button_manual" />
+
      <Button
-      android:layout_width="fill_parent"
-      android:layout_height="wrap_content"
-      android:layout_weight="1"
+      style="@style/SyncButton"
       android:onClick="cancelClickHandler"
       android:text="@string/sync_button_cancel" />
   </LinearLayout>

--- a/res/values/sync_styles.xml
+++ b/res/values/sync_styles.xml
@@ -63,6 +63,7 @@
     <style name="SyncBottom">
     <item name="android:layout_width">fill_parent</item>
     <item name="android:layout_height">wrap_content</item>
+    <item name="android:layout_gravity">center</item>
     <item name="android:gravity">center</item>
     <item name="android:layout_alignParentBottom">true</item>
     <item name="android:background">@android:drawable/bottom_bar</item>

--- a/res/values/sync_styles.xml
+++ b/res/values/sync_styles.xml
@@ -39,6 +39,7 @@
     <item name="android:layout_width">fill_parent</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:singleLine">true</item>
+    <item name="android:inputType">textNoSuggestions</item>
   </style>
   <style name="SyncEditPin" parent="@style/SyncEditItem">
     <item name="android:layout_width">wrap_content</item>

--- a/src/main/java/org/mozilla/gecko/sync/jpake/JPakeClient.java
+++ b/src/main/java/org/mozilla/gecko/sync/jpake/JPakeClient.java
@@ -937,7 +937,7 @@ public class JPakeClient implements JPakeRequestDelegate {
 
     @Override
     public String getCredentials() {
-      // J-PAKE setup has no credentials
+      // J-PAKE setup has no credentials.
       return null;
     }
 

--- a/src/main/java/org/mozilla/gecko/sync/setup/AccountCreator.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/AccountCreator.java
@@ -34,7 +34,7 @@ public class AccountCreator {
     Logger.info(LOG_TAG, "Adding account for " + Constants.ACCOUNTTYPE_SYNC);
     boolean result = false;
     try { // Bug 709879: Handle error during creation of account.
-      accountManager.addAccountExplicitly(account, password, userbundle);
+      result = accountManager.addAccountExplicitly(account, password, userbundle);
     } catch (SQLiteDiskIOException e) {
       Logger.warn(LOG_TAG, "Could not add account: SQLite error.", e);
       return null;

--- a/src/main/java/org/mozilla/gecko/sync/setup/AccountCreator.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/AccountCreator.java
@@ -1,0 +1,65 @@
+package org.mozilla.gecko.sync.setup;
+
+import org.mozilla.gecko.sync.Logger;
+import org.mozilla.gecko.sync.Utils;
+import org.mozilla.gecko.sync.repositories.android.Authorities;
+
+import android.accounts.Account;
+import android.accounts.AccountManager;
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+
+public class AccountCreator {
+  private static final String LOG_TAG = "AccountCreator";
+
+  public static Intent createAccount(Context context,
+      AccountManager accountManager, String username, String syncKey,
+      String password, String serverURL) {
+
+    final Account account = new Account(username, Constants.ACCOUNTTYPE_SYNC);
+    final Bundle userbundle = new Bundle();
+
+    // Add sync key and server URL.
+    userbundle.putString(Constants.OPTION_SYNCKEY, syncKey);
+    if (serverURL != null) {
+      Logger.info(LOG_TAG, "Setting explicit server URL: " + serverURL);
+      userbundle.putString(Constants.OPTION_SERVER, serverURL);
+    } else {
+      userbundle.putString(Constants.OPTION_SERVER, Constants.AUTH_NODE_DEFAULT);
+    }
+    Logger.info(LOG_TAG, "Adding account for " + Constants.ACCOUNTTYPE_SYNC);
+    boolean result = accountManager.addAccountExplicitly(account, password,
+        userbundle);
+
+    Logger.info(LOG_TAG, "Account: " + account.toString() +
+                         " added successfully? " + result);
+    if (!result) {
+      Logger.error(LOG_TAG, "Error adding account!");
+    }
+
+    // Set components to sync (default: all).
+    ContentResolver.setMasterSyncAutomatically(true);
+    ContentResolver.setSyncAutomatically(account,
+        Authorities.BROWSER_AUTHORITY, true);
+
+    // TODO: add other ContentProviders as needed (e.g. passwords)
+    // TODO: for each, also add to res/xml to make visible in account settings
+    Logger.debug(LOG_TAG, "Finished setting syncables.");
+
+    // TODO: correctly implement Sync Options.
+    Logger.info(LOG_TAG, "Clearing preferences for this account.");
+    try {
+      Utils.getSharedPreferences(context, username, serverURL).edit().clear().commit();
+    } catch (Exception e) {
+      Logger.error(LOG_TAG, "Could not clear prefs path!", e);
+    }
+
+    final Intent intent = new Intent();
+    intent.putExtra(AccountManager.KEY_ACCOUNT_NAME, username);
+    intent.putExtra(AccountManager.KEY_ACCOUNT_TYPE, Constants.ACCOUNTTYPE_SYNC);
+    intent.putExtra(AccountManager.KEY_AUTHTOKEN,    Constants.ACCOUNTTYPE_SYNC);
+    return intent;
+  }
+}

--- a/src/main/java/org/mozilla/gecko/sync/setup/Constants.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/Constants.java
@@ -56,6 +56,17 @@ public class Constants {
     Intent.FLAG_ACTIVITY_REORDER_TO_FRONT |
     Intent.FLAG_ACTIVITY_NO_ANIMATION;
 
+  // Constants for Account Authentication.
+  public static final String AUTH_NODE_DEFAULT    = "https://auth.services.mozilla.com/";
+  public static final String AUTH_NODE_PATHNAME   = "user/";
+  public static final String AUTH_NODE_VERSION    = "1.0/";
+  public static final String AUTH_NODE_SUFFIX     = "node/weave";
+  public static final String AUTH_SERVER_VERSION  = "1.1/";
+  public static final String AUTH_SERVER_SUFFIX   = "info/collections/";
+
+  // Account Authentication Errors.
+  public static final String AUTH_ERROR_NOUSER    = "auth.error.badcredentials";
+
   // Links for J-PAKE setup help pages.
   public static final String LINK_FIND_CODE       = "https://support.mozilla.org/kb/find-code-to-add-device-to-firefox-sync";
   public static final String LINK_FIND_ADD_DEVICE = "https://support.mozilla.org/kb/add-a-device-to-firefox-sync";

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
@@ -41,6 +41,7 @@ package org.mozilla.gecko.sync.setup.activities;
 import org.mozilla.gecko.R;
 import org.mozilla.gecko.sync.setup.AccountCreator;
 import org.mozilla.gecko.sync.setup.Constants;
+import org.mozilla.gecko.sync.setup.auth.AccountAuthenticator;
 
 import android.accounts.AccountAuthenticatorActivity;
 import android.accounts.AccountManager;
@@ -156,11 +157,10 @@ public class AccountActivity extends AccountAuthenticatorActivity {
       }
     }
     enableCredEntry(false);
+    activateView(connectButton, false);
 
-    // TODO : Authenticate with Sync Service, once implemented, with
-    // onAuthSuccess as callback
-
-    authCallback();
+    AccountAuthenticator accountAuth = new AccountAuthenticator(this);
+    accountAuth.authenticate(server, username, password);
   }
 
   /* Helper UI functions */
@@ -206,19 +206,25 @@ public class AccountActivity extends AccountAuthenticatorActivity {
   /*
    * Callback that handles auth based on success/failure
    */
-  private void authCallback() {
-    // Create and add account to AccountManager
-    // TODO: only allow one account to be added?
+  public void authCallback(boolean isSuccess) {
+    if (!isSuccess) {
+      Log.d(LOG_TAG, "not successful");
+      runOnUiThread(new Runnable() {
+        @Override
+        public void run() {
+          authFailure();
+        }
+      });
+      return;
+    }
+
+    // Successful authentication. Create and add account to AccountManager.
+    // Note: Sync key may incorrect!
     Log.d(LOG_TAG, "Using account manager " + mAccountManager);
     final Intent intent = AccountCreator.createAccount(mContext, mAccountManager,
                                         username,
                                         key, password, server);
     setAccountAuthenticatorResult(intent.getExtras());
-
-    // TODO: Currently, we do not actually authenticate username/pass against
-    // Moz sync server.
-
-    // Successful authentication result
     setResult(RESULT_OK, intent);
 
     runOnUiThread(new Runnable() {
@@ -229,14 +235,21 @@ public class AccountActivity extends AccountAuthenticatorActivity {
     });
   }
 
-  private void authFailure() {
+  /**
+   * Feedback to user of account setup failure.
+   */
+  public void authFailure() {
     enableCredEntry(true);
     Intent intent = new Intent(mContext, SetupFailureActivity.class);
     intent.setFlags(Constants.FLAG_ACTIVITY_REORDER_TO_FRONT_NO_ANIMATION);
     startActivity(intent);
   }
 
-  private void authSuccess() {
+  /**
+   * Feedback to user of account setup success.
+   */
+  public void authSuccess() {
+    // Display feedback of successful account setup.
     Intent intent = new Intent(mContext, SetupSuccessActivity.class);
     intent.setFlags(Constants.FLAG_ACTIVITY_REORDER_TO_FRONT_NO_ANIMATION);
     startActivity(intent);

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
@@ -139,9 +139,21 @@ public class AccountActivity extends AccountAuthenticatorActivity {
     Log.d(LOG_TAG, "connectClickHandler for view " + target);
     username = usernameInput.getText().toString();
     password = passwordInput.getText().toString();
-    key = synckeyInput.getText().toString();
+    key      = synckeyInput.getText().toString();
+
     if (serverCheckbox.isChecked()) {
-      server = serverInput.getText().toString();
+      String userServer = serverInput.getText().toString();
+      if (userServer != null) {
+        userServer = userServer.trim();
+        if (userServer.length() != 0) {
+          if (!userServer.startsWith("https://") &&
+              !userServer.startsWith("http://")) {
+            // Assume HTTPS if not specified.
+            userServer = "https://" + userServer;
+          }
+          server = userServer;
+        }
+      }
     }
     enableCredEntry(false);
 

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
@@ -52,6 +52,7 @@ import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.Log;
 import android.view.View;
+import android.view.View.OnClickListener;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
@@ -75,6 +76,9 @@ public class AccountActivity extends AccountAuthenticatorActivity {
   private EditText            synckeyInput;
   private CheckBox            serverCheckbox;
   private Button              connectButton;
+  private Button              cancelButton;
+
+  private AccountAuthenticator accountAuthenticator;
 
   @Override
   public void onCreate(Bundle savedInstanceState) {
@@ -99,6 +103,7 @@ public class AccountActivity extends AccountAuthenticatorActivity {
     serverInput.addTextChangedListener(inputValidator);
 
     connectButton = (Button) findViewById(R.id.accountConnectButton);
+    cancelButton = (Button) findViewById(R.id.accountCancelButton);
     serverCheckbox = (CheckBox) findViewById(R.id.checkbox_server);
 
     serverCheckbox.setOnCheckedChangeListener(new OnCheckedChangeListener() {
@@ -119,17 +124,41 @@ public class AccountActivity extends AccountAuthenticatorActivity {
   }
 
   @Override
-  public void onStart() {
-    super.onStart();
+  public void onResume() {
+    super.onResume();
+    clearCredentials();
+    usernameInput.requestFocus();
+    enableCredEntry(true);
+    cancelButton.setOnClickListener(new OnClickListener() {
+
+      @Override
+      public void onClick(View v) {
+        cancelClickHandler(v);
+      }
+
+    });
+  }
+  public void cancelClickHandler(View target) {
+    finish();
+  }
+
+  public void cancelConnectHandler(View target) {
+    if (accountAuthenticator != null) {
+      accountAuthenticator.isCanceled = true;
+      accountAuthenticator = null;
+    }
+    enableCredEntry(true);
+    activateView(connectButton, true);
+    clearCredentials();
+    usernameInput.requestFocus();
+  }
+
+  private void clearCredentials() {
     // Start with an empty form
     usernameInput.setText("");
     passwordInput.setText("");
-    synckeyInput.setText("");
     passwordInput.setText("");
-  }
-
-  public void cancelClickHandler(View target) {
-    finish();
+    // Don't clear sync key until exiting.
   }
 
   /*
@@ -158,9 +187,16 @@ public class AccountActivity extends AccountAuthenticatorActivity {
     }
     enableCredEntry(false);
     activateView(connectButton, false);
+    cancelButton.setOnClickListener(new OnClickListener() {
 
-    AccountAuthenticator accountAuth = new AccountAuthenticator(this);
-    accountAuth.authenticate(server, username, password);
+      @Override
+      public void onClick(View v) {
+        cancelConnectHandler(v);
+      }
+    });
+
+    accountAuthenticator = new AccountAuthenticator(this);
+    accountAuthenticator.authenticate(server, username, password);
   }
 
   /* Helper UI functions */
@@ -168,6 +204,7 @@ public class AccountActivity extends AccountAuthenticatorActivity {
     usernameInput.setEnabled(toEnable);
     passwordInput.setEnabled(toEnable);
     synckeyInput.setEnabled(toEnable);
+    serverCheckbox.setEnabled(toEnable);
     if (!toEnable) {
       serverInput.setEnabled(toEnable);
     } else {
@@ -239,7 +276,6 @@ public class AccountActivity extends AccountAuthenticatorActivity {
    * Feedback to user of account setup failure.
    */
   public void authFailure() {
-    enableCredEntry(true);
     Intent intent = new Intent(mContext, SetupFailureActivity.class);
     intent.setFlags(Constants.FLAG_ACTIVITY_REORDER_TO_FRONT_NO_ANIMATION);
     startActivity(intent);

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
@@ -39,6 +39,7 @@
 package org.mozilla.gecko.sync.setup.activities;
 
 import org.mozilla.gecko.R;
+import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.setup.AccountCreator;
 import org.mozilla.gecko.sync.setup.Constants;
 import org.mozilla.gecko.sync.setup.auth.AccountAuthenticator;
@@ -50,7 +51,6 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
-import android.util.Log;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.Button;
@@ -86,7 +86,7 @@ public class AccountActivity extends AccountAuthenticatorActivity {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.sync_account);
     mContext = getApplicationContext();
-    Log.d(LOG_TAG, "AccountManager.get(" + mContext + ")");
+    Logger.debug(LOG_TAG, "AccountManager.get(" + mContext + ")");
     mAccountManager = AccountManager.get(mContext);
 
     // Find UI elements.
@@ -109,7 +109,7 @@ public class AccountActivity extends AccountAuthenticatorActivity {
     serverCheckbox.setOnCheckedChangeListener(new OnCheckedChangeListener() {
       @Override
       public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-        Log.i(LOG_TAG, "Toggling checkbox: " + isChecked);
+        Logger.info(LOG_TAG, "Toggling checkbox: " + isChecked);
         // Hack for pre-3.0 Android: can enter text into disabled EditText.
         if (!isChecked) { // Clear server input.
           serverInput.setVisibility(View.GONE);
@@ -166,7 +166,7 @@ public class AccountActivity extends AccountAuthenticatorActivity {
    * accessed by Fennec and Sync Service.
    */
   public void connectClickHandler(View target) {
-    Log.d(LOG_TAG, "connectClickHandler for view " + target);
+    Logger.debug(LOG_TAG, "connectClickHandler for view " + target);
     username = usernameInput.getText().toString();
     password = passwordInput.getText().toString();
     key      = synckeyInput.getText().toString();
@@ -188,7 +188,6 @@ public class AccountActivity extends AccountAuthenticatorActivity {
     enableCredEntry(false);
     activateView(connectButton, false);
     cancelButton.setOnClickListener(new OnClickListener() {
-
       @Override
       public void onClick(View v) {
         cancelConnectHandler(v);
@@ -232,9 +231,11 @@ public class AccountActivity extends AccountAuthenticatorActivity {
   }
 
   private boolean validateInputs() {
-    if (usernameInput.length() == 0 || passwordInput.length() == 0
-        || synckeyInput.length() == 0
-        || (serverCheckbox.isChecked() && serverInput.length() == 0)) {
+    if (usernameInput.length() == 0 ||
+        passwordInput.length() == 0 ||
+        synckeyInput.length()  == 0 ||
+        (serverCheckbox.isChecked() &&
+         serverInput.length() == 0)) {
       return false;
     }
     return true;
@@ -244,30 +245,35 @@ public class AccountActivity extends AccountAuthenticatorActivity {
    * Callback that handles auth based on success/failure
    */
   public void authCallback(boolean isSuccess) {
-    if (!isSuccess) {
-      Log.d(LOG_TAG, "not successful");
-      runOnUiThread(new Runnable() {
-        @Override
-        public void run() {
-          authFailure();
-        }
-      });
-      return;
+    if (isSuccess) {
+      // Successful authentication. Create and add account to AccountManager.
+      // Note: Sync key may be incorrect!
+      Logger.debug(LOG_TAG, "Using account manager " + mAccountManager);
+      final Intent intent = AccountCreator.createAccount(mContext, mAccountManager,
+                                                         username, key, password, server);
+      if (intent != null) {
+        setAccountAuthenticatorResult(intent.getExtras());
+        setResult(RESULT_OK, intent);
+
+        runOnUiThread(new Runnable() {
+          @Override
+          public void run() {
+            authSuccess();
+          }
+        });
+        return;
+      }
+      // TODO: Display error to user, probably will require new strings.
+      // For now, fall through and display default failure screen.
+    } else {
+      Logger.debug(LOG_TAG, "Authentication failure.");
     }
 
-    // Successful authentication. Create and add account to AccountManager.
-    // Note: Sync key may incorrect!
-    Log.d(LOG_TAG, "Using account manager " + mAccountManager);
-    final Intent intent = AccountCreator.createAccount(mContext, mAccountManager,
-                                        username,
-                                        key, password, server);
-    setAccountAuthenticatorResult(intent.getExtras());
-    setResult(RESULT_OK, intent);
-
+    // Display default failure screen to user.
     runOnUiThread(new Runnable() {
       @Override
       public void run() {
-        authSuccess();
+        authFailure();
       }
     });
   }

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
@@ -191,6 +191,12 @@ public class AccountActivity extends AccountAuthenticatorActivity {
       @Override
       public void onClick(View v) {
         cancelConnectHandler(v);
+        // Set cancel click handler to leave account setup.
+        cancelButton.setOnClickListener(new OnClickListener() {
+          public void onClick(View v) {
+            cancelClickHandler(v);
+          }
+        });
       }
     });
 

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupFailureActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupFailureActivity.java
@@ -69,6 +69,7 @@ public class SetupFailureActivity extends Activity {
 
   public void cancelClickHandler(View target) {
     setResult(RESULT_CANCELED);
+    moveTaskToBack(true);
     finish();
   }
 }

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSyncActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSyncActivity.java
@@ -42,6 +42,7 @@ import org.json.simple.JSONObject;
 import org.mozilla.gecko.R;
 import org.mozilla.gecko.sync.jpake.JPakeClient;
 import org.mozilla.gecko.sync.jpake.JPakeNoActivePairingException;
+import org.mozilla.gecko.sync.setup.AccountCreator;
 import org.mozilla.gecko.sync.setup.Constants;
 
 import android.accounts.Account;
@@ -339,9 +340,9 @@ public class SetupSyncActivity extends AccountAuthenticatorActivity {
       String serverURL    = (String) jCreds.get(Constants.JSON_KEY_SERVER);
 
       Log.d(LOG_TAG, "Using account manager " + mAccountManager);
-      final Intent intent = AccountActivity.createAccount(mContext, mAccountManager,
-                                                          accountName,
-                                                          syncKey, password, serverURL);
+      final Intent intent = AccountCreator.createAccount(mContext, mAccountManager,
+                                                         accountName,
+                                                         syncKey, password, serverURL);
       setAccountAuthenticatorResult(intent.getExtras());
 
       setResult(RESULT_OK, intent);

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/AccountAuthenticator.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/AccountAuthenticator.java
@@ -5,11 +5,10 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.ThreadPool;
 import org.mozilla.gecko.sync.Utils;
 import org.mozilla.gecko.sync.setup.activities.AccountActivity;
-
-import android.util.Log;
 
 public class AccountAuthenticator {
   private final String LOG_TAG = "AccountSetupAuthenticator";
@@ -57,7 +56,7 @@ public class AccountAuthenticator {
     } catch (UnsupportedEncodingException e) {
       abort("Username hash error.", e);
     }
-    Log.d(LOG_TAG, "usernameHash:" + usernameHash);
+    Logger.debug(LOG_TAG, "usernameHash:" + usernameHash);
 
     // Start first stage of authentication.
     runNextStage();
@@ -77,7 +76,7 @@ public class AccountAuthenticator {
     try {
       stages.get(stageIndex).execute(this);
     } catch (Exception e) {
-      Log.w(LOG_TAG, "Exception in stage " + stages.get(stageIndex));
+      Logger.warn(LOG_TAG, "Exception in stage " + stages.get(stageIndex));
       abort("Stage exception.", e);
     }
   }
@@ -94,7 +93,7 @@ public class AccountAuthenticator {
     if (isCanceled) {
       return;
     }
-    Log.w(LOG_TAG, reason, e);
+    Logger.warn(LOG_TAG, reason, e);
     activityCallback.authCallback(false);
   }
 

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/AccountAuthenticator.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/AccountAuthenticator.java
@@ -26,6 +26,7 @@ public class AccountAuthenticator {
   public String nodeServer;
 
   public boolean isSuccess = false;
+  public boolean isCanceled = false;
 
   public AccountAuthenticator(AccountActivity activity) {
     activityCallback = activity;
@@ -64,6 +65,9 @@ public class AccountAuthenticator {
    * Run next stage of authentication.
    */
   public void runNextStage() {
+    if (isCanceled) {
+      return;
+    }
     if (++stageIndex == stages.size()) {
       activityCallback.authCallback(isSuccess);
       return;
@@ -85,6 +89,9 @@ public class AccountAuthenticator {
    *    Reason for abort.
    */
   public void abort(String reason, Exception e) {
+    if (isCanceled) {
+      return;
+    }
     Log.w(LOG_TAG, reason, e);
     activityCallback.authCallback(false);
   }

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/AccountAuthenticator.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/AccountAuthenticator.java
@@ -1,0 +1,92 @@
+package org.mozilla.gecko.sync.setup.auth;
+
+import java.io.UnsupportedEncodingException;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.mozilla.gecko.sync.Utils;
+import org.mozilla.gecko.sync.setup.activities.AccountActivity;
+
+import android.util.Log;
+
+public class AccountAuthenticator {
+  private final String LOG_TAG = "AccountSetupAuthenticator";
+
+  private AccountActivity activityCallback;
+  private List<AuthenticatorStage> stages;
+
+  private int stageIndex = -1; // Stages not started.
+
+  // Values for authentication.
+  public String password;
+  public String usernameHash;
+
+  public String authServer;
+  public String nodeServer;
+
+  public boolean isSuccess = false;
+
+  public AccountAuthenticator(AccountActivity activity) {
+    activityCallback = activity;
+    prepareStages();
+  }
+
+  private void prepareStages() {
+    stages = new ArrayList<AuthenticatorStage>();
+    stages.add(new FetchUserNodeStage());
+    stages.add(new AuthenticateAccountStage());
+  }
+
+  public void authenticate(String server, String username, String password) {
+    // Set authentication values.
+    if (!server.endsWith("/")) {
+      server += "/";
+    }
+    nodeServer = server;
+    this.password = password;
+
+    // Calculate and save username hash.
+    try {
+      usernameHash = Utils.sha1Base32(username.toLowerCase()).toLowerCase();
+    } catch (NoSuchAlgorithmException e) {
+      abort("Username hash error.", e);
+    } catch (UnsupportedEncodingException e) {
+      abort("Username hash error.", e);
+    }
+    Log.d(LOG_TAG, "usernameHash:" + usernameHash);
+
+    // Start first stage of authentication.
+    runNextStage();
+  }
+
+  /**
+   * Run next stage of authentication.
+   */
+  public void runNextStage() {
+    if (++stageIndex == stages.size()) {
+      activityCallback.authCallback(isSuccess);
+      return;
+    }
+    try {
+      stages.get(stageIndex).execute(this);
+    } catch (Exception e) {
+      Log.w(LOG_TAG, "Exception in stage " + stages.get(stageIndex));
+      abort("Stage exception.", e);
+    }
+  }
+
+  /**
+   * Abort authentication.
+   *
+   * @param e
+   *    Exception causing abort.
+   * @param reason
+   *    Reason for abort.
+   */
+  public void abort(String reason, Exception e) {
+    Log.w(LOG_TAG, reason, e);
+    activityCallback.authCallback(false);
+  }
+
+}

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/AccountAuthenticator.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/AccountAuthenticator.java
@@ -5,6 +5,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.mozilla.gecko.sync.ThreadPool;
 import org.mozilla.gecko.sync.Utils;
 import org.mozilla.gecko.sync.setup.activities.AccountActivity;
 
@@ -35,6 +36,7 @@ public class AccountAuthenticator {
 
   private void prepareStages() {
     stages = new ArrayList<AuthenticatorStage>();
+    stages.add(new EnsureUserExistenceStage());
     stages.add(new FetchUserNodeStage());
     stages.add(new AuthenticateAccountStage());
   }
@@ -96,4 +98,8 @@ public class AccountAuthenticator {
     activityCallback.authCallback(false);
   }
 
+  /* Helper functions */
+  public static void runOnThread(Runnable run) {
+    ThreadPool.run(run);
+  }
 }

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/AuthenticateAccountStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/AuthenticateAccountStage.java
@@ -1,0 +1,140 @@
+package org.mozilla.gecko.sync.setup.auth;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.GeneralSecurityException;
+
+import org.mozilla.gecko.sync.ThreadPool;
+import org.mozilla.gecko.sync.net.BaseResource;
+import org.mozilla.gecko.sync.net.SyncResourceDelegate;
+import org.mozilla.gecko.sync.net.SyncStorageRequest;
+import org.mozilla.gecko.sync.setup.Constants;
+
+import android.util.Base64;
+import android.util.Log;
+import ch.boye.httpclientandroidlib.HeaderIterator;
+import ch.boye.httpclientandroidlib.HttpResponse;
+import ch.boye.httpclientandroidlib.client.ClientProtocolException;
+import ch.boye.httpclientandroidlib.client.methods.HttpRequestBase;
+import ch.boye.httpclientandroidlib.conn.params.ConnConnectionPNames;
+import ch.boye.httpclientandroidlib.impl.client.DefaultHttpClient;
+import ch.boye.httpclientandroidlib.message.BasicHeader;
+
+public class AuthenticateAccountStage implements AuthenticatorStage {
+  private final String LOG_TAG = "AuthenticateAccountStage";
+
+  public interface AuthenticateAccountStageDelegate {
+    public void handleSuccess(boolean isSuccess);
+    public void handleFailure(HttpResponse response);
+    public void handleError(Exception e);
+  }
+
+  @Override
+  public void execute(final AccountAuthenticator aa) throws URISyntaxException, UnsupportedEncodingException {
+    AuthenticateAccountStageDelegate callbackDelegate = new AuthenticateAccountStageDelegate() {
+
+      @Override
+      public void handleSuccess(boolean isSuccess) {
+        aa.isSuccess = isSuccess;
+        aa.runNextStage();
+      }
+
+      @Override
+      public void handleFailure(HttpResponse response) {
+        Log.d(LOG_TAG, "handleFailure");
+        aa.abort(response.toString(), new Exception(response.getStatusLine().getStatusCode() + " error."));
+        try {
+          BufferedReader reader = new BufferedReader(new InputStreamReader(response.getEntity().getContent(), "UTF-8"));
+          Log.w(LOG_TAG, "content: " + reader.readLine());
+          SyncResourceDelegate.consumeReader(reader);
+          reader.close();
+          SyncResourceDelegate.consumeEntity(response.getEntity());
+        } catch (IllegalStateException e) {
+          Log.d(LOG_TAG, "Error reading content.", e);
+        } catch (IOException e) {
+          Log.d(LOG_TAG, "Error reading content.", e);
+        }
+      }
+
+      @Override
+      public void handleError(Exception e) {
+        Log.d(LOG_TAG, "handleError");
+        aa.abort("HTTP failure.", e);
+      }
+    };
+
+    // Calculate BasicAuth hash of username/password.
+    String authHash = Base64.encodeToString((aa.usernameHash + ":" + aa.password).getBytes(), Base64.DEFAULT);
+    String authRequestUrl = aa.authServer + Constants.AUTH_SERVER_VERSION + aa.usernameHash + "/" + Constants.AUTH_SERVER_SUFFIX;
+    authenticateAccount(callbackDelegate, authRequestUrl, authHash);
+  }
+
+  private void authenticateAccount(final AuthenticateAccountStageDelegate callbackDelegate, final String authRequestUrl, final String authHeader) throws URISyntaxException {
+    final BaseResource httpResource = new BaseResource(authRequestUrl);
+    httpResource.delegate = new SyncResourceDelegate(httpResource) {
+
+      @Override
+      public void addHeaders(HttpRequestBase request, DefaultHttpClient client) {
+
+        client.log.enableDebug(true);
+        request.setHeader(new BasicHeader("User-Agent", SyncStorageRequest.USER_AGENT));
+        // Host header is not set for some reason, so do it explicitly.
+        try {
+          URI authServerUri = new URI(authRequestUrl);
+          request.setHeader(new BasicHeader("Host", authServerUri.getHost()));
+        } catch (URISyntaxException e) {
+          Log.e(LOG_TAG, "Malformed uri, will be caught elsewhere.", e);
+        }
+        request.setHeader(new BasicHeader("Authorization", "Basic " + authHeader));
+      }
+
+      @Override
+      public void handleHttpResponse(HttpResponse response) {
+        int statusCode = response.getStatusLine().getStatusCode();
+        switch(statusCode) {
+        case 200:
+          callbackDelegate.handleSuccess(true);
+          SyncResourceDelegate.consumeEntity(response.getEntity());
+          break;
+        case 401:
+          callbackDelegate.handleSuccess(false);
+          SyncResourceDelegate.consumeEntity(response.getEntity());
+          break;
+        default:
+          callbackDelegate.handleFailure(response);
+        }
+      }
+
+      @Override
+      public void handleHttpProtocolException(ClientProtocolException e) {
+        Log.e(LOG_TAG, "Client protocol error.");
+        callbackDelegate.handleError(e);
+      }
+
+      @Override
+      public void handleHttpIOException(IOException e) {
+        callbackDelegate.handleError(e);
+      }
+
+      @Override
+      public void handleTransportException(GeneralSecurityException e) {
+        callbackDelegate.handleError(e);
+      }
+    };
+
+    runOnThread(new Runnable() {
+      @Override
+      public void run() {
+        httpResource.get();
+      }
+    });
+  }
+
+  private static void runOnThread(Runnable run) {
+    ThreadPool.run(run);
+  }
+}

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/AuthenticateAccountStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/AuthenticateAccountStage.java
@@ -8,6 +8,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 
+import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.ThreadPool;
 import org.mozilla.gecko.sync.net.BaseResource;
 import org.mozilla.gecko.sync.net.SyncResourceDelegate;
@@ -15,12 +16,9 @@ import org.mozilla.gecko.sync.net.SyncStorageRequest;
 import org.mozilla.gecko.sync.setup.Constants;
 
 import android.util.Base64;
-import android.util.Log;
-import ch.boye.httpclientandroidlib.HeaderIterator;
 import ch.boye.httpclientandroidlib.HttpResponse;
 import ch.boye.httpclientandroidlib.client.ClientProtocolException;
 import ch.boye.httpclientandroidlib.client.methods.HttpRequestBase;
-import ch.boye.httpclientandroidlib.conn.params.ConnConnectionPNames;
 import ch.boye.httpclientandroidlib.impl.client.DefaultHttpClient;
 import ch.boye.httpclientandroidlib.message.BasicHeader;
 
@@ -45,24 +43,24 @@ public class AuthenticateAccountStage implements AuthenticatorStage {
 
       @Override
       public void handleFailure(HttpResponse response) {
-        Log.d(LOG_TAG, "handleFailure");
+        Logger.debug(LOG_TAG, "handleFailure");
         aa.abort(response.toString(), new Exception(response.getStatusLine().getStatusCode() + " error."));
         try {
           BufferedReader reader = new BufferedReader(new InputStreamReader(response.getEntity().getContent(), "UTF-8"));
-          Log.w(LOG_TAG, "content: " + reader.readLine());
+          Logger.warn(LOG_TAG, "content: " + reader.readLine());
           SyncResourceDelegate.consumeReader(reader);
           reader.close();
           SyncResourceDelegate.consumeEntity(response.getEntity());
         } catch (IllegalStateException e) {
-          Log.d(LOG_TAG, "Error reading content.", e);
+          Logger.debug(LOG_TAG, "Error reading content.", e);
         } catch (IOException e) {
-          Log.d(LOG_TAG, "Error reading content.", e);
+          Logger.debug(LOG_TAG, "Error reading content.", e);
         }
       }
 
       @Override
       public void handleError(Exception e) {
-        Log.d(LOG_TAG, "handleError");
+        Logger.debug(LOG_TAG, "handleError");
         aa.abort("HTTP failure.", e);
       }
     };
@@ -87,7 +85,7 @@ public class AuthenticateAccountStage implements AuthenticatorStage {
           URI authServerUri = new URI(authRequestUrl);
           request.setHeader(new BasicHeader("Host", authServerUri.getHost()));
         } catch (URISyntaxException e) {
-          Log.e(LOG_TAG, "Malformed uri, will be caught elsewhere.", e);
+          Logger.error(LOG_TAG, "Malformed uri, will be caught elsewhere.", e);
         }
         request.setHeader(new BasicHeader("Authorization", "Basic " + authHeader));
       }
@@ -111,7 +109,7 @@ public class AuthenticateAccountStage implements AuthenticatorStage {
 
       @Override
       public void handleHttpProtocolException(ClientProtocolException e) {
-        Log.e(LOG_TAG, "Client protocol error.");
+        Logger.error(LOG_TAG, "Client protocol error.");
         callbackDelegate.handleError(e);
       }
 

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/AuthenticatorStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/AuthenticatorStage.java
@@ -1,0 +1,8 @@
+package org.mozilla.gecko.sync.setup.auth;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URISyntaxException;
+
+public interface AuthenticatorStage {
+  public void execute(AccountAuthenticator aa) throws URISyntaxException, UnsupportedEncodingException;
+}

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/EnsureUserExistenceStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/EnsureUserExistenceStage.java
@@ -8,11 +8,11 @@ import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 
+import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.net.BaseResource;
 import org.mozilla.gecko.sync.net.SyncResourceDelegate;
 import org.mozilla.gecko.sync.setup.Constants;
 
-import android.util.Log;
 import ch.boye.httpclientandroidlib.HttpResponse;
 import ch.boye.httpclientandroidlib.client.ClientProtocolException;
 
@@ -60,7 +60,7 @@ public class EnsureUserExistenceStage implements AuthenticatorStage {
             InputStream content = response.getEntity().getContent();
             BufferedReader reader = new BufferedReader(new InputStreamReader(content, "UTF-8"), 1024);
             String inUse = reader.readLine();
-            Log.d(LOG_TAG, "username inUse:" + inUse);
+            Logger.debug(LOG_TAG, "username inUse:" + inUse);
             if (inUse.equals("1")) { // Username exists.
               callbackDelegate.handleSuccess();
             } else { // User does not exist.

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/FetchUserNodeStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/FetchUserNodeStage.java
@@ -7,11 +7,11 @@ import java.io.InputStreamReader;
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 
+import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.net.BaseResource;
 import org.mozilla.gecko.sync.net.SyncResourceDelegate;
 import org.mozilla.gecko.sync.setup.Constants;
 
-import android.util.Log;
 import ch.boye.httpclientandroidlib.HttpResponse;
 import ch.boye.httpclientandroidlib.client.ClientProtocolException;
 
@@ -32,7 +32,7 @@ public class FetchUserNodeStage implements AuthenticatorStage {
       @Override
       public void handleSuccess(String server) {
         if (server == null) { // No separate auth node; use server url.
-          Log.d(LOG_TAG, "Using server as auth node.");
+          Logger.debug(LOG_TAG, "Using server as auth node.");
           aa.authServer = aa.nodeServer;
           aa.runNextStage();
           return;
@@ -47,7 +47,7 @@ public class FetchUserNodeStage implements AuthenticatorStage {
       @Override
       public void handleFailure(HttpResponse response) {
         int statusCode = response.getStatusLine().getStatusCode();
-        Log.d(LOG_TAG, "Failed to authenticate with status " + statusCode);
+        Logger.debug(LOG_TAG, "Failed to authenticate with status " + statusCode);
         aa.abort(response.toString(), new Exception("HTTP " + statusCode + " error."));
       }
 
@@ -57,7 +57,7 @@ public class FetchUserNodeStage implements AuthenticatorStage {
       }
     };
     String nodeRequestUrl = aa.nodeServer + Constants.AUTH_NODE_PATHNAME + Constants.AUTH_NODE_VERSION + aa.usernameHash + "/" + Constants.AUTH_NODE_SUFFIX;
-    Log.d(LOG_TAG, "nodeUrl: " + nodeRequestUrl);
+    Logger.debug(LOG_TAG, "nodeUrl: " + nodeRequestUrl);
     makeFetchNodeRequest(callbackDelegate, nodeRequestUrl);
   }
 

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/FetchUserNodeStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/FetchUserNodeStage.java
@@ -1,0 +1,119 @@
+package org.mozilla.gecko.sync.setup.auth;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URISyntaxException;
+import java.security.GeneralSecurityException;
+
+import org.mozilla.gecko.sync.ThreadPool;
+import org.mozilla.gecko.sync.net.BaseResource;
+import org.mozilla.gecko.sync.net.SyncResourceDelegate;
+import org.mozilla.gecko.sync.setup.Constants;
+
+import android.util.Log;
+import ch.boye.httpclientandroidlib.HttpResponse;
+import ch.boye.httpclientandroidlib.client.ClientProtocolException;
+
+public class FetchUserNodeStage implements AuthenticatorStage {
+  private final String LOG_TAG = "FetchUserNodeStage";
+
+  public interface FetchNodeStageDelegate {
+    public void handleSuccess(String url);
+    public void handleFailure(HttpResponse response);
+    public void handleError(Exception e);
+  }
+
+  @Override
+  public void execute(final AccountAuthenticator aa) throws URISyntaxException {
+
+    FetchNodeStageDelegate callbackDelegate = new FetchNodeStageDelegate() {
+
+      @Override
+      public void handleSuccess(String server) {
+        if (!server.endsWith("/")) {
+          server += "/";
+        }
+        aa.authServer = server;
+        aa.runNextStage();
+      }
+
+      @Override
+      public void handleFailure(HttpResponse response) {
+        if (response.getStatusLine().getStatusCode() == 404) {
+          aa.abort(response.toString(), new Exception(LOG_TAG + " 404 no such user."));
+        } else {
+          aa.abort(response.toString(), new Exception(response.getStatusLine().getStatusCode() + " error."));
+        }
+      }
+
+      @Override
+      public void handleError(Exception e) {
+        aa.abort("HTTP failure.", e);
+      }
+    };
+    String nodeRequestUrl = aa.nodeServer + Constants.AUTH_NODE_PATHNAME + Constants.AUTH_NODE_VERSION + aa.usernameHash + "/" + Constants.AUTH_NODE_SUFFIX;
+    Log.d(LOG_TAG, "nodeUrl: " + nodeRequestUrl);
+    makeFetchNodeRequest(callbackDelegate, nodeRequestUrl);
+  }
+
+  private void makeFetchNodeRequest(final FetchNodeStageDelegate callbackDelegate, String fetchNodeUrl) throws URISyntaxException {
+    // Fetch node containing user.
+    final BaseResource httpResource = new BaseResource(fetchNodeUrl);
+    httpResource.delegate = new SyncResourceDelegate(httpResource) {
+
+      @Override
+      public void handleHttpResponse(HttpResponse response) {
+        int statusCode = response.getStatusLine().getStatusCode();
+        switch(statusCode) {
+        case 200:
+          try {
+            InputStream content = response.getEntity().getContent();
+            BufferedReader reader = new BufferedReader(new InputStreamReader(content, "UTF-8"), 1024);
+            String server = reader.readLine();
+            callbackDelegate.handleSuccess(server);
+            SyncResourceDelegate.consumeReader(reader);
+            reader.close();
+          } catch (IllegalStateException e) {
+            callbackDelegate.handleError(e);
+          } catch (IOException e) {
+            callbackDelegate.handleError(e);
+          }
+          break;
+        default:
+          // No other acceptable states.
+          callbackDelegate.handleFailure(response);
+        }
+        SyncResourceDelegate.consumeEntity(response.getEntity());
+      }
+
+      @Override
+      public void handleHttpProtocolException(ClientProtocolException e) {
+        callbackDelegate.handleError(e);
+      }
+
+      @Override
+      public void handleHttpIOException(IOException e) {
+        callbackDelegate.handleError(e);
+      }
+
+      @Override
+      public void handleTransportException(GeneralSecurityException e) {
+        callbackDelegate.handleError(e);
+      }
+
+    };
+    runOnThread(new Runnable() {
+
+      @Override
+      public void run() {
+        httpResource.get();
+      }
+    });
+  }
+
+  private static void runOnThread(Runnable run) {
+    ThreadPool.run(run);
+  }
+}

--- a/src/main/java/org/mozilla/gecko/sync/stage/EnsureClusterURLStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/EnsureClusterURLStage.java
@@ -109,12 +109,13 @@ public class EnsureClusterURLStage implements GlobalSyncStage {
         case 404:
           Log.i(LOG_TAG, "Got " + status + " for cluster URL request.");
           delegate.handleFailure(response);
+          SyncResourceDelegate.consumeEntity(response.getEntity());
           break;
         default:
           Log.w(LOG_TAG, "Got " + status + " fetching node/weave. Returning failure.");
           delegate.handleFailure(response);
+          SyncResourceDelegate.consumeEntity(response.getEntity());
         }
-        SyncResourceDelegate.consumeEntity(response.getEntity());
       }
 
       @Override

--- a/src/main/java/org/mozilla/gecko/sync/stage/EnsureClusterURLStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/EnsureClusterURLStage.java
@@ -109,13 +109,12 @@ public class EnsureClusterURLStage implements GlobalSyncStage {
         case 404:
           Log.i(LOG_TAG, "Got " + status + " for cluster URL request.");
           delegate.handleFailure(response);
-          SyncResourceDelegate.consumeEntity(response.getEntity());
           break;
         default:
           Log.w(LOG_TAG, "Got " + status + " fetching node/weave. Returning failure.");
           delegate.handleFailure(response);
-          SyncResourceDelegate.consumeEntity(response.getEntity());
         }
+        SyncResourceDelegate.consumeEntity(response.getEntity());
       }
 
       @Override


### PR DESCRIPTION
Added check for user existence with 1.0/user; use server URL if info/collections then returns 404.

HTTP request to server is set to be "kept alive indefinitely" and isn't consumed on consumeEntity - leads to next HTTP request connection getting shut down. Not sure what to do about that.
