### PR TITLE
Bug 726054 - Desktop parity: track last sync time from final upload, not final fetch

### DIFF
--- a/src/main/java/org/mozilla/android/sync/test/helpers/WBORepository.java
+++ b/src/main/java/org/mozilla/android/sync/test/helpers/WBORepository.java
@@ -134,10 +134,10 @@ public class WBORepository extends Repository {
     }
 
     @Override
-    public void storeDone() {
+    public void storeDone(long end) {
       // TODO: this is not guaranteed to be called after all of the record
       // store callbacks have completed!
-      delegate.deferredStoreDelegate(delegateExecutor).onStoreCompleted();
+      delegate.deferredStoreDelegate(delegateExecutor).onStoreCompleted(end);
     }
   }
 

--- a/src/main/java/org/mozilla/android/sync/test/helpers/WBORepository.java
+++ b/src/main/java/org/mozilla/android/sync/test/helpers/WBORepository.java
@@ -19,11 +19,23 @@ import org.mozilla.gecko.sync.repositories.delegates.RepositorySessionWipeDelega
 import org.mozilla.gecko.sync.repositories.domain.Record;
 
 import android.content.Context;
-import android.util.Log;
 
 public class WBORepository extends Repository {
 
+  public class WBORepositoryStats {
+    public long created         = -1;
+    public long begun           = -1;
+    public long fetchBegan      = -1;
+    public long fetchCompleted  = -1;
+    public long storeBegan      = -1;
+    public long storeCompleted  = -1;
+    public long finished        = -1;
+  }
+
   public static final String LOG_TAG = "WBORepository";
+
+  // Access to stats is not guarded.
+  public WBORepositoryStats stats;
 
   public class WBORepositorySession extends StoreTrackingRepositorySession {
 
@@ -34,7 +46,9 @@ public class WBORepository extends Repository {
     public WBORepositorySession(WBORepository repository) {
       super(repository);
       wboRepository = repository;
-      wbos = new ConcurrentHashMap<String, Record>();
+      wbos          = new ConcurrentHashMap<String, Record>();
+      stats         = new WBORepositoryStats();
+      stats.created = now();
     }
 
     @Override
@@ -53,7 +67,8 @@ public class WBORepository extends Repository {
     @Override
     public void fetchSince(long timestamp,
                            RepositorySessionFetchRecordsDelegate delegate) {
-      long fetchBegin = System.currentTimeMillis();
+      long fetchBegan  = now();
+      stats.fetchBegan = fetchBegan;
       RecordFilter filter = storeTracker.getFilter();
 
       for (Entry<String, Record> entry : wbos.entrySet()) {
@@ -67,35 +82,46 @@ public class WBORepository extends Repository {
           delegate.deferredFetchDelegate(delegateExecutor).onFetchedRecord(record);
         }
       }
-      delegate.deferredFetchDelegate(delegateExecutor).onFetchCompleted(fetchBegin);
+      long fetchCompleted  = now();
+      stats.fetchCompleted = fetchCompleted;
+      delegate.deferredFetchDelegate(delegateExecutor).onFetchCompleted(fetchCompleted);
     }
 
     @Override
     public void fetch(final String[] guids,
                       final RepositorySessionFetchRecordsDelegate delegate) {
-      long fetchBegin = System.currentTimeMillis();
+      long fetchBegan  = now();
+      stats.fetchBegan = fetchBegan;
       for (String guid : guids) {
         if (wbos.containsKey(guid)) {
           delegate.deferredFetchDelegate(delegateExecutor).onFetchedRecord(wbos.get(guid));
         }
       }
-      delegate.deferredFetchDelegate(delegateExecutor).onFetchCompleted(fetchBegin);
+      long fetchCompleted  = now();
+      stats.fetchCompleted = fetchCompleted;
+      delegate.deferredFetchDelegate(delegateExecutor).onFetchCompleted(fetchCompleted);
     }
 
     @Override
     public void fetchAll(final RepositorySessionFetchRecordsDelegate delegate) {
-      long fetchBegin = System.currentTimeMillis();
+      long fetchBegan  = now();
+      stats.fetchBegan = fetchBegan;
       for (Entry<String, Record> entry : wbos.entrySet()) {
         Record record = entry.getValue();
         delegate.deferredFetchDelegate(delegateExecutor).onFetchedRecord(record);
       }
-      delegate.deferredFetchDelegate(delegateExecutor).onFetchCompleted(fetchBegin);
+      long fetchCompleted  = now();
+      stats.fetchCompleted = fetchCompleted;
+      delegate.deferredFetchDelegate(delegateExecutor).onFetchCompleted(fetchCompleted);
     }
 
     @Override
     public void store(final Record record) throws NoStoreDelegateException {
       if (delegate == null) {
         throw new NoStoreDelegateException();
+      }
+      if (stats.storeBegan < 0) {
+        stats.storeBegan = now();
       }
       Record existing = wbos.get(record.guid);
       Logger.debug(LOG_TAG, "Existing record is " + (existing == null ? "<null>" : (existing.guid + ", " + existing)));
@@ -124,12 +150,14 @@ public class WBORepository extends Repository {
     @Override
     public void finish(RepositorySessionFinishDelegate delegate) {
       ((WBORepository) repository).wbos = this.wbos;
+      stats.finished = now();
       delegate.deferredFinishDelegate(delegateExecutor).onFinishSucceeded(this, this.getBundle());
     }
 
     @Override
     public void begin(RepositorySessionBeginDelegate delegate) {
       this.wbos = ((WBORepository) repository).cloneWBOs();
+      stats.begun = now();
       super.begin(delegate);
     }
 
@@ -137,6 +165,10 @@ public class WBORepository extends Repository {
     public void storeDone(long end) {
       // TODO: this is not guaranteed to be called after all of the record
       // store callbacks have completed!
+      if (stats.storeBegan < 0) {
+        stats.storeBegan = end;
+      }
+      stats.storeCompleted = end;
       delegate.deferredStoreDelegate(delegateExecutor).onStoreCompleted(end);
     }
   }

--- a/src/main/java/org/mozilla/gecko/sync/middleware/Crypto5MiddlewareRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/middleware/Crypto5MiddlewareRepositorySession.java
@@ -237,4 +237,9 @@ public class Crypto5MiddlewareRepositorySession extends RepositorySession {
   public void storeDone() {
     inner.storeDone();
   }
+
+  @Override
+  public void storeDone(long end) {
+    inner.storeDone(end);
+  }
 }

--- a/src/main/java/org/mozilla/gecko/sync/repositories/RepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/RepositorySession.java
@@ -147,11 +147,18 @@ public abstract class RepositorySession {
   public abstract void store(Record record) throws NoStoreDelegateException;
 
   public void storeDone() {
+    // Our default behavior will be to assume that the Runnable is
+    // executed as soon as all the stores synchronously finish, so
+    // our end timestamp can just be… now.
+    storeDone(now());
+  }
+
+  public void storeDone(final long end) {
     Log.d(LOG_TAG, "Scheduling onStoreCompleted for after storing is done.");
     Runnable command = new Runnable() {
       @Override
       public void run() {
-        delegate.onStoreCompleted();
+        delegate.onStoreCompleted(end);
       }
     };
     storeWorkQueue.execute(command);

--- a/src/main/java/org/mozilla/gecko/sync/repositories/RepositorySessionBundle.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/RepositorySessionBundle.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 
 import org.json.simple.parser.ParseException;
 import org.mozilla.gecko.sync.ExtendedJSONObject;
+import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.NonObjectJSONException;
 
 import android.util.Log;
@@ -75,8 +76,11 @@ public class RepositorySessionBundle extends ExtendedJSONObject {
   }
 
   public void bumpTimestamp(long timestamp) {
-    if (timestamp > this.getTimestamp()) {
+    long existing = this.getTimestamp();
+    if (timestamp > existing) {
       this.setTimestamp(timestamp);
+    } else {
+      Logger.debug(LOG_TAG, "Timestamp " + timestamp + " not greater than " + existing + "; not bumping.");
     }
   }
 }

--- a/src/main/java/org/mozilla/gecko/sync/repositories/Server11RepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/Server11RepositorySession.java
@@ -44,6 +44,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.json.simple.JSONArray;
 import org.mozilla.gecko.sync.CryptoRecord;
@@ -186,6 +187,20 @@ public class Server11RepositorySession extends RepositorySession {
 
 
   Server11Repository serverRepository;
+  AtomicLong uploadTimestamp = new AtomicLong(0);
+
+  private void bumpUploadTimestamp(long ts) {
+    while (true) {
+      long existing = uploadTimestamp.get();
+      if (existing > ts) {
+        return;
+      }
+      if (uploadTimestamp.compareAndSet(existing, ts)) {
+        return;
+      }
+    }
+  }
+
   public Server11RepositorySession(Repository repository) {
     super(repository);
     serverRepository = (Server11Repository) repository;
@@ -320,7 +335,7 @@ public class Server11RepositorySession extends RepositorySession {
   public void storeDone() {
     synchronized (recordsBufferMonitor) {
       flush();
-      super.storeDone();
+      storeDone(uploadTimestamp.get());
     }
   }
 
@@ -379,6 +394,10 @@ public class Server11RepositorySession extends RepositorySession {
             (success.size() > 0)) {
           Log.d(LOG_TAG, "Successful records: " + success.toString());
           // TODO: how do we notify without the whole record?
+
+          long ts = response.normalizedWeaveTimestamp();
+          Log.d(LOG_TAG, "Passing back upload X-Weave-Timestamp: " + ts);
+          bumpUploadTimestamp(ts);
         }
         if ((failed != null) &&
             (failed.object.size() > 0)) {

--- a/src/main/java/org/mozilla/gecko/sync/repositories/delegates/DeferredRepositorySessionStoreDelegate.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/delegates/DeferredRepositorySessionStoreDelegate.java
@@ -81,11 +81,11 @@ public class DeferredRepositorySessionStoreDelegate implements
   }
 
   @Override
-  public void onStoreCompleted() {
+  public void onStoreCompleted(final long end) {
     executor.execute(new Runnable() {
       @Override
       public void run() {
-        inner.onStoreCompleted();
+        inner.onStoreCompleted(end);
       }
     });
   }

--- a/src/main/java/org/mozilla/gecko/sync/repositories/delegates/RepositorySessionStoreDelegate.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/delegates/RepositorySessionStoreDelegate.java
@@ -51,6 +51,6 @@ import org.mozilla.gecko.sync.repositories.domain.Record;
 public interface RepositorySessionStoreDelegate {
   public void onRecordStoreFailed(Exception ex);
   public void onRecordStoreSucceeded(Record record);
-  public void onStoreCompleted();
+  public void onStoreCompleted(long end);
   public RepositorySessionStoreDelegate deferredStoreDelegate(ExecutorService executor);
 }

--- a/src/main/java/org/mozilla/gecko/sync/synchronizer/RecordsChannel.java
+++ b/src/main/java/org/mozilla/gecko/sync/synchronizer/RecordsChannel.java
@@ -51,8 +51,6 @@ import org.mozilla.gecko.sync.repositories.delegates.RepositorySessionFetchRecor
 import org.mozilla.gecko.sync.repositories.delegates.RepositorySessionStoreDelegate;
 import org.mozilla.gecko.sync.repositories.domain.Record;
 
-import android.util.Log;
-
 /**
  * Pulls records from `source`, applying them to `sink`.
  * Notifies its delegate of errors and completion.
@@ -104,7 +102,7 @@ class RecordsChannel implements
   public RepositorySession sink;
   private RecordsChannelDelegate delegate;
   private long timestamp;
-  private long end = -1;                     // Oo er, missus.
+  private long fetchEnd = -1;
 
   public RecordsChannel(RepositorySession source, RepositorySession sink, RecordsChannelDelegate delegate) {
     this.source    = source;
@@ -210,7 +208,7 @@ class RecordsChannel implements
   public void onFetchCompleted(long end) {
     Logger.info(LOG_TAG, "onFetchCompleted. Stopping consumer once stores are done.");
     Logger.info(LOG_TAG, "Fetch timestamp is " + end);
-    this.end = end;
+    this.fetchEnd = end;
     this.consumer.queueFilled();
   }
 
@@ -237,10 +235,11 @@ class RecordsChannel implements
   }
 
   @Override
-  public void onStoreCompleted() {
-    Logger.info(LOG_TAG, "onStoreCompleted. Notifying delegate of onFlowCompleted. End is " + end);
+  public void onStoreCompleted(long storeEnd) {
+    Logger.info(LOG_TAG, "onStoreCompleted. Notifying delegate of onFlowCompleted. " +
+                         "Fetch end is " + fetchEnd + ", store end is " + storeEnd);
     // TODO: synchronize on consumer callback?
-    delegate.onFlowCompleted(this, end);
+    delegate.onFlowCompleted(this, fetchEnd, storeEnd);
   }
 
   @Override

--- a/src/main/java/org/mozilla/gecko/sync/synchronizer/RecordsChannelDelegate.java
+++ b/src/main/java/org/mozilla/gecko/sync/synchronizer/RecordsChannelDelegate.java
@@ -38,7 +38,7 @@
 package org.mozilla.gecko.sync.synchronizer;
 
 public interface RecordsChannelDelegate {
-  public void onFlowCompleted(RecordsChannel recordsChannel, long end);
+  public void onFlowCompleted(RecordsChannel recordsChannel, long fetchEnd, long storeEnd);
   public void onFlowBeginFailed(RecordsChannel recordsChannel, Exception ex);
   public void onFlowStoreFailed(RecordsChannel recordsChannel, Exception ex);
   public void onFlowFinishFailed(RecordsChannel recordsChannel, Exception ex);

--- a/src/main/java/org/mozilla/gecko/sync/synchronizer/SynchronizerSession.java
+++ b/src/main/java/org/mozilla/gecko/sync/synchronizer/SynchronizerSession.java
@@ -66,8 +66,15 @@ implements RecordsChannelDelegate,
   private RepositorySession sessionB;
   private RepositorySessionBundle bundleA;
   private RepositorySessionBundle bundleB;
+
+  // Bug 726054: just like desktop, we track our last interaction with the server,
+  // not the last record timestamp that we fetched. This ensures that we don't re-
+  // download the records we just uploaded, at the cost of skipping any records
+  // that a concurrently syncing client has uploaded.
   private long pendingATimestamp = -1;
   private long pendingBTimestamp = -1;
+  private long storeEndATimestamp = -1;
+  private long storeEndBTimestamp = -1;
   private boolean flowAToBCompleted = false;
   private boolean flowBToACompleted = false;
 
@@ -137,6 +144,7 @@ implements RecordsChannelDelegate,
         info("First RecordsChannel flow completed. Fetch end is " + fetchEnd +
              ". Store end is " + storeEnd + ". Starting next.");
         pendingATimestamp = fetchEnd;
+        storeEndBTimestamp = storeEnd;
         flowAToBCompleted = true;
         channelBToA.flow();
       }
@@ -169,7 +177,9 @@ implements RecordsChannelDelegate,
   public void onFlowCompleted(RecordsChannel channel, long fetchEnd, long storeEnd) {
     info("First RecordsChannel flow completed. Fetch end is " + fetchEnd +
          ". Store end is " + storeEnd + ". Finishing.");
+
     pendingBTimestamp = fetchEnd;
+    storeEndATimestamp = storeEnd;
     flowBToACompleted = true;
 
     // Finish the two sessions.
@@ -280,8 +290,8 @@ implements RecordsChannelDelegate,
 
     if (session == sessionA) {
       if (flowAToBCompleted) {
-        info("onFinishSucceeded: bumping session A's timestamp to " + pendingATimestamp);
-        bundle.bumpTimestamp(pendingATimestamp);
+        info("onFinishSucceeded: bumping session A's timestamp to " + pendingATimestamp + " or " + storeEndATimestamp);
+        bundle.bumpTimestamp(Math.max(pendingATimestamp, storeEndATimestamp));
         this.synchronizer.bundleA = bundle;
       }
       if (this.sessionB != null) {
@@ -291,8 +301,8 @@ implements RecordsChannelDelegate,
       }
     } else if (session == sessionB) {
       if (flowBToACompleted) {
-        info("onFinishSucceeded: bumping session B's timestamp to " + pendingBTimestamp);
-        bundle.bumpTimestamp(pendingBTimestamp);
+        info("onFinishSucceeded: bumping session B's timestamp to " + pendingBTimestamp + " or " + storeEndBTimestamp);
+        bundle.bumpTimestamp(Math.max(pendingBTimestamp, storeEndBTimestamp));
         this.synchronizer.bundleB = bundle;
         info("Notifying delegate.onSynchronized.");
         this.delegate.onSynchronized(this);

--- a/src/main/java/org/mozilla/gecko/sync/synchronizer/SynchronizerSession.java
+++ b/src/main/java/org/mozilla/gecko/sync/synchronizer/SynchronizerSession.java
@@ -133,9 +133,10 @@ implements RecordsChannelDelegate,
     // TODO: failed record handling.
     final RecordsChannel channelBToA = new RecordsChannel(this.sessionB, this.sessionA, this);
     RecordsChannelDelegate channelDelegate = new RecordsChannelDelegate() {
-      public void onFlowCompleted(RecordsChannel recordsChannel, long end) {
-        info("First RecordsChannel flow completed. End is " + end + ". Starting next.");
-        pendingATimestamp = end;
+      public void onFlowCompleted(RecordsChannel recordsChannel, long fetchEnd, long storeEnd) {
+        info("First RecordsChannel flow completed. Fetch end is " + fetchEnd +
+             ". Store end is " + storeEnd + ". Starting next.");
+        pendingATimestamp = fetchEnd;
         flowAToBCompleted = true;
         channelBToA.flow();
       }
@@ -165,9 +166,10 @@ implements RecordsChannelDelegate,
   }
 
   @Override
-  public void onFlowCompleted(RecordsChannel channel, long end) {
-    info("Second RecordsChannel flow completed. End is " + end + ". Finishing.");
-    pendingBTimestamp = end;
+  public void onFlowCompleted(RecordsChannel channel, long fetchEnd, long storeEnd) {
+    info("First RecordsChannel flow completed. Fetch end is " + fetchEnd +
+         ". Store end is " + storeEnd + ". Finishing.");
+    pendingBTimestamp = fetchEnd;
     flowBToACompleted = true;
 
     // Finish the two sessions.

--- a/test/src/org/mozilla/android/sync/test/StoreTrackingTest.java
+++ b/test/src/org/mozilla/android/sync/test/StoreTrackingTest.java
@@ -406,6 +406,25 @@ public class StoreTrackingTest extends
             Log.d(getName(), "Counts: " + countA + ", " + countB);
             assertEq(2L, countA);
             assertEq(3L, countB);
+
+            // Testing for store timestamp 'hack'.
+            // We fetched from A first, and so its bundle timestamp will be the last
+            // stored time. We fetched from B second, so its bundle timestamp will be
+            // the last fetched time.
+            final long timestampA = synchronizer.bundleA.getTimestamp();
+            final long timestampB = synchronizer.bundleB.getTimestamp();
+            Log.d(getName(), "Repo A timestamp: " + timestampA);
+            Log.d(getName(), "Repo B timestamp: " + timestampB);
+            Log.d(getName(), "Repo A fetch done: " + repoA.stats.fetchCompleted);
+            Log.d(getName(), "Repo A store done: " + repoA.stats.storeCompleted);
+            Log.d(getName(), "Repo B fetch done: " + repoB.stats.fetchCompleted);
+            Log.d(getName(), "Repo B store done: " + repoB.stats.storeCompleted);
+
+            assertTrue(timestampB <= timestampA);
+            assertTrue(repoA.stats.fetchCompleted <= timestampA);
+            assertTrue(repoA.stats.storeCompleted >= repoA.stats.fetchCompleted);
+            assertEquals(repoA.stats.storeCompleted, timestampA);
+            assertEquals(repoB.stats.fetchCompleted, timestampB);
             performNotify();
           }
 

--- a/test/src/org/mozilla/android/sync/test/StoreTrackingTest.java
+++ b/test/src/org/mozilla/android/sync/test/StoreTrackingTest.java
@@ -156,8 +156,8 @@ public class StoreTrackingTest extends
       }
 
       @Override
-      public void onStoreCompleted() {
-        Log.d(getName(), "Store completed.");
+      public void onStoreCompleted(long timestamp) {
+        Log.d(getName(), "Store completed at " + timestamp + ".");
         session.fetch(new String[] { expectedGUID }, new SuccessFetchDelegate() {
          @Override
           public void onFetchedRecord(Record record) {
@@ -167,7 +167,7 @@ public class StoreTrackingTest extends
 
           @Override
           public void onFetchCompleted(long end) {
-            Log.d(getName(), "Fetch completed.");
+            Log.d(getName(), "Fetch completed at " + end + ".");
 
             // But fetching by time returns nothing.
             session.fetchSince(0, new SuccessFetchDelegate() {

--- a/test/src/org/mozilla/android/sync/test/helpers/DefaultStoreDelegate.java
+++ b/test/src/org/mozilla/android/sync/test/helpers/DefaultStoreDelegate.java
@@ -21,7 +21,7 @@ public class DefaultStoreDelegate extends DefaultDelegate implements RepositoryS
   }
 
   @Override
-  public void onStoreCompleted() {
+  public void onStoreCompleted(long timestamp) {
     sharedFail("DefaultStoreDelegate used");
   }
 
@@ -51,11 +51,11 @@ public class DefaultStoreDelegate extends DefaultDelegate implements RepositoryS
       }
 
       @Override
-      public void onStoreCompleted() {
+      public void onStoreCompleted(final long end) {
         executor.execute(new Runnable() {
           @Override
           public void run() {
-            self.onStoreCompleted();
+            self.onStoreCompleted(end);
           }
         });
       }

--- a/test/src/org/mozilla/android/sync/test/helpers/ExpectManyStoredDelegate.java
+++ b/test/src/org/mozilla/android/sync/test/helpers/ExpectManyStoredDelegate.java
@@ -25,7 +25,7 @@ public class ExpectManyStoredDelegate extends DefaultStoreDelegate {
   }
 
   @Override
-  public void onStoreCompleted() {
+  public void onStoreCompleted(long timestamp) {
     assertEquals(stored.get(), expectedGUIDs.size());
     System.out.println("Notifying in onStoreCompleted.");
     testWaiter().performNotify();

--- a/test/src/org/mozilla/android/sync/test/helpers/ExpectStoreCompletedDelegate.java
+++ b/test/src/org/mozilla/android/sync/test/helpers/ExpectStoreCompletedDelegate.java
@@ -13,7 +13,7 @@ public class ExpectStoreCompletedDelegate extends DefaultStoreDelegate {
   }
 
   @Override
-  public void onStoreCompleted() {
+  public void onStoreCompleted(long timestamp) {
     testWaiter().performNotify();
   }
 }

--- a/test/src/org/mozilla/android/sync/test/helpers/ExpectStoredDelegate.java
+++ b/test/src/org/mozilla/android/sync/test/helpers/ExpectStoredDelegate.java
@@ -18,7 +18,7 @@ public class ExpectStoredDelegate extends DefaultStoreDelegate {
   }
 
   @Override
-  public synchronized void onStoreCompleted() {
+  public synchronized void onStoreCompleted(long timestamp) {
     if (this.storedRecord == null) {
       System.out.println("Notifying in onStoreCompleted.");
       testWaiter().performNotify();


### PR DESCRIPTION
This sequence of commits threads a store finish time through the delegate callbacks, mirroring fetch, and isolates logic for deciding on the final persisted timestamp in a single location in Synchronizer.

It also includes a trivial extension of an existing test.
