### PR TITLE
Bug 722007 - update row in place in AndroidBrowserHistoryDataExtender.

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserHistoryDataExtender.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserHistoryDataExtender.java
@@ -139,17 +139,6 @@ public class AndroidBrowserHistoryDataExtender extends SQLiteOpenHelper {
   public void store(String guid, JSONArray visits) {
     SQLiteDatabase db = this.getCachedWritableDatabase();
 
-    boolean rowExists = false;
-    try {
-      Cursor cur = fetch(guid);
-      if (cur.getCount() >= 1) {
-        rowExists = true;
-      }
-      cur.close();
-    } catch (NullCursorException e) {
-      // Do nothing.
-    }
-
     ContentValues cv = new ContentValues();
     cv.put(COL_GUID, guid);
     if (visits == null) {
@@ -158,15 +147,14 @@ public class AndroidBrowserHistoryDataExtender extends SQLiteOpenHelper {
       cv.put(COL_VISITS, visits.toJSONString());
     }
 
-    if (!rowExists) {
+    String where = COL_GUID + " = ?";
+    String[] args = new String[] { guid };
+    int rowsUpdated = db.update(TBL_HISTORY_EXT, cv, where, args);
+    if (rowsUpdated >= 1) {
+      Logger.debug(LOG_TAG, "Replaced history extension record for row with GUID " + guid);
+    } else {
       long rowId = db.insert(TBL_HISTORY_EXT, null, cv);
       Logger.debug(LOG_TAG, "Inserted history extension record into row: " + rowId);
-    } else {
-      String where = COL_GUID + " = ?";
-      String[] args = new String[] { guid };
-
-      db.update(TBL_HISTORY_EXT, cv, where, args);
-      Logger.debug(LOG_TAG, "Replaced history extension record for row with GUID " + guid);
     }
   }
 

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserHistoryDataExtender.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserHistoryDataExtender.java
@@ -61,8 +61,11 @@ public class AndroidBrowserHistoryDataExtender extends SQLiteOpenHelper {
   public static final String COL_GUID = "guid";
   public static final String COL_VISITS = "visits";
 
+  private final RepoUtils.QueryHelper queryHelper;
+
   public AndroidBrowserHistoryDataExtender(Context context) {
     super(context, DB_NAME, null, SCHEMA_VERSION);
+    this.queryHelper = new RepoUtils.QueryHelper(context, null, LOG_TAG);
   }
 
   @Override
@@ -178,16 +181,9 @@ public class AndroidBrowserHistoryDataExtender extends SQLiteOpenHelper {
     String[] args = new String[] { guid };
 
     SQLiteDatabase db = this.getCachedReadableDatabase();
-    long queryStart = System.currentTimeMillis();
-    Cursor cur = db.query(TBL_HISTORY_EXT,
-                          new String[] { COL_GUID, COL_VISITS },
-                          where, args,
-                          null, null, null);
-    RepoUtils.queryTimeLogger("AndroidBrowserHistoryDataExtender.fetch(guid)", queryStart, System.currentTimeMillis());
-    if (cur == null) {
-      Logger.error(LOG_TAG, "Got a null cursor while doing fetch for guid " + guid + " on history extension table");
-      throw new NullCursorException(null);
-    }
+    Cursor cur = queryHelper.safeQuery(db, ".fetch", TBL_HISTORY_EXT,
+        new String[] { COL_GUID, COL_VISITS },
+        where, args, null, null, null, null);
     return cur;
   }
 

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserHistoryDataExtender.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserHistoryDataExtender.java
@@ -57,9 +57,10 @@ public class AndroidBrowserHistoryDataExtender extends SQLiteOpenHelper {
   protected static final int SCHEMA_VERSION = 1;
 
   // History Table.
-  public static final String TBL_HISTORY_EXT = "HistoryExtension";
-  public static final String COL_GUID = "guid";
-  public static final String COL_VISITS = "visits";
+  public static final String   TBL_HISTORY_EXT = "HistoryExtension";
+  public static final String   COL_GUID = "guid";
+  public static final String   COL_VISITS = "visits";
+  public static final String[] TBL_COLUMNS = { COL_GUID, COL_VISITS };
 
   private final RepoUtils.QueryHelper queryHelper;
 
@@ -182,7 +183,7 @@ public class AndroidBrowserHistoryDataExtender extends SQLiteOpenHelper {
 
     SQLiteDatabase db = this.getCachedReadableDatabase();
     Cursor cur = queryHelper.safeQuery(db, ".fetch", TBL_HISTORY_EXT,
-        new String[] { COL_GUID, COL_VISITS },
+        TBL_COLUMNS,
         where, args, null, null, null, null);
     return cur;
   }
@@ -225,7 +226,7 @@ public class AndroidBrowserHistoryDataExtender extends SQLiteOpenHelper {
   public Cursor fetchAll() throws NullCursorException {
     SQLiteDatabase db = this.getCachedReadableDatabase();
     Cursor cur = db.query(TBL_HISTORY_EXT,
-        new String[] { COL_GUID, COL_VISITS },
+        TBL_COLUMNS,
         null, null, null, null, null);
     if (cur == null) {
       throw new NullCursorException(null);

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserHistoryDataExtender.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserHistoryDataExtender.java
@@ -39,6 +39,7 @@
 package org.mozilla.gecko.sync.repositories.android;
 
 import org.json.simple.JSONArray;
+import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.repositories.NullCursorException;
 
 import android.content.ContentValues;
@@ -46,12 +47,11 @@ import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
-import android.util.Log;
 
 public class AndroidBrowserHistoryDataExtender extends SQLiteOpenHelper {
 
-  public static final String TAG = "AndroidBrowserHistoryDataExtender";
-  
+  public static final String LOG_TAG = "A.BrowHist.DataExtender";
+
   // Database Specifications.
   protected static final String DB_NAME = "history_extension_database";
   protected static final int SCHEMA_VERSION = 1;
@@ -60,8 +60,8 @@ public class AndroidBrowserHistoryDataExtender extends SQLiteOpenHelper {
   public static final String TBL_HISTORY_EXT = "HistoryExtension";
   public static final String COL_GUID = "guid";
   public static final String COL_VISITS = "visits";
-  
-  protected AndroidBrowserHistoryDataExtender(Context context) {
+
+  public AndroidBrowserHistoryDataExtender(Context context) {
     super(context, DB_NAME, null, SCHEMA_VERSION);
   }
 
@@ -123,15 +123,29 @@ public class AndroidBrowserHistoryDataExtender extends SQLiteOpenHelper {
     onUpgrade(db, SCHEMA_VERSION, SCHEMA_VERSION);
   }
 
-  // If a record with given GUID exists, we'll delete it
-  // and store the updated version.
-  public long store(String guid, JSONArray visits) {
+  /**
+   * Store visit data.
+   *
+   * If a row with GUID `guid` does not exist, insert a new row.
+   * If a row with GUID `guid` does exist, replace the visits column.
+   *
+   * @param guid The GUID to store to.
+   * @param visits New visits data.
+   */
+  public void store(String guid, JSONArray visits) {
     SQLiteDatabase db = this.getCachedReadableDatabase();
-    
-    // delete if exists
-    delete(guid);
-    
-    // insert new
+
+    boolean rowExists = false;
+    try {
+      Cursor cur = fetch(guid);
+      if (cur.getCount() >= 1) {
+        rowExists = true;
+      }
+      cur.close();
+    } catch (NullCursorException e) {
+      // Do nothing.
+    }
+
     ContentValues cv = new ContentValues();
     cv.put(COL_GUID, guid);
     if (visits == null) {
@@ -139,11 +153,26 @@ public class AndroidBrowserHistoryDataExtender extends SQLiteOpenHelper {
     } else {
       cv.put(COL_VISITS, visits.toJSONString());
     }
-    long rowId = db.insert(TBL_HISTORY_EXT, null, cv);
-    Log.i(TAG, "Inserted history extension record into row: " + rowId);
-    return rowId;
+
+    if (!rowExists) {
+      long rowId = db.insert(TBL_HISTORY_EXT, null, cv);
+      Logger.debug(LOG_TAG, "Inserted history extension record into row: " + rowId);
+    } else {
+      String where = COL_GUID + " = ?";
+      String[] args = new String[] { guid };
+
+      db.update(TBL_HISTORY_EXT, cv, where, args);
+      Logger.debug(LOG_TAG, "Replaced history extension record for row with GUID " + guid);
+    }
   }
-  
+
+  /**
+   * Fetch a row.
+   *
+   * @param guid The GUID of the row to fetch.
+   * @return A Cursor.
+   * @throws NullCursorException
+   */
   public Cursor fetch(String guid) throws NullCursorException {
     String where = COL_GUID + " = ?";
     String[] args = new String[] { guid };
@@ -156,17 +185,55 @@ public class AndroidBrowserHistoryDataExtender extends SQLiteOpenHelper {
                           null, null, null);
     RepoUtils.queryTimeLogger("AndroidBrowserHistoryDataExtender.fetch(guid)", queryStart, System.currentTimeMillis());
     if (cur == null) {
-      Log.e(TAG, "Got a null cursor while doing fetch for guid " + guid + " on history extension table");
+      Logger.error(LOG_TAG, "Got a null cursor while doing fetch for guid " + guid + " on history extension table");
       throw new NullCursorException(null);
     }
     return cur;
   }
-  
-  public void delete(String guid) {
+
+  public JSONArray visitsForGUID(String guid) throws NullCursorException {
+    Logger.debug(LOG_TAG, "Fetching visits for GUID " + guid);
+    Cursor visits = fetch(guid);
+    try {
+      if (!visits.moveToFirst()) {
+        // Cursor is empty.
+        return new JSONArray();
+      } else {
+        return RepoUtils.getJSONArrayFromCursor(visits, COL_VISITS);
+      }
+    } finally {
+      visits.close();
+    }
+  }
+
+  /**
+   * Delete a row.
+   *
+   * @param guid The GUID of the row to delete.
+   * @return The number of rows deleted, either 0 (if a row with this GUID does not exist) or 1.
+   */
+  public int delete(String guid) {
     String where = COL_GUID + " = ?";
     String[] args = new String[] { guid };
 
     SQLiteDatabase db = this.getCachedWritableDatabase();
-    db.delete(TBL_HISTORY_EXT, where, args);
+    return db.delete(TBL_HISTORY_EXT, where, args);
+  }
+
+  /**
+   * Fetch all rows.
+   *
+   * @return A Cursor.
+   * @throws NullCursorException
+   */
+  public Cursor fetchAll() throws NullCursorException {
+    SQLiteDatabase db = this.getCachedReadableDatabase();
+    Cursor cur = db.query(TBL_HISTORY_EXT,
+        new String[] { COL_GUID, COL_VISITS },
+        null, null, null, null, null);
+    if (cur == null) {
+      throw new NullCursorException(null);
+    }
+    return cur;
   }
 }

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserHistoryDataExtender.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserHistoryDataExtender.java
@@ -137,7 +137,7 @@ public class AndroidBrowserHistoryDataExtender extends SQLiteOpenHelper {
    * @param visits New visits data.
    */
   public void store(String guid, JSONArray visits) {
-    SQLiteDatabase db = this.getCachedReadableDatabase();
+    SQLiteDatabase db = this.getCachedWritableDatabase();
 
     boolean rowExists = false;
     try {

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserHistoryDataExtender.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserHistoryDataExtender.java
@@ -50,7 +50,7 @@ import android.database.sqlite.SQLiteOpenHelper;
 
 public class AndroidBrowserHistoryDataExtender extends SQLiteOpenHelper {
 
-  public static final String LOG_TAG = "A.BrowHist.DataExtender";
+  public static final String LOG_TAG = "SyncHistoryVisits";
 
   // Database Specifications.
   protected static final String DB_NAME = "history_extension_database";

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserHistoryRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserHistoryRepositorySession.java
@@ -92,25 +92,10 @@ public class AndroidBrowserHistoryRepositorySession extends AndroidBrowserReposi
     return ((AndroidBrowserHistoryDataAccessor) dbHelper).getHistoryDataExtender();
   }
 
-  private JSONArray visitsForGUID(String guid) throws NullCursorException {
-    Log.d(LOG_TAG, "Fetching visits for GUID " + guid);
-    Cursor visits = getDataExtender().fetch(guid);
-    try {
-      if (!visits.moveToFirst()) {
-        // Cursor is empty.
-        return new JSONArray();
-      } else {
-        return RepoUtils.getJSONArrayFromCursor(visits, AndroidBrowserHistoryDataExtender.COL_VISITS);
-      }
-    } finally {
-      visits.close();
-    }
-  }
-
   private Record addVisitsToRecord(Record record) throws NullCursorException {
     Log.d(LOG_TAG, "Adding visits for GUID " + record.guid);
     HistoryRecord hist = (HistoryRecord) record;
-    JSONArray visitsArray = visitsForGUID(hist.guid);
+    JSONArray visitsArray = getDataExtender().visitsForGUID(hist.guid);
     long missingRecords = hist.fennecVisitCount - visitsArray.size();
 
     // Note that Fennec visit times are milliseconds, and we are working

--- a/test/src/org/mozilla/gecko/sync/repositories/android/test/AndroidBrowserHistoryDataExtenderTest.java
+++ b/test/src/org/mozilla/gecko/sync/repositories/android/test/AndroidBrowserHistoryDataExtenderTest.java
@@ -25,7 +25,7 @@ import android.util.Log;
 public class AndroidBrowserHistoryDataExtenderTest extends ActivityInstrumentationTestCase2<StubActivity> {
 
   protected AndroidBrowserHistoryDataExtender extender;
-  protected static final String LOG_TAG = "AndroidBrowserHistoryDataExtenderTest";
+  protected static final String LOG_TAG = "SyncHistoryVisitsTest";
 
   public AndroidBrowserHistoryDataExtenderTest() {
     super(StubActivity.class);

--- a/test/src/org/mozilla/gecko/sync/repositories/android/test/AndroidBrowserHistoryDataExtenderTest.java
+++ b/test/src/org/mozilla/gecko/sync/repositories/android/test/AndroidBrowserHistoryDataExtenderTest.java
@@ -1,0 +1,130 @@
+/* Any copyright is dedicated to the Public Domain.
+http://creativecommons.org/publicdomain/zero/1.0/ */
+
+package org.mozilla.gecko.sync.repositories.android.test;
+
+import java.io.IOException;
+
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.ParseException;
+import org.mozilla.gecko.sync.ExtendedJSONObject;
+import org.mozilla.gecko.sync.NonArrayJSONException;
+import org.mozilla.gecko.sync.NonObjectJSONException;
+import org.mozilla.gecko.sync.StubActivity;
+import org.mozilla.gecko.sync.Utils;
+import org.mozilla.gecko.sync.repositories.NullCursorException;
+import org.mozilla.gecko.sync.repositories.android.AndroidBrowserHistoryDataExtender;
+import org.mozilla.gecko.sync.repositories.android.RepoUtils;
+
+import android.content.Context;
+import android.database.Cursor;
+import android.test.ActivityInstrumentationTestCase2;
+import android.util.Log;
+
+public class AndroidBrowserHistoryDataExtenderTest extends ActivityInstrumentationTestCase2<StubActivity> {
+
+  protected AndroidBrowserHistoryDataExtender extender;
+  protected static final String LOG_TAG = "AndroidBrowserHistoryDataExtenderTest";
+
+  public AndroidBrowserHistoryDataExtenderTest() {
+    super(StubActivity.class);
+  }
+
+  public Context getApplicationContext() {
+    return this.getInstrumentation().getTargetContext().getApplicationContext();
+  }
+
+  public void setUp() {
+    Log.i(LOG_TAG, "Wiping.");
+    extender = new AndroidBrowserHistoryDataExtender(getApplicationContext());
+    extender.wipe();
+  }
+
+  public void testStoreFetch() throws NullCursorException, NonObjectJSONException, IOException, ParseException {
+    String guid = Utils.generateGuid();
+    extender.store(Utils.generateGuid(), null);
+    extender.store(guid, null);
+    extender.store(Utils.generateGuid(), null);
+
+    Cursor cur = null;
+    try {
+      cur = extender.fetch(guid);
+      assertEquals(1, cur.getCount());
+      assertTrue(cur.moveToFirst());
+      assertEquals(guid, cur.getString(0));
+    } finally {
+      if (cur != null) {
+        cur.close();
+      }
+    }
+  }
+
+  public void testVisitsForGUID() throws NonArrayJSONException, NonObjectJSONException, IOException, ParseException, NullCursorException {
+    String guid = Utils.generateGuid();
+    JSONArray visits = new ExtendedJSONObject("{ \"visits\": [ { \"key\" : \"value\" } ] }").getArray("visits");
+
+    extender.store(Utils.generateGuid(), null);
+    extender.store(guid, visits);
+    extender.store(Utils.generateGuid(), null);
+
+    JSONArray fetchedVisits = extender.visitsForGUID(guid);
+    assertEquals(1, fetchedVisits.size());
+    assertEquals("value", ((JSONObject)fetchedVisits.get(0)).get("key"));
+  }
+
+  public void testDeleteHandlesBadGUIDs() {
+    String evilGUID = "' or '1'='1";
+    extender.store(Utils.generateGuid(), null);
+    extender.store(Utils.generateGuid(), null);
+    extender.store(evilGUID, null);
+    extender.delete(evilGUID);
+
+    Cursor cur = null;
+    try {
+      cur = extender.fetchAll();
+      assertEquals(cur.getCount(), 2);
+      assertTrue(cur.moveToFirst());
+      while (!cur.isAfterLast()) {
+        String guid = RepoUtils.getStringFromCursor(cur, AndroidBrowserHistoryDataExtender.COL_GUID);
+        assertFalse(evilGUID.equals(guid));
+        cur.moveToNext();
+      }
+    } catch (NullCursorException e) {
+      e.printStackTrace();
+      fail("Should not have null cursor.");
+    } finally {
+      if (cur != null) {
+        cur.close();
+      }
+      extender.close();
+    }
+  }
+
+  public void testStoreFetchHandlesBadGUIDs() {
+    String evilGUID = "' or '1'='1";
+    extender.store(Utils.generateGuid(), null);
+    extender.store(Utils.generateGuid(), null);
+    extender.store(evilGUID, null);
+
+    Cursor cur = null;
+    try {
+      cur = extender.fetch(evilGUID);
+      assertEquals(1, cur.getCount());
+      assertTrue(cur.moveToFirst());
+      while (!cur.isAfterLast()) {
+        String guid = RepoUtils.getStringFromCursor(cur, AndroidBrowserHistoryDataExtender.COL_GUID);
+        assertEquals(evilGUID, guid);
+        cur.moveToNext();
+      }
+    } catch (NullCursorException e) {
+      e.printStackTrace();
+      fail("Should not have null cursor.");
+    } finally {
+      if (cur != null) {
+        cur.close();
+      }
+      extender.close();
+    }
+  }
+}


### PR DESCRIPTION
And factor out AndroidBrowserHistoryDataExtenderTest.

The ticket asks not to blow away the existing visit data, but I don't know how to do that without changing the history extension database schema: since visits are stored as a JSON string, there's no 'update only part'.  I doubt we want to change the database schema right now, so I'm pushing this small cleaning/preparation for new data extenders patch and suggesting we close/de-prioritize 722007.

Or I've completely misunderstood :)
