### PR TITLE
Bug 718238 - Fundamental bookmarks improvements.

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/CryptoRecord.java
+++ b/src/main/java/org/mozilla/gecko/sync/CryptoRecord.java
@@ -176,7 +176,7 @@ public class CryptoRecord extends Record {
     if (jsonRecord.containsKey(KEY_MODIFIED)) {
       record.lastModified = jsonRecord.getTimestamp(KEY_MODIFIED);
     }
-    if (jsonRecord.containsKey(KEY_SORTINDEX )) {
+    if (jsonRecord.containsKey(KEY_SORTINDEX)) {
       record.sortIndex = jsonRecord.getLong(KEY_SORTINDEX);
     }
     // TODO: deleted?

--- a/src/main/java/org/mozilla/gecko/sync/Utils.java
+++ b/src/main/java/org/mozilla/gecko/sync/Utils.java
@@ -44,8 +44,9 @@ import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.Locale;
+import java.util.TreeMap;
 
 import org.mozilla.apache.commons.codec.binary.Base32;
 import org.mozilla.apache.commons.codec.binary.Base64;
@@ -234,37 +235,12 @@ public class Utils {
     return context.getSharedPreferences(prefsPath, SHARED_PREFERENCES_MODE);
   }
 
-  /**
-   * Populate null slots in the provided array from keys in the provided Map.
-   * Set values in the map to be the new indices.
-   *
-   * @param dest
-   * @param source
-   * @throws Exception
-   */
-  public static void fillArraySpaces(String[] dest, HashMap<String, Long> source) throws Exception {
-    int i = 0;
-    int c = dest.length;
-    int needed = source.size();
-    if (needed == 0) {
-      return;
+  public static void addToIndexBucketMap(TreeMap<Long, ArrayList<String>> map, long index, String value) {
+    ArrayList<String> bucket = map.get(index);
+    if (bucket == null) {
+      bucket = new ArrayList<String>();
     }
-    if (needed > c) {
-      throw new Exception("Need " + needed + " array spaces, have no more than " + c);
-    }
-    for (String key : source.keySet()) {
-      while (i < c) {
-        if (dest[i] == null) {
-          // Great!
-          dest[i] = key;
-          source.put(key, (long) i);
-          break;
-        }
-        ++i;
-      }
-    }
-    if (i >= c) {
-      throw new Exception("Could not fill array spaces.");
-    }
+    bucket.add(value);
+    map.put(index, bucket);
   }
 }

--- a/src/main/java/org/mozilla/gecko/sync/repositories/RepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/RepositorySession.java
@@ -50,8 +50,6 @@ import org.mozilla.gecko.sync.repositories.delegates.RepositorySessionStoreDeleg
 import org.mozilla.gecko.sync.repositories.delegates.RepositorySessionWipeDelegate;
 import org.mozilla.gecko.sync.repositories.domain.Record;
 
-import android.util.Log;
-
 /**
  * A RepositorySession is created and used thusly:
  *
@@ -75,10 +73,6 @@ public abstract class RepositorySession {
   }
 
   private static final String LOG_TAG = "RepositorySession";
-
-  private static void error(String message) {
-    Logger.error(LOG_TAG, message);
-  }
 
   protected static void trace(String message) {
     Logger.trace(LOG_TAG, message);
@@ -141,7 +135,7 @@ public abstract class RepositorySession {
    * Store success calls are not guaranteed.
    */
   public void setStoreDelegate(RepositorySessionStoreDelegate delegate) {
-    Log.d(LOG_TAG, "Setting store delegate to " + delegate);
+    Logger.debug(LOG_TAG, "Setting store delegate to " + delegate);
     this.delegate = delegate;
   }
   public abstract void store(Record record) throws NoStoreDelegateException;
@@ -154,7 +148,7 @@ public abstract class RepositorySession {
   }
 
   public void storeDone(final long end) {
-    Log.d(LOG_TAG, "Scheduling onStoreCompleted for after storing is done.");
+    Logger.debug(LOG_TAG, "Scheduling onStoreCompleted for after storing is done.");
     Runnable command = new Runnable() {
       @Override
       public void run() {
@@ -189,7 +183,7 @@ public abstract class RepositorySession {
     if (this.status == SessionStatus.UNSTARTED) {
       this.status = SessionStatus.ACTIVE;
     } else {
-      error("Tried to begin() an already active or finished session");
+      Logger.error(LOG_TAG, "Tried to begin() an already active or finished session");
       throw new InvalidSessionTransitionException(null);
     }
   }
@@ -220,11 +214,11 @@ public abstract class RepositorySession {
    * @return
    */
   protected RepositorySessionBundle getBundle(RepositorySessionBundle optional) {
-    System.out.println("RepositorySession.getBundle(optional).");
+    Logger.debug(LOG_TAG, "RepositorySession.getBundle(optional).");
     // Why don't we just persist the old bundle?
     RepositorySessionBundle bundle = (optional == null) ? new RepositorySessionBundle() : optional;
     bundle.put("timestamp", this.lastSyncTimestamp);
-    System.out.println("Setting bundle timestamp to " + this.lastSyncTimestamp);
+    Logger.debug(LOG_TAG, "Setting bundle timestamp to " + this.lastSyncTimestamp);
     return bundle;
   }
 
@@ -244,11 +238,11 @@ public abstract class RepositorySession {
       this.status = SessionStatus.DONE;
       delegate.deferredFinishDelegate(delegateQueue).onFinishSucceeded(this, this.getBundle(null));
     } else {
-      Log.e(LOG_TAG, "Tried to finish() an unstarted or already finished session");
+      Logger.error(LOG_TAG, "Tried to finish() an unstarted or already finished session");
       Exception e = new InvalidSessionTransitionException(null);
       delegate.deferredFinishDelegate(delegateQueue).onFinishFailed(e);
     }
-    Log.i(LOG_TAG, "Shutting down work queues.");
+    Logger.info(LOG_TAG, "Shutting down work queues.");
  //   storeWorkQueue.shutdown();
  //   delegateQueue.shutdown();
   }
@@ -311,11 +305,11 @@ public abstract class RepositorySession {
                                     final Record localRecord,
                                     final long lastRemoteRetrieval,
                                     final long lastLocalRetrieval) {
-    Log.d(LOG_TAG, "Reconciling remote " + remoteRecord.guid + " against local " + localRecord.guid);
+    Logger.debug(LOG_TAG, "Reconciling remote " + remoteRecord.guid + " against local " + localRecord.guid);
 
     if (localRecord.equalPayloads(remoteRecord)) {
       if (remoteRecord.lastModified > localRecord.lastModified) {
-        Log.d(LOG_TAG, "Records are equal. No record application needed.");
+        Logger.debug(LOG_TAG, "Records are equal. No record application needed.");
         return null;
       }
 
@@ -329,7 +323,7 @@ public abstract class RepositorySession {
     // * The modified times of each record (interpreted through the lens of clock skew);
     // * ...
     boolean localIsMoreRecent = localRecord.lastModified > remoteRecord.lastModified;
-    Log.d(LOG_TAG, "Local record is more recent? " + localIsMoreRecent);
+    Logger.debug(LOG_TAG, "Local record is more recent? " + localIsMoreRecent);
     Record donor = localIsMoreRecent ? localRecord : remoteRecord;
 
     // Modify the local record to match the remote record's GUID and values.

--- a/src/main/java/org/mozilla/gecko/sync/repositories/RepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/RepositorySession.java
@@ -358,4 +358,7 @@ public abstract class RepositorySession {
    */
   protected synchronized void trackRecord(Record record) {
   }
+
+  protected synchronized void untrackRecord(Record record) {
+  }
 }

--- a/src/main/java/org/mozilla/gecko/sync/repositories/StoreTrackingRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/StoreTrackingRepositorySession.java
@@ -48,6 +48,16 @@ public abstract class StoreTrackingRepositorySession extends RepositorySession {
   }
 
   @Override
+  protected synchronized void untrackRecord(Record record) {
+    if (this.storeTracker == null) {
+      throw new IllegalStateException("Store tracker not yet initialized!");
+    }
+
+    Logger.debug(LOG_TAG, "Un-tracking record " + record.guid + ".");
+    this.storeTracker.untrackStoredForExclusion(record.guid);
+  }
+
+  @Override
   public void abort(RepositorySessionFinishDelegate delegate) {
     this.storeTracker = null;
     super.abort(delegate);

--- a/src/main/java/org/mozilla/gecko/sync/repositories/StoreTrackingRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/StoreTrackingRepositorySession.java
@@ -4,11 +4,10 @@
 
 package org.mozilla.gecko.sync.repositories;
 
+import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.repositories.delegates.RepositorySessionBeginDelegate;
 import org.mozilla.gecko.sync.repositories.delegates.RepositorySessionFinishDelegate;
 import org.mozilla.gecko.sync.repositories.domain.Record;
-
-import android.util.Log;
 
 public abstract class StoreTrackingRepositorySession extends RepositorySession {
   private static final String LOG_TAG = "StoreTrackSession";
@@ -42,8 +41,8 @@ public abstract class StoreTrackingRepositorySession extends RepositorySession {
       throw new IllegalStateException("Store tracker not yet initialized!");
     }
 
-    Log.d(LOG_TAG, "Tracking record " + record.guid +
-                   " (" + record.lastModified + ") to avoid re-upload.");
+    Logger.debug(LOG_TAG, "Tracking record " + record.guid +
+                           " (" + record.lastModified + ") to avoid re-upload.");
     // Future: we care about the timestamp…
     this.storeTracker.trackRecordForExclusion(record.guid);
   }

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksDataAccessor.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksDataAccessor.java
@@ -96,12 +96,13 @@ public class AndroidBrowserBookmarksDataAccessor extends AndroidBrowserRepositor
    * Insert them if they aren't there.
    */
   public void checkAndBuildSpecialGuids() throws NullCursorException {
-    Cursor cur = fetch(RepoUtils.SPECIAL_GUIDS);
+    final String[] specialGUIDs = AndroidBrowserBookmarksRepositorySession.SPECIAL_GUIDS;
+    Cursor cur = fetch(specialGUIDs);
     long mobileRoot  = 0;
     long desktopRoot = 0;
 
     // Map from GUID to whether deleted. Non-presence implies just that.
-    HashMap<String, Boolean> statuses = new HashMap<String, Boolean>(RepoUtils.SPECIAL_GUIDS.length);
+    HashMap<String, Boolean> statuses = new HashMap<String, Boolean>(specialGUIDs.length);
     try {
       if (cur.moveToFirst()) {
         while (!cur.isAfterLast()) {
@@ -123,7 +124,7 @@ public class AndroidBrowserBookmarksDataAccessor extends AndroidBrowserRepositor
     }
 
     // Insert or undelete them if missing.
-    for (String guid : RepoUtils.SPECIAL_GUIDS) {
+    for (String guid : specialGUIDs) {
       if (statuses.containsKey(guid)) {
         if (statuses.get(guid)) {
           // Undelete.
@@ -149,7 +150,7 @@ public class AndroidBrowserBookmarksDataAccessor extends AndroidBrowserRepositor
 
   private long insertSpecialFolder(String guid, long parentId) {
     BookmarkRecord record = new BookmarkRecord(guid);
-    record.title = RepoUtils.SPECIAL_GUIDS_MAP.get(guid);
+    record.title = AndroidBrowserBookmarksRepositorySession.SPECIAL_GUIDS_MAP.get(guid);
     record.type = "folder";
     record.androidParentID = parentId;
     return(RepoUtils.getAndroidIdFromUri(insert(record)));

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksDataAccessor.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksDataAccessor.java
@@ -139,6 +139,7 @@ public class AndroidBrowserBookmarksDataAccessor extends AndroidBrowserRepositor
           Log.i(LOG_TAG, "No mobile folder. Inserting one.");
           mobileRoot = insertSpecialFolder("mobile", 0);
         } else if (guid.equals("places")) {
+          // This is awkward.
           desktopRoot = insertSpecialFolder("places", mobileRoot);
         } else {
           // unfiled, menu, toolbar.
@@ -181,10 +182,13 @@ public class AndroidBrowserBookmarksDataAccessor extends AndroidBrowserRepositor
     return cv;
   }
   
-  // Returns a cursor with any records that list the given androidID as a parent
+  // Returns a cursor with any records that list the given androidID as a parent.
+  // Exclude "places", which is stored under "mobile" for convenience.
+  // Remember to manually reparent "places" if you change "mobile"!
   public Cursor getChildren(long androidID) throws NullCursorException {
-    String where = BrowserContract.Bookmarks.PARENT + " = ?";
-    String[] args = new String[] { String.valueOf(androidID) };
+    String where = BrowserContract.Bookmarks.PARENT + " = ? AND " +
+                   BrowserContract.SyncColumns.GUID + " <> ?" ;
+    String[] args = new String[] { String.valueOf(androidID), "places" };
     return queryHelper.safeQuery(".getChildren", getAllColumns(), where, args, null);
   }
   

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksDataAccessor.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksDataAccessor.java
@@ -41,6 +41,7 @@ package org.mozilla.gecko.sync.repositories.android;
 import java.util.HashMap;
 
 import org.json.simple.JSONArray;
+import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.repositories.NullCursorException;
 import org.mozilla.gecko.sync.repositories.domain.BookmarkRecord;
 import org.mozilla.gecko.sync.repositories.domain.Record;
@@ -49,7 +50,6 @@ import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
-import android.util.Log;
 
 public class AndroidBrowserBookmarksDataAccessor extends AndroidBrowserRepositoryDataAccessor {
 
@@ -128,7 +128,7 @@ public class AndroidBrowserBookmarksDataAccessor extends AndroidBrowserRepositor
       if (statuses.containsKey(guid)) {
         if (statuses.get(guid)) {
           // Undelete.
-          Log.i(LOG_TAG, "Undeleting special GUID " + guid);
+          Logger.info(LOG_TAG, "Undeleting special GUID " + guid);
           ContentValues cv = new ContentValues();
           cv.put(BrowserContract.SyncColumns.IS_DELETED, 0);
           updateByGuid(guid, cv);
@@ -136,13 +136,15 @@ public class AndroidBrowserBookmarksDataAccessor extends AndroidBrowserRepositor
       } else {
         // Insert.
         if (guid.equals("mobile")) {
-          Log.i(LOG_TAG, "No mobile folder. Inserting one.");
+          Logger.info(LOG_TAG, "No mobile folder. Inserting one.");
           mobileRoot = insertSpecialFolder("mobile", 0);
         } else if (guid.equals("places")) {
           // This is awkward.
+          Logger.info(LOG_TAG, "No places root. Inserting one under mobile (" + mobileRoot + ").");
           desktopRoot = insertSpecialFolder("places", mobileRoot);
         } else {
           // unfiled, menu, toolbar.
+          Logger.info(LOG_TAG, "No " + guid + " root. Inserting one under places (" + desktopRoot + ").");
           insertSpecialFolder(guid, desktopRoot);
         }
       }

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksDataAccessor.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksDataAccessor.java
@@ -220,13 +220,17 @@ public class AndroidBrowserBookmarksDataAccessor extends AndroidBrowserRepositor
     return cv;
   }
   
-  // Returns a cursor with any records that list the given androidID as a parent.
-  // Exclude "places", which is stored under "mobile" for convenience.
-  // Remember to manually reparent "places" if you change "mobile"!
+  /**
+   * Returns a cursor over non-deleted records that list the given androidID as a parent.
+   */
   public Cursor getChildren(long androidID) throws NullCursorException {
     return getChildren(androidID, false);
   }
 
+  /**
+   * Returns a cursor with any records that list the given androidID as a parent.
+   * Excludes 'places', and optionally any deleted records.
+   */
   public Cursor getChildren(long androidID, boolean includeDeleted) throws NullCursorException {
     final String where = BrowserContract.Bookmarks.PARENT + " = ? AND " +
                          BrowserContract.SyncColumns.GUID + " <> ? " +

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksDataAccessor.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksDataAccessor.java
@@ -115,7 +115,7 @@ public class AndroidBrowserBookmarksDataAccessor extends AndroidBrowserRepositor
     ContentValues values = new ContentValues();
     values.put(Bookmarks.DATE_MODIFIED, modified);
 
-    return context.getContentResolver().update(getUri(), values, where, selectionArgs );
+    return context.getContentResolver().update(getUri(), values, where, selectionArgs);
   }
 
   protected void updateParentAndPosition(String guid, long newParentId, long position) {

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksDataAccessor.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksDataAccessor.java
@@ -96,6 +96,7 @@ public class AndroidBrowserBookmarksDataAccessor extends AndroidBrowserRepositor
    * @param childArray
    */
   public int updatePositions(ArrayList<String> childArray) {
+    Logger.debug(LOG_TAG, "Updating positions for " + childArray.size() + " items.");
     String[] args = childArray.toArray(new String[childArray.size()]);
     return context.getContentResolver().update(getPositionsUri(), new ContentValues(), null, args);
   }
@@ -108,6 +109,7 @@ public class AndroidBrowserBookmarksDataAccessor extends AndroidBrowserRepositor
    * @return
    */
   public int bumpModified(long id, long modified) {
+    Logger.debug(LOG_TAG, "Bumping modified for " + id + " to " + modified);
     String where = Bookmarks._ID + " = ?";
     String[] selectionArgs = new String[] { String.valueOf(id) };
     ContentValues values = new ContentValues();
@@ -119,7 +121,9 @@ public class AndroidBrowserBookmarksDataAccessor extends AndroidBrowserRepositor
   protected void updateParentAndPosition(String guid, long newParentId, long position) {
     ContentValues cv = new ContentValues();
     cv.put(BrowserContract.Bookmarks.PARENT, newParentId);
-    cv.put(BrowserContract.Bookmarks.POSITION, position);
+    if (position >= 0) {
+      cv.put(BrowserContract.Bookmarks.POSITION, position);
+    }
     updateByGuid(guid, cv);
   } 
   

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
@@ -460,12 +460,19 @@ public class AndroidBrowserBookmarksRepositorySession extends AndroidBrowserRepo
 
   @Override
   protected boolean checkRecordType(Record record) {
-    BookmarkRecord bmk = (BookmarkRecord) record;
-    if (bmk.type.equalsIgnoreCase(AndroidBrowserBookmarksDataAccessor.TYPE_BOOKMARK) ||
-        bmk.type.equalsIgnoreCase(AndroidBrowserBookmarksDataAccessor.TYPE_FOLDER)) {
+    if (!(record instanceof BookmarkRecord)) {
+      return false;
+    }
+    if (record.deleted) {
       return true;
     }
-    Logger.info(LOG_TAG, "Ignoring record with guid: " + record.guid + " and type: " + ((BookmarkRecord)record).type);
+    BookmarkRecord bmk = (BookmarkRecord) record;
+
+    if (bmk.isBookmark() ||
+        bmk.isFolder()) {
+      return true;
+    }
+    Logger.info(LOG_TAG, "Ignoring record with guid: " + bmk.guid + " and type: " + bmk.type);
     return false;
   }
   

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
@@ -1,39 +1,6 @@
-/* ***** BEGIN LICENSE BLOCK *****
- * Version: MPL 1.1/GPL 2.0/LGPL 2.1
- *
- * The contents of this file are subject to the Mozilla Public License Version
- * 1.1 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- * http://www.mozilla.org/MPL/
- *
- * Software distributed under the License is distributed on an "AS IS" basis,
- * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
- * for the specific language governing rights and limitations under the
- * License.
- *
- * The Original Code is Android Sync Client.
- *
- * The Initial Developer of the Original Code is
- * the Mozilla Foundation.
- * Portions created by the Initial Developer are Copyright (C) 2011
- * the Initial Developer. All Rights Reserved.
- *
- * Contributor(s):
- * Jason Voll <jvoll@mozilla.com>
- *
- * Alternatively, the contents of this file may be used under the terms of
- * either the GNU General Public License Version 2 or later (the "GPL"), or
- * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
- * in which case the provisions of the GPL or the LGPL are applicable instead
- * of those above. If you wish to allow use of your version of this file only
- * under the terms of either the GPL or the LGPL, and not to allow others to
- * use your version of this file under the terms of the MPL, indicate your
- * decision by deleting the provisions above and replace them with the notice
- * and other provisions required by the GPL or the LGPL. If you do not delete
- * the provisions above, a recipient may use your version of this file under
- * the terms of any one of the MPL, the GPL or the LGPL.
- *
- * ***** END LICENSE BLOCK ***** */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.gecko.sync.repositories.android;
 
@@ -94,6 +61,15 @@ public class AndroidBrowserBookmarksRepositorySession extends AndroidBrowserRepo
     String guid = idToGuid.get(androidID);
     trace("  " + androidID + " => " + guid);
     return guid;
+  }
+
+  private long getIDForGUID(String guid) {
+    Long id = guidToID.get(guid);
+    if (id == null) {
+      Logger.warn(LOG_TAG, "Couldn't find local ID for GUID " + guid);
+      return -1;
+    }
+    return id.longValue();
   }
 
   private String getGUID(Cursor cur) {

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
@@ -258,7 +258,8 @@ public class AndroidBrowserBookmarksRepositorySession extends AndroidBrowserRepo
       // Get children into array in correct order.
       while (!children.isAfterLast()) {
         String childGuid = getGUID(children);
-        trace("  Child GUID: " + childGuid);
+        long parent = getParentID(children);
+        trace("  Child GUID: " + childGuid + ", parent " + parent);
         int childPosition = (int) RepoUtils.getLongFromCursor(children, BrowserContract.Bookmarks.POSITION);
         trace("  Child position: " + childPosition);
         if (childPosition >= count) {

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
@@ -210,6 +210,14 @@ public class AndroidBrowserBookmarksRepositorySession extends AndroidBrowserRepo
     return RepoUtils.getLongFromCursor(cur, BrowserContract.Bookmarks.PARENT);
   }
 
+  // More efficient for bulk operations.
+  private long getPosition(Cursor cur, int positionIndex) {
+    return cur.getLong(positionIndex);
+  }
+  private long getPosition(Cursor cur) {
+    return RepoUtils.getLongFromCursor(cur, BrowserContract.Bookmarks.POSITION);
+  }
+
   private String getParentName(String parentGUID) throws ParentNotFoundException, NullCursorException {
     if (parentGUID == null) {
       return "";
@@ -347,7 +355,7 @@ public class AndroidBrowserBookmarksRepositorySession extends AndroidBrowserRepo
 
       String destination = bookmark.deleted ? "unfiled" : "mobile";
       bookmark.androidParentID = getIDForGUID(destination);
-      bookmark.androidPosition = 0;
+      bookmark.androidPosition = getPosition(cur);
       bookmark.parentID        = destination;
       bookmark.parentName      = getParentName(destination);
       if (!bookmark.deleted) {

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
@@ -577,7 +577,31 @@ public class AndroidBrowserBookmarksRepositorySession extends AndroidBrowserRepo
       Logger.debug(LOG_TAG, "Told to delete record " + record.guid + ". Ignoring.");
       return;
     }
+    final BookmarkRecord bookmarkRecord = (BookmarkRecord) record;
+    if (bookmarkRecord.isFolder()) {
+      Logger.debug(LOG_TAG, "Deleting folder. Ensuring consistency of children.");
+      handleFolderDeletion(bookmarkRecord);
+      return;
+    }
     super.storeRecordDeletion(record);
+  }
+
+  /**
+   * When a folder deletion is received, we must ensure -- for database
+   * consistency -- that its children are placed somewhere sane.
+   *
+   * Note that its children might also be deleted, but we'll process
+   * folders first. For that reason we might want to queue up these
+   * folder deletions and handle them in onStoreDone.
+   *
+   * See Bug 724739.
+   *
+   * @param folder
+   */
+  protected void handleFolderDeletion(final BookmarkRecord folder) {
+    // TODO: reparent children. Bug 724740.
+    // For now we'll trust that we'll process the item deletions, too.
+    super.storeRecordDeletion(folder);
   }
 
   @Override

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
@@ -554,6 +554,15 @@ public class AndroidBrowserBookmarksRepositorySession extends AndroidBrowserRepo
   }
 
   @Override
+  protected void storeRecordDeletion(final Record record) {
+    if (SPECIAL_GUIDS_MAP.containsKey(record.guid)) {
+      Logger.debug(LOG_TAG, "Told to delete record " + record.guid + ". Ignoring.");
+      return;
+    }
+    super.storeRecordDeletion(record);
+  }
+
+  @Override
   protected String buildRecordString(Record record) {
     BookmarkRecord bmk = (BookmarkRecord) record;
     return bmk.title + bmk.bookmarkURI + bmk.type + bmk.parentName;

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
@@ -321,6 +321,10 @@ public class AndroidBrowserBookmarksRepositorySession extends AndroidBrowserRepo
     return childArray;
   }
 
+  protected static boolean isDeleted(Cursor cur) {
+    return RepoUtils.getLongFromCursor(cur, BrowserContract.SyncColumns.IS_DELETED) != 0;
+  }
+
   @Override
   protected Record recordFromMirrorCursor(Cursor cur) throws NoGuidForIdException, NullCursorException, ParentNotFoundException {
     String recordGUID = getGUID(cur);
@@ -329,6 +333,11 @@ public class AndroidBrowserBookmarksRepositorySession extends AndroidBrowserRepo
     if (forbiddenGUID(recordGUID)) {
       Logger.debug(LOG_TAG, "Ignoring " + recordGUID + " record in recordFromMirrorCursor.");
       return null;
+    }
+
+    // Short-cut for deleted items.
+    if (isDeleted(cur)) {
+      return AndroidBrowserBookmarksRepositorySession.bookmarkFromMirrorCursor(cur, null, null, null);
     }
 
     long androidParentID = getParentID(cur);
@@ -646,9 +655,10 @@ public class AndroidBrowserBookmarksRepositorySession extends AndroidBrowserRepo
 
   private static BookmarkRecord logBookmark(BookmarkRecord rec) {
     try {
-      Logger.debug(LOG_TAG, "Returning bookmark record " + rec.guid + " (" + rec.androidID +
+      Logger.debug(LOG_TAG, "Returning " + (rec.deleted ? "deleted " : "") +
+                            "bookmark record " + rec.guid + " (" + rec.androidID +
                            ", parent " + rec.parentID + ")");
-      if (Logger.LOG_PERSONAL_INFORMATION) {
+      if (!rec.deleted && Logger.LOG_PERSONAL_INFORMATION) {
         Logger.pii(LOG_TAG, "> Parent name:      " + rec.parentName);
         Logger.pii(LOG_TAG, "> Title:            " + rec.title);
         Logger.pii(LOG_TAG, "> Type:             " + rec.type);
@@ -670,13 +680,18 @@ public class AndroidBrowserBookmarksRepositorySession extends AndroidBrowserRepo
 
   // Create a BookmarkRecord object from a cursor on a row containing a Fennec bookmark.
   public static BookmarkRecord bookmarkFromMirrorCursor(Cursor cur, String parentGUID, String parentName, JSONArray children) {
-
-    String guid = RepoUtils.getStringFromCursor(cur, BrowserContract.SyncColumns.GUID);
-    String collection = "bookmarks";
-    long lastModified = RepoUtils.getLongFromCursor(cur, BrowserContract.SyncColumns.DATE_MODIFIED);
-    boolean deleted   = RepoUtils.getLongFromCursor(cur, BrowserContract.SyncColumns.IS_DELETED) == 1 ? true : false;
-    boolean isFolder  = RepoUtils.getIntFromCursor(cur, BrowserContract.Bookmarks.IS_FOLDER) == 1;
+    final String collection = "bookmarks";
+    final String guid       = RepoUtils.getStringFromCursor(cur, BrowserContract.SyncColumns.GUID);
+    final long lastModified = RepoUtils.getLongFromCursor(cur,   BrowserContract.SyncColumns.DATE_MODIFIED);
+    final boolean deleted   = isDeleted(cur);
     BookmarkRecord rec = new BookmarkRecord(guid, collection, lastModified, deleted);
+
+    // No point in populating it.
+    if (deleted) {
+      return logBookmark(rec);
+    }
+
+    boolean isFolder  = RepoUtils.getIntFromCursor(cur, BrowserContract.Bookmarks.IS_FOLDER) == 1;
 
     rec.title = RepoUtils.getStringFromCursor(cur, BrowserContract.Bookmarks.TITLE);
     rec.bookmarkURI = RepoUtils.getStringFromCursor(cur, BrowserContract.Bookmarks.URL);

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
@@ -520,8 +520,11 @@ public class AndroidBrowserBookmarksRepositorySession extends AndroidBrowserRepo
 
     // If record is folder, update maps and re-parent children if necessary.
     if (!bmk.type.equalsIgnoreCase(AndroidBrowserBookmarksDataAccessor.TYPE_FOLDER)) {
+      Logger.debug(LOG_TAG, "Not a folder. No bookkeeping.");
       return;
     }
+
+    Logger.debug(LOG_TAG, "Updating bookkeeping for folder " + record.guid);
 
     // Mappings between ID and GUID.
     // TODO: update our persisted children arrays!
@@ -531,6 +534,7 @@ public class AndroidBrowserBookmarksRepositorySession extends AndroidBrowserRepo
 
     JSONArray childArray = bmk.children;
 
+    Logger.debug(LOG_TAG, record.guid + " has children " + childArray.toJSONString());
     parentToChildArray.put(bmk.guid, childArray);
 
     // Re-parent.

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
@@ -495,7 +495,11 @@ public class AndroidBrowserBookmarksRepositorySession extends AndroidBrowserRepo
     // hairy stuff. Here's the setup for it.
 
     Logger.debug(LOG_TAG, "Preparing folder ID mappings.");
-    idToGuid.put(0L, "places");       // Fake our root.
+
+    // Fake our root.
+    Logger.debug(LOG_TAG, "Tracking places root as ID 0.");
+    idToGuid.put(0L, "places");
+    guidToID.put("places", 0L);
     try {
       cur.moveToFirst();
       while (!cur.isAfterLast()) {

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
@@ -673,6 +673,53 @@ public class AndroidBrowserBookmarksRepositorySession extends AndroidBrowserRepo
     super.storeRecordDeletion(folder);
   }
 
+  @SuppressWarnings("unchecked")
+  private void finishUp() {
+    try {
+      Logger.debug(LOG_TAG, "Have " + parentToChildArray.size() + " folders whose children might need repositioning.");
+      for (Entry<String, JSONArray> entry : parentToChildArray.entrySet()) {
+        String guid = entry.getKey();
+        JSONArray onServer = entry.getValue();
+        try {
+          final long folderID = getIDForGUID(guid);
+          JSONArray inDB = getChildrenArray(folderID, false);
+          int added = 0;
+          for (Object o : inDB) {
+            if (!onServer.contains(o)) {
+              onServer.add(o);
+              added++;
+            }
+          }
+          Logger.debug(LOG_TAG, "Added " + added + " items locally.");
+          dataAccessor.updatePositions(new ArrayList<String>(onServer));
+          dataAccessor.bumpModified(folderID, now());
+          // Wow, this is spectacularly wasteful.
+          Logger.debug(LOG_TAG, "Untracking " + guid);
+          final Record record = retrieveByGUIDDuringStore(guid);
+          if (record == null) {
+            return;
+          }
+          untrackRecord(record);
+        } catch (Exception e) {
+          Logger.warn(LOG_TAG, "Error repositioning children for " + guid, e);
+        }
+      }
+    } finally {
+      super.storeDone();
+    }
+  }
+
+  @Override
+  public void storeDone() {
+    Runnable command = new Runnable() {
+      @Override
+      public void run() {
+        finishUp();
+      }
+    };
+    storeWorkQueue.execute(command);
+  }
+
   @Override
   protected String buildRecordString(Record record) {
     BookmarkRecord bmk = (BookmarkRecord) record;

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserHistoryRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserHistoryRepositorySession.java
@@ -1,40 +1,6 @@
-/* ***** BEGIN LICENSE BLOCK *****
- * Version: MPL 1.1/GPL 2.0/LGPL 2.1
- *
- * The contents of this file are subject to the Mozilla Public License Version
- * 1.1 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- * http://www.mozilla.org/MPL/
- *
- * Software distributed under the License is distributed on an "AS IS" basis,
- * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
- * for the specific language governing rights and limitations under the
- * License.
- *
- * The Original Code is Android Sync Client.
- *
- * The Initial Developer of the Original Code is
- * the Mozilla Foundation.
- * Portions created by the Initial Developer are Copyright (C) 2011
- * the Initial Developer. All Rights Reserved.
- *
- * Contributor(s):
- *   Jason Voll <jvoll@mozilla.com>
- *   Richard Newman <rnewman@mozilla.com>
- *
- * Alternatively, the contents of this file may be used under the terms of
- * either the GNU General Public License Version 2 or later (the "GPL"), or
- * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
- * in which case the provisions of the GPL or the LGPL are applicable instead
- * of those above. If you wish to allow use of your version of this file only
- * under the terms of either the GPL or the LGPL, and not to allow others to
- * use your version of this file under the terms of the MPL, indicate your
- * decision by deleting the provisions above and replace them with the notice
- * and other provisions required by the GPL or the LGPL. If you do not delete
- * the provisions above, a recipient may use your version of this file under
- * the terms of any one of the MPL, the GPL or the LGPL.
- *
- * ***** END LICENSE BLOCK ***** */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.gecko.sync.repositories.android;
 

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserHistoryRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserHistoryRepositorySession.java
@@ -27,7 +27,12 @@ public class AndroidBrowserHistoryRepositorySession extends AndroidBrowserReposi
   }
 
   @Override
-  protected Record recordFromMirrorCursor(Cursor cur) {
+  protected Record retrieveDuringStore(Cursor cur) {
+    return RepoUtils.historyFromMirrorCursor(cur);
+  }
+
+  @Override
+  protected Record retrieveDuringFetch(Cursor cur) {
     return RepoUtils.historyFromMirrorCursor(cur);
   }
 

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserPasswordsRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserPasswordsRepositorySession.java
@@ -1,39 +1,6 @@
-/* ***** BEGIN LICENSE BLOCK *****
- * Version: MPL 1.1/GPL 2.0/LGPL 2.1
- *
- * The contents of this file are subject to the Mozilla Public License Version
- * 1.1 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- * http://www.mozilla.org/MPL/
- *
- * Software distributed under the License is distributed on an "AS IS" basis,
- * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
- * for the specific language governing rights and limitations under the
- * License.
- *
- * The Original Code is Android Sync Client.
- *
- * The Initial Developer of the Original Code is
- * the Mozilla Foundation.
- * Portions created by the Initial Developer are Copyright (C) 2011
- * the Initial Developer. All Rights Reserved.
- *
- * Contributor(s):
- * Jason Voll <jvoll@mozilla.com>
- *
- * Alternatively, the contents of this file may be used under the terms of
- * either the GNU General Public License Version 2 or later (the "GPL"), or
- * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
- * in which case the provisions of the GPL or the LGPL are applicable instead
- * of those above. If you wish to allow use of your version of this file only
- * under the terms of either the GPL or the LGPL, and not to allow others to
- * use your version of this file under the terms of the MPL, indicate your
- * decision by deleting the provisions above and replace them with the notice
- * and other provisions required by the GPL or the LGPL. If you do not delete
- * the provisions above, a recipient may use your version of this file under
- * the terms of any one of the MPL, the GPL or the LGPL.
- *
- * ***** END LICENSE BLOCK ***** */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.gecko.sync.repositories.android;
 

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserPasswordsRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserPasswordsRepositorySession.java
@@ -20,7 +20,12 @@ public class AndroidBrowserPasswordsRepositorySession extends
   }
 
   @Override
-  protected Record recordFromMirrorCursor(Cursor cur) {
+  protected Record retrieveDuringStore(Cursor cur) {
+    return RepoUtils.passwordFromMirrorCursor(cur);
+  }
+
+  @Override
+  protected Record retrieveDuringFetch(Cursor cur) {
     return RepoUtils.passwordFromMirrorCursor(cur);
   }
 

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserRepositoryDataAccessor.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserRepositoryDataAccessor.java
@@ -38,6 +38,7 @@
 
 package org.mozilla.gecko.sync.repositories.android;
 
+import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.repositories.NullCursorException;
 import org.mozilla.gecko.sync.repositories.domain.Record;
 
@@ -45,7 +46,6 @@ import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
-import android.util.Log;
 
 public abstract class AndroidBrowserRepositoryDataAccessor {
 
@@ -68,7 +68,7 @@ public abstract class AndroidBrowserRepositoryDataAccessor {
   }
 
   public void wipe() {
-    Log.i(LOG_TAG, "wiping: " + getUri());
+    Logger.info(LOG_TAG, "wiping: " + getUri());
     String where = BrowserContract.SyncColumns.GUID + " NOT IN ('mobile')";
     context.getContentResolver().delete(getUri(), where, null);
   }
@@ -98,7 +98,7 @@ public abstract class AndroidBrowserRepositoryDataAccessor {
     if (deleted == 1) {
       return;
     }
-    Log.w(LOG_TAG, "Unexpectedly deleted " + deleted + " rows for guid " + guid);
+    Logger.warn(LOG_TAG, "Unexpectedly deleted " + deleted + " rows for guid " + guid);
   }
 
   public void update(String guid, Record newRecord) {
@@ -107,13 +107,12 @@ public abstract class AndroidBrowserRepositoryDataAccessor {
     ContentValues cv = getContentValues(newRecord);
     int updated = context.getContentResolver().update(getUri(), cv, where, args);
     if (updated != 1) {
-      Log.w(LOG_TAG, "Unexpectedly updated " + updated + " rows for guid " + guid);
+      Logger.warn(LOG_TAG, "Unexpectedly updated " + updated + " rows for guid " + guid);
     }
   }
 
   public Uri insert(Record record) {
     ContentValues cv = getContentValues(record);
-    Log.d(LOG_TAG, "INSERTING: " + cv.getAsString("guid"));
     return context.getContentResolver().insert(getUri(), cv);
   }
 
@@ -193,7 +192,7 @@ public abstract class AndroidBrowserRepositoryDataAccessor {
     if (deleted == 1) {
       return;
     }
-    Log.w(LOG_TAG, "Unexpectedly deleted " + deleted + " rows for guid " + record.guid);
+    Logger.warn(LOG_TAG, "Unexpectedly deleted " + deleted + " rows for guid " + record.guid);
   }
 
   public void updateByGuid(String guid, ContentValues cv) {
@@ -204,6 +203,6 @@ public abstract class AndroidBrowserRepositoryDataAccessor {
     if (updated == 1) {
       return;
     }
-    Log.w(LOG_TAG, "Unexpectedly updated " + updated + " rows for guid " + guid);
+    Logger.warn(LOG_TAG, "Unexpectedly updated " + updated + " rows for guid " + guid);
   }
 }

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserRepositoryDataAccessor.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserRepositoryDataAccessor.java
@@ -137,9 +137,9 @@ public abstract class AndroidBrowserRepositoryDataAccessor {
    */
   public Cursor getGUIDsSince(long timestamp) throws NullCursorException {
     return queryHelper.safeQuery(".getGUIDsSince",
-        GUID_COLUMNS,
-        dateModifiedWhere(timestamp),
-        null, null);
+                                 GUID_COLUMNS,
+                                 dateModifiedWhere(timestamp),
+                                 null, null);
   }
 
   /**
@@ -152,9 +152,9 @@ public abstract class AndroidBrowserRepositoryDataAccessor {
    */
   public Cursor fetchSince(long timestamp) throws NullCursorException {
     return queryHelper.safeQuery(".fetchSince",
-        getAllColumns(),
-        dateModifiedWhere(timestamp),
-        null, null);
+                                 getAllColumns(),
+                                 dateModifiedWhere(timestamp),
+                                 null, null);
   }
 
   /**

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserRepositorySession.java
@@ -604,6 +604,10 @@ public abstract class AndroidBrowserRepositorySession extends StoreTrackingRepos
   private void createRecordToGuidMap() throws NoGuidForIdException, NullCursorException, ParentNotFoundException {
     Logger.info(LOG_TAG, "BEGIN: creating record -> GUID map.");
     recordToGuid = new HashMap<String, String>();
+
+    // TODO: we should be able to do this entire thing with string concatenations within SQL.
+    // Also consider whether it's better to fetch and process every record in the DB into
+    // memory, or run a query per record to do the same thing.
     Cursor cur = dbHelper.fetchAll();
     try {
       if (!cur.moveToFirst()) {

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserRepositorySession.java
@@ -96,7 +96,9 @@ public abstract class AndroidBrowserRepositorySession extends StoreTrackingRepos
   }
 
   /**
-   * Override this.
+   * Retrieve a record from a cursor. Act as if we don't know the final contents of
+   * the record: for example, a folder's child array might change.
+   *
    * Return null if this record should not be processed.
    *
    * @param cur
@@ -105,7 +107,20 @@ public abstract class AndroidBrowserRepositorySession extends StoreTrackingRepos
    * @throws NullCursorException
    * @throws ParentNotFoundException
    */
-  protected abstract Record recordFromMirrorCursor(Cursor cur) throws NoGuidForIdException, NullCursorException, ParentNotFoundException;
+  protected abstract Record retrieveDuringStore(Cursor cur) throws NoGuidForIdException, NullCursorException, ParentNotFoundException;
+
+  /**
+   * Retrieve a record from a cursor. Ensure that the contents of the database are
+   * updated to match the record that we're constructing: for example, the children
+   * of a folder might be repositioned as we generate the folder's record.
+   *
+   * @param cur
+   * @return
+   * @throws NoGuidForIdException
+   * @throws NullCursorException
+   * @throws ParentNotFoundException
+   */
+  protected abstract Record retrieveDuringFetch(Cursor cur) throws NoGuidForIdException, NullCursorException, ParentNotFoundException;
 
   // Must be overriden by AndroidBookmarkRepositorySession.
   protected boolean checkRecordType(Record record) {
@@ -247,7 +262,7 @@ public abstract class AndroidBrowserRepositorySession extends StoreTrackingRepos
             return;
           }
           while (!cursor.isAfterLast()) {
-            Record r = recordFromMirrorCursor(cursor);
+            Record r = retrieveDuringFetch(cursor);
             if (r != null) {
               if (filter == null || !filter.excludeRecord(r)) {
                 Logger.trace(LOG_TAG, "Processing record " + r.guid);
@@ -408,7 +423,7 @@ public abstract class AndroidBrowserRepositorySession extends StoreTrackingRepos
         Record existingRecord;
         try {
           // GUID matching only: deleted records don't have a payload with which to search.
-          existingRecord = recordForGUID(record.guid);
+          existingRecord = retrieveByGUIDDuringStore(record.guid);
           if (record.deleted) {
             if (existingRecord == null) {
               // We're done. Don't bother with a callback. That can change later
@@ -540,7 +555,18 @@ public abstract class AndroidBrowserRepositorySession extends StoreTrackingRepos
     return toStore;
   }
 
-  protected Record recordForGUID(String guid) throws
+  /**
+   * Retrieve a record from the store by GUID, without writing unnecessarily to the
+   * database.
+   *
+   * @param guid
+   * @return
+   * @throws NoGuidForIdException
+   * @throws NullCursorException
+   * @throws ParentNotFoundException
+   * @throws MultipleRecordsForGuidException
+   */
+  protected Record retrieveByGUIDDuringStore(String guid) throws
                                              NoGuidForIdException,
                                              NullCursorException,
                                              ParentNotFoundException,
@@ -551,7 +577,7 @@ public abstract class AndroidBrowserRepositorySession extends StoreTrackingRepos
         return null;
       }
 
-      Record r = recordFromMirrorCursor(cursor);
+      Record r = retrieveDuringStore(cursor);
 
       cursor.moveToNext();
       if (cursor.isAfterLast()) {
@@ -588,7 +614,7 @@ public abstract class AndroidBrowserRepositorySession extends StoreTrackingRepos
     String guid = getRecordToGuidMap().get(recordString);
     if (guid != null) {
       Logger.debug(LOG_TAG, "Found one. Returning computed record.");
-      return recordForGUID(guid);
+      return retrieveByGUIDDuringStore(guid);
     }
     Logger.debug(LOG_TAG, "findExistingRecord failed to find one for " + record.guid);
     return null;
@@ -614,7 +640,7 @@ public abstract class AndroidBrowserRepositorySession extends StoreTrackingRepos
         return;
       }
       while (!cur.isAfterLast()) {
-        Record record = recordFromMirrorCursor(cur);
+        Record record = retrieveDuringStore(cur);
         if (record != null) {
           recordToGuid.put(buildRecordString(record), record.guid);
         }

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/BrowserContract.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/BrowserContract.java
@@ -112,6 +112,8 @@ public class BrowserContract {
             .buildUpon().appendQueryParameter(PARAM_IS_SYNC, "true")
             .appendQueryParameter(PARAM_SHOW_DELETED, "true")
             .build();
+        public static final Uri PARENTS_CONTENT_URI = Uri.withAppendedPath(CONTENT_URI, "parents");
+        public static final Uri POSITIONS_CONTENT_URI = Uri.withAppendedPath(CONTENT_URI, "positions");
 
         public static final String CONTENT_TYPE = "vnd.android.cursor.dir/bookmark";
 

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/RepoUtils.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/RepoUtils.java
@@ -4,17 +4,11 @@
 
 package org.mozilla.gecko.sync.repositories.android;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.json.simple.JSONArray;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
-import org.mozilla.gecko.R;
 import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.repositories.NullCursorException;
-import org.mozilla.gecko.sync.repositories.domain.BookmarkRecord;
 import org.mozilla.gecko.sync.repositories.domain.HistoryRecord;
 import org.mozilla.gecko.sync.repositories.domain.PasswordRecord;
 
@@ -26,89 +20,6 @@ import android.net.Uri;
 public class RepoUtils {
 
   private static final String LOG_TAG = "RepoUtils";
-
-  /**
-   * An array of known-special GUIDs.
-   */
-  public static String[] SPECIAL_GUIDS = new String[] {
-    // Mobile and desktop places roots have to come first.
-    "mobile",
-    "places",
-    "toolbar",
-    "menu",
-    "unfiled"
-  };
-
-  /**
-   * = A note about folder mapping =
-   *
-   * Note that _none_ of Places's folders actually have a special GUID. They're all
-   * randomly generated. Special folders are indicated by membership in the
-   * moz_bookmarks_roots table, and by having the parent `1`.
-   *
-   * Additionally, the mobile root is annotated. In Firefox Sync, PlacesUtils is
-   * used to find the IDs of these special folders.
-   *
-   * Sync skips over `places` and `tags` when finding IDs.
-   *
-   * We need to consume records with these various guids, producing a local
-   * representation which we are able to stably map upstream.
-   *
-   * That is:
-   *
-   * * We should not upload a `places` record or a `tags` record.
-   * * We can stably _store_ menu/toolbar/unfiled/mobile as special GUIDs, and set
-     * their parent ID as appropriate on upload.
-   *
-   *
-   * = Places folders =
-   *
-   * guid        root_name   folder_id   parent
-   * ----------  ----------  ----------  ----------
-   * ?           places      1           0
-   * ?           menu        2           1
-   * ?           toolbar     3           1
-   * ?           tags        4           1
-   * ?           unfiled     5           1
-   *
-   * ?           mobile*     474         1
-   *
-   *
-   * = Fennec folders =
-   *
-   * guid        folder_id   parent
-   * ----------  ----------  ----------
-   * mobile      ?           0
-   *
-  */
-  public static final Map<String, String> SPECIAL_GUID_PARENTS;
-  static {
-    HashMap<String, String> m = new HashMap<String, String>();
-    m.put("places",  null);
-    m.put("menu",    "places");
-    m.put("toolbar", "places");
-    m.put("tags",    "places");
-    m.put("unfiled", "places");
-    m.put("mobile",  "places");
-    SPECIAL_GUID_PARENTS = Collections.unmodifiableMap(m);
-  }
-
-  /**
-   * A map of guids to their localized name strings.
-   */
-  // Oh, if only we could make this final and initialize it in the static initializer.
-  public static Map<String, String> SPECIAL_GUIDS_MAP;
-  public static void initialize(Context context) {
-    if (SPECIAL_GUIDS_MAP == null) {
-      HashMap<String, String> m = new HashMap<String, String>();
-      m.put("menu",    context.getString(R.string.bookmarks_folder_menu));
-      m.put("places",  context.getString(R.string.bookmarks_folder_places));
-      m.put("toolbar", context.getString(R.string.bookmarks_folder_toolbar));
-      m.put("unfiled", context.getString(R.string.bookmarks_folder_unfiled));
-      m.put("mobile",  context.getString(R.string.bookmarks_folder_mobile));
-      SPECIAL_GUIDS_MAP = Collections.unmodifiableMap(m);
-    }
-  }
 
   /**
    * A helper class for monotonous SQL querying. Does timing and logging,
@@ -203,97 +114,6 @@ public class RepoUtils {
     String path = uri.getPath();
     int lastSlash = path.lastIndexOf('/');
     return Long.parseLong(path.substring(lastSlash + 1));
-  }
-
-  public static BookmarkRecord computeParentFields(BookmarkRecord rec, String suggestedParentGUID, String suggestedParentName) {
-    final String guid = rec.guid;
-    if (guid == null) {
-      // Oh dear.
-      Logger.error(LOG_TAG, "No guid in computeParentFields!");
-      return null;
-    }
-
-    String realParent = SPECIAL_GUID_PARENTS.get(guid);
-    if (realParent == null) {
-      // No magic parent. Use whatever the caller suggests.
-      realParent = suggestedParentGUID;
-    } else {
-      Logger.debug(LOG_TAG, "Ignoring suggested parent ID " + suggestedParentGUID +
-                           " for " + guid + "; using " + realParent);
-    }
-
-    if (realParent == null) {
-      // Oh dear.
-      Logger.error(LOG_TAG, "No parent for record " + guid);
-      return null;
-    }
-
-    // Always set the parent name for special folders back to default.
-    String parentName = SPECIAL_GUIDS_MAP.get(realParent);
-    if (parentName == null) {
-      parentName = suggestedParentName;
-    }
-
-    rec.parentID = realParent;
-    rec.parentName = parentName;
-    return rec;
-  }
-
-  // Create a BookmarkRecord object from a cursor on a row containing a Fennec bookmark.
-  public static BookmarkRecord bookmarkFromMirrorCursor(Cursor cur, String parentGUID, String parentName, JSONArray children) {
-
-    String guid = getStringFromCursor(cur, BrowserContract.SyncColumns.GUID);
-    String collection = "bookmarks";
-    long lastModified = getLongFromCursor(cur, BrowserContract.SyncColumns.DATE_MODIFIED);
-    boolean deleted   = getLongFromCursor(cur, BrowserContract.SyncColumns.IS_DELETED) == 1 ? true : false;
-    boolean isFolder  = getIntFromCursor(cur, BrowserContract.Bookmarks.IS_FOLDER) == 1;
-    BookmarkRecord rec = new BookmarkRecord(guid, collection, lastModified, deleted);
-
-    rec.title = getStringFromCursor(cur, BrowserContract.Bookmarks.TITLE);
-    rec.bookmarkURI = getStringFromCursor(cur, BrowserContract.Bookmarks.URL);
-    rec.description = getStringFromCursor(cur, BrowserContract.Bookmarks.DESCRIPTION);
-    rec.tags = getJSONArrayFromCursor(cur, BrowserContract.Bookmarks.TAGS);
-    rec.keyword = getStringFromCursor(cur, BrowserContract.Bookmarks.KEYWORD);
-    rec.type = isFolder ? AndroidBrowserBookmarksDataAccessor.TYPE_FOLDER :
-                          AndroidBrowserBookmarksDataAccessor.TYPE_BOOKMARK;
-
-    rec.androidID = getLongFromCursor(cur, BrowserContract.Bookmarks._ID);
-    rec.androidPosition = getLongFromCursor(cur, BrowserContract.Bookmarks.POSITION);
-    rec.children = children;
-
-    // Need to restore the parentId since it isn't stored in content provider.
-    // We also take this opportunity to fix up parents for special folders,
-    // allowing us to map between the hierarchies used by Fennec and Places.
-    BookmarkRecord withParentFields = computeParentFields(rec, parentGUID, parentName);
-    if (withParentFields == null) {
-      // Oh dear. Something went wrong.
-      return null;
-    }
-    return logBookmark(withParentFields);
-  }
-
-  private static BookmarkRecord logBookmark(BookmarkRecord rec) {
-    try {
-      Logger.debug(LOG_TAG, "Returning bookmark record " + rec.guid + " (" + rec.androidID +
-                           ", parent " + rec.parentID + ")");
-      if (Logger.LOG_PERSONAL_INFORMATION) {
-        Logger.pii(LOG_TAG, "> Parent name:      " + rec.parentName);
-        Logger.pii(LOG_TAG, "> Title:            " + rec.title);
-        Logger.pii(LOG_TAG, "> Type:             " + rec.type);
-        Logger.pii(LOG_TAG, "> URI:              " + rec.bookmarkURI);
-        Logger.pii(LOG_TAG, "> Android position: " + rec.androidPosition);
-        Logger.pii(LOG_TAG, "> Position:         " + rec.pos);
-        if (rec.isFolder()) {
-          Logger.pii(LOG_TAG, "FOLDER: Children are " +
-                             (rec.children == null ?
-                                 "null" :
-                                 rec.children.toJSONString()));
-        }
-      }
-    } catch (Exception e) {
-      Logger.debug(LOG_TAG, "Exception logging bookmark record " + rec, e);
-    }
-    return rec;
   }
 
   //Create a HistoryRecord object from a cursor on a row with a Moz History record in it

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/RepoUtils.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/RepoUtils.java
@@ -264,7 +264,12 @@ public class RepoUtils {
     // Need to restore the parentId since it isn't stored in content provider.
     // We also take this opportunity to fix up parents for special folders,
     // allowing us to map between the hierarchies used by Fennec and Places.
-    return logBookmark(computeParentFields(rec, parentId, parentName));
+    BookmarkRecord withParentFields = computeParentFields(rec, parentGUID, parentName);
+    if (withParentFields == null) {
+      // Oh dear. Something went wrong.
+      return null;
+    }
+    return logBookmark(withParentFields);
   }
 
   private static BookmarkRecord logBookmark(BookmarkRecord rec) {

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/RepoUtils.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/RepoUtils.java
@@ -25,7 +25,7 @@ import android.net.Uri;
 
 public class RepoUtils {
 
-  private static final String LOG_TAG = "DBUtils";
+  private static final String LOG_TAG = "RepoUtils";
 
   /**
    * An array of known-special GUIDs.

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/RepoUtils.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/RepoUtils.java
@@ -205,7 +205,7 @@ public class RepoUtils {
     return Long.parseLong(path.substring(lastSlash + 1));
   }
 
-  public static BookmarkRecord computeParentFields(BookmarkRecord rec, String suggestedParentID, String suggestedParentName) {
+  public static BookmarkRecord computeParentFields(BookmarkRecord rec, String suggestedParentGUID, String suggestedParentName) {
     final String guid = rec.guid;
     if (guid == null) {
       // Oh dear.
@@ -216,9 +216,9 @@ public class RepoUtils {
     String realParent = SPECIAL_GUID_PARENTS.get(guid);
     if (realParent == null) {
       // No magic parent. Use whatever the caller suggests.
-      realParent = suggestedParentID;
+      realParent = suggestedParentGUID;
     } else {
-      Logger.debug(LOG_TAG, "Ignoring suggested parent ID " + suggestedParentID +
+      Logger.debug(LOG_TAG, "Ignoring suggested parent ID " + suggestedParentGUID +
                            " for " + guid + "; using " + realParent);
     }
 
@@ -240,7 +240,7 @@ public class RepoUtils {
   }
 
   // Create a BookmarkRecord object from a cursor on a row containing a Fennec bookmark.
-  public static BookmarkRecord bookmarkFromMirrorCursor(Cursor cur, String parentId, String parentName, JSONArray children) {
+  public static BookmarkRecord bookmarkFromMirrorCursor(Cursor cur, String parentGUID, String parentName, JSONArray children) {
 
     String guid = getStringFromCursor(cur, BrowserContract.SyncColumns.GUID);
     String collection = "bookmarks";

--- a/src/main/java/org/mozilla/gecko/sync/repositories/domain/BookmarkRecord.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/domain/BookmarkRecord.java
@@ -150,9 +150,13 @@ public class BookmarkRecord extends Record {
     this.guid = payload.guid;
     checkGUIDs(p);
 
+    final Object del = p.get("deleted");
+    if (del instanceof Boolean) {
+      this.deleted = (Boolean) del;
+    }
+
     this.collection    = payload.collection;
     this.lastModified  = payload.lastModified;
-    this.deleted       = payload.deleted;
 
     this.type          = (String) p.get("type");
     this.title         = (String) p.get("title");
@@ -209,18 +213,23 @@ public class BookmarkRecord extends Record {
     CryptoRecord rec = new CryptoRecord(this);
     rec.payload = new ExtendedJSONObject();
     rec.payload.put("id", this.guid);
-    rec.payload.put("type", this.type);
-    rec.payload.put("title", this.title);
-    rec.payload.put("description", this.description);
-    rec.payload.put("parentid", this.parentID);
-    rec.payload.put("parentName", this.parentName);
-    if (isBookmark()) {
-      rec.payload.put("bmkUri", bookmarkURI);
-      rec.payload.put("keyword", keyword);
-      rec.payload.put("tags", this.tags);
-    }
-    if (isFolder()) {
-      rec.payload.put("children", this.children);
+
+    if (this.deleted) {
+      rec.payload.put("deleted", true);
+    } else {
+      putPayload(rec, "type", this.type);
+      putPayload(rec, "title", this.title);
+      putPayload(rec, "description", this.description);
+      putPayload(rec, "parentid", this.parentID);
+      putPayload(rec, "parentName", this.parentName);
+
+      if (isBookmark()) {
+        rec.payload.put("bmkUri", bookmarkURI);
+        rec.payload.put("keyword", keyword);
+        rec.payload.put("tags", this.tags);
+      } else if (isFolder()) {
+        rec.payload.put("children", this.children);
+      }
     }
     return rec;
   }

--- a/src/main/java/org/mozilla/gecko/sync/repositories/domain/BookmarkRecord.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/domain/BookmarkRecord.java
@@ -44,6 +44,7 @@ import org.mozilla.gecko.sync.ExtendedJSONObject;
 import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.NonArrayJSONException;
 import org.mozilla.gecko.sync.Utils;
+import org.mozilla.gecko.sync.repositories.android.AndroidBrowserBookmarksDataAccessor;
 import org.mozilla.gecko.sync.repositories.android.RepoUtils;
 
 import android.util.Log;
@@ -196,11 +197,11 @@ public class BookmarkRecord extends Record {
   }
 
   public boolean isBookmark() {
-    return "bookmark".equals(this.type);
+    return AndroidBrowserBookmarksDataAccessor.TYPE_BOOKMARK.equalsIgnoreCase(this.type);
   }
 
   public boolean isFolder() {
-    return "folder".equals(this.type);
+    return AndroidBrowserBookmarksDataAccessor.TYPE_FOLDER.equalsIgnoreCase(this.type);
   }
 
   @Override

--- a/src/main/java/org/mozilla/gecko/sync/repositories/domain/HistoryRecord.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/domain/HistoryRecord.java
@@ -116,7 +116,10 @@ public class HistoryRecord extends Record {
     this.checkGUIDs(p);
 
     this.lastModified  = payload.lastModified;
-    this.deleted       = payload.deleted;
+    final Object del = p.get("deleted");
+    if (del instanceof Boolean) {
+      this.deleted = (Boolean) del;
+    }
 
     this.histURI = (String) p.get("histUri");
     this.title   = (String) p.get("title");
@@ -133,10 +136,15 @@ public class HistoryRecord extends Record {
     CryptoRecord rec = new CryptoRecord(this);
     rec.payload = new ExtendedJSONObject();
     Logger.debug(LOG_TAG, "Getting payload for history record " + this.guid + " (" + this.guid.length() + ").");
-    rec.payload.put("id",      this.guid);
-    rec.payload.put("title",   this.title);
-    rec.payload.put("histUri", this.histURI);             // TODO: encoding?
-    rec.payload.put("visits",  this.visits);
+
+    if (this.deleted) {
+      rec.payload.put("deleted", true);
+    } else {
+      putPayload(rec, "id",      this.guid);
+      putPayload(rec, "title",   this.title);
+      putPayload(rec, "histUri", this.histURI);             // TODO: encoding?
+      rec.payload.put("visits",  this.visits);
+    }
     return rec;
   }
 

--- a/src/main/java/org/mozilla/gecko/sync/repositories/domain/Record.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/domain/Record.java
@@ -240,6 +240,20 @@ public abstract class Record {
     }
   }
 
+  /**
+   * Utility for safely populating an output CryptoRecord.
+   *
+   * @param rec
+   * @param key
+   * @param value
+   */
+  protected void putPayload(CryptoRecord rec, String key, String value) {
+    if (value == null) {
+      return;
+    }
+    rec.payload.put(key, value);
+  }
+
   protected void checkGUIDs(ExtendedJSONObject payload) {
     String payloadGUID = (String) payload.get("id");
     if (this.guid == null ||

--- a/src/main/java/org/mozilla/gecko/sync/syncadapter/SyncAdapter.java
+++ b/src/main/java/org/mozilla/gecko/sync/syncadapter/SyncAdapter.java
@@ -81,6 +81,7 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements GlobalSe
 
   private static final int     SHARED_PREFERENCES_MODE = 0;
   private static final int     BACKOFF_PAD_SECONDS = 5;
+  private static final int     MINIMUM_SYNC_INTERVAL_MILLISECONDS = 5 * 60 * 1000;   // 5 minutes.
 
   private final AccountManager mAccountManager;
   private final Context        mContext;
@@ -222,12 +223,17 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements GlobalSe
                             final SyncResult syncResult) {
     Utils.reseedSharedRandom(); // Make sure we don't work with the same random seed for too long.
 
+    boolean force = (extras != null) && (extras.getBoolean("force", false));
     long delay = delayMilliseconds();
     if (delay > 0) {
-      Log.i(LOG_TAG, "Not syncing: must wait another " + delay + "ms.");
-      long remainingSeconds = delay / 1000;
-      syncResult.delayUntil = remainingSeconds + BACKOFF_PAD_SECONDS;
-      return;
+      if (force) {
+        Log.i(LOG_TAG, "Forced sync: overruling remaining backoff of " + delay + "ms.");
+      } else {
+        Log.i(LOG_TAG, "Not syncing: must wait another " + delay + "ms.");
+        long remainingSeconds = delay / 1000;
+        syncResult.delayUntil = remainingSeconds + BACKOFF_PAD_SECONDS;
+        return;
+      }
     }
 
     // TODO: don't clear the auth token unless we have a sync error.
@@ -300,6 +306,9 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements GlobalSe
       Log.i(LOG_TAG, "Waiting on sync monitor.");
       try {
         syncMonitor.wait();
+        long next = System.currentTimeMillis() + MINIMUM_SYNC_INTERVAL_MILLISECONDS;
+        Log.i(LOG_TAG, "Setting minimum next sync time to " + next);
+        extendEarliestNextSync(next);
       } catch (InterruptedException e) {
         Log.i(LOG_TAG, "Waiting on sync monitor interrupted.", e);
       }
@@ -338,7 +347,6 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements GlobalSe
                                                     keyBundle, this, this.mContext, extras);
 
     globalSession.start();
-
   }
 
   private void notifyMonitor() {

--- a/src/main/java/org/mozilla/gecko/sync/syncadapter/SyncAdapter.java
+++ b/src/main/java/org/mozilla/gecko/sync/syncadapter/SyncAdapter.java
@@ -232,7 +232,6 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements GlobalSe
 
     // TODO: don't clear the auth token unless we have a sync error.
     Log.i(LOG_TAG, "Got onPerformSync. Extras bundle is " + extras);
-    Log.d(LOG_TAG, "Extras clusterURL: " + extras.getString("clusterURL"));
     Log.i(LOG_TAG, "Account name: " + account.name);
 
     // TODO: don't always invalidate; use getShouldInvalidateAuthToken.

--- a/src/test/java/org/mozilla/android/sync/test/TestUtils.java
+++ b/src/test/java/org/mozilla/android/sync/test/TestUtils.java
@@ -3,33 +3,12 @@
 
 package org.mozilla.android.sync.test;
 
-import static org.junit.Assert.*;
-
-import java.util.HashMap;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 import org.mozilla.gecko.sync.Utils;
 
 public class TestUtils {
-
-  @Test
-  public void testFillArraySpaces() throws Exception {
-    HashMap<String, Long> from = new HashMap<String, Long>();
-    from.put("Foo", 0L);
-    from.put("Bar", 2L);
-    String[] to = new String[4];
-    to[0] = "Baz";
-    to[2] = "Noo";
-    Utils.fillArraySpaces(to, from);
-    assertEquals("Baz", to[0]);
-    assertEquals("Foo", to[1]);
-    assertEquals("Noo", to[2]);
-    assertEquals("Bar", to[3]);
-    assertEquals(new Long(1L), from.get("Foo"));
-    assertEquals(new Long(3L), from.get("Bar"));
-
-    Utils.fillArraySpaces(new String[] {}, new HashMap<String, Long>());
-  }
 
   @Test
   public void testGenerateGUID() {

--- a/test/src/org/mozilla/android/sync/test/AndroidBrowserBookmarksRepositoryTest.java
+++ b/test/src/org/mozilla/android/sync/test/AndroidBrowserBookmarksRepositoryTest.java
@@ -110,7 +110,7 @@ public class AndroidBrowserBookmarksRepositoryTest extends AndroidBrowserReposit
   @Override
   public void testFetchSinceOneRecord() {
     fetchSinceOneRecord(BookmarkHelpers.createBookmarkInMobileFolder1(),
-        BookmarkHelpers.createBookmarkInMobileFolder2());
+                        BookmarkHelpers.createBookmarkInMobileFolder2());
   }
 
   @Override
@@ -121,7 +121,7 @@ public class AndroidBrowserBookmarksRepositoryTest extends AndroidBrowserReposit
   @Override
   public void testFetchOneRecordByGuid() {
     fetchOneRecordByGuid(BookmarkHelpers.createBookmarkInMobileFolder1(),
-        BookmarkHelpers.createBookmarkInMobileFolder2());
+                         BookmarkHelpers.createBookmarkInMobileFolder2());
   }
   
   @Override
@@ -140,7 +140,8 @@ public class AndroidBrowserBookmarksRepositoryTest extends AndroidBrowserReposit
     
   @Override
   public void testWipe() {
-    doWipe(BookmarkHelpers.createBookmarkInMobileFolder1(), BookmarkHelpers.createBookmarkInMobileFolder2());
+    doWipe(BookmarkHelpers.createBookmarkInMobileFolder1(),
+           BookmarkHelpers.createBookmarkInMobileFolder2());
   }
   
   @Override
@@ -244,7 +245,7 @@ public class AndroidBrowserBookmarksRepositoryTest extends AndroidBrowserReposit
     prepSession();
     AndroidBrowserRepositorySession session = getSession();
     doStore(session, expected);
-    ExpectFetchDelegate delegate = new ExpectFetchDelegate(expected);
+    ExpectFetchDelegate delegate = BookmarkHelpers.preparedExpectFetchDelegate(expected);
     performWait(fetchAllRunnable(session, delegate));
     session.finish(new ExpectFinishDelegate());
   }
@@ -302,7 +303,7 @@ public class AndroidBrowserBookmarksRepositoryTest extends AndroidBrowserReposit
     rec0.children = new JSONArray();
     performWait(storeRunnable(session, record0));
 
-    ExpectFetchDelegate timestampDelegate = new ExpectFetchDelegate(new Record[] { rec0 });
+    ExpectFetchDelegate timestampDelegate = BookmarkHelpers.preparedExpectFetchDelegate(new Record[] { rec0 });
     performWait(fetchRunnable(session, new String[] { record0.guid }, timestampDelegate));
 
     BookmarkHelpers.dumpBookmarksDB(getApplicationContext());
@@ -331,7 +332,7 @@ public class AndroidBrowserBookmarksRepositoryTest extends AndroidBrowserReposit
     Record[] expect = new Record[] {
         bmk1, bmk2, record3
     };
-    fetchAllRunnable(session, new ExpectFetchDelegate(expect));
+    fetchAllRunnable(session, BookmarkHelpers.preparedExpectFetchDelegate(expect));
   }
   
   @Override
@@ -390,8 +391,8 @@ public class AndroidBrowserBookmarksRepositoryTest extends AndroidBrowserReposit
                                           + expected[1].guid + ", "
                                           + expected[2].guid);
     doStore(session, expected);
-    
-    ExpectFetchDelegate delegate = new ExpectFetchDelegate(expected);
+
+    ExpectFetchDelegate delegate = BookmarkHelpers.preparedExpectFetchDelegate(expected);
     performWait(fetchAllRunnable(session, delegate));
     
     int found = 0;

--- a/test/src/org/mozilla/android/sync/test/AndroidBrowserRepositoryTestHelper.java
+++ b/test/src/org/mozilla/android/sync/test/AndroidBrowserRepositoryTestHelper.java
@@ -5,7 +5,7 @@ package org.mozilla.android.sync.test;
 
 import org.mozilla.android.sync.test.helpers.DefaultSessionCreationDelegate;
 import org.mozilla.android.sync.test.helpers.ExpectBeginDelegate;
-import org.mozilla.android.sync.test.helpers.ExpectNoGUIDsSinceDelegate;
+import org.mozilla.android.sync.test.helpers.ExpectOnlySpecialFoldersDelegate;
 import org.mozilla.android.sync.test.helpers.WaitHelper;
 import org.mozilla.gecko.sync.repositories.android.AndroidBrowserRepository;
 import org.mozilla.gecko.sync.repositories.android.AndroidBrowserRepositorySession;
@@ -49,7 +49,7 @@ public class AndroidBrowserRepositoryTestHelper {
     Runnable runnable = new Runnable() {
       @Override
       public void run() {
-        session.guidsSince(0, new ExpectNoGUIDsSinceDelegate());
+        session.guidsSince(0, new ExpectOnlySpecialFoldersDelegate());
       }
     };
     testWaiter.performWait(runnable);

--- a/test/src/org/mozilla/android/sync/test/BookmarkPositioningTest.java
+++ b/test/src/org/mozilla/android/sync/test/BookmarkPositioningTest.java
@@ -1,0 +1,586 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+package org.mozilla.android.sync.test;
+
+import java.util.HashMap;
+
+import junit.framework.AssertionFailedError;
+
+import org.json.simple.JSONArray;
+import org.mozilla.android.sync.test.helpers.simple.SimpleSuccessBeginDelegate;
+import org.mozilla.android.sync.test.helpers.simple.SimpleSuccessCreationDelegate;
+import org.mozilla.android.sync.test.helpers.simple.SimpleSuccessFetchDelegate;
+import org.mozilla.android.sync.test.helpers.simple.SimpleSuccessFinishDelegate;
+import org.mozilla.android.sync.test.helpers.simple.SimpleSuccessStoreDelegate;
+import org.mozilla.gecko.R;
+import org.mozilla.gecko.sync.StubActivity;
+import org.mozilla.gecko.sync.repositories.NoStoreDelegateException;
+import org.mozilla.gecko.sync.repositories.NullCursorException;
+import org.mozilla.gecko.sync.repositories.RepositorySession;
+import org.mozilla.gecko.sync.repositories.RepositorySessionBundle;
+import org.mozilla.gecko.sync.repositories.android.AndroidBrowserBookmarksDataAccessor;
+import org.mozilla.gecko.sync.repositories.android.AndroidBrowserBookmarksRepository;
+import org.mozilla.gecko.sync.repositories.android.BrowserContract;
+import org.mozilla.gecko.sync.repositories.android.RepoUtils;
+import org.mozilla.gecko.sync.repositories.delegates.RepositorySessionBeginDelegate;
+import org.mozilla.gecko.sync.repositories.delegates.RepositorySessionCreationDelegate;
+import org.mozilla.gecko.sync.repositories.delegates.RepositorySessionFetchRecordsDelegate;
+import org.mozilla.gecko.sync.repositories.delegates.RepositorySessionStoreDelegate;
+import org.mozilla.gecko.sync.repositories.domain.BookmarkRecord;
+import org.mozilla.gecko.sync.repositories.domain.Record;
+
+import android.content.ContentResolver;
+import android.content.ContentValues;
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+import android.test.ActivityInstrumentationTestCase2;
+import android.util.Log;
+
+public class BookmarkPositioningTest extends ActivityInstrumentationTestCase2<StubActivity> {
+
+  protected static final String tag = "BookmarkPositioningTest";
+
+  public BookmarkPositioningTest() {
+    super(StubActivity.class);
+  }
+
+  public void testRetrieveFolderHasAccurateChildren() {
+    AndroidBrowserBookmarksRepository repo = new AndroidBrowserBookmarksRepository();
+
+    long now = System.currentTimeMillis();
+
+    final String folderGUID = "eaaaaaaaafff";
+    BookmarkRecord folder    = new BookmarkRecord(folderGUID,     "bookmarks", now -5, false);
+    BookmarkRecord bookmarkA = new BookmarkRecord("daaaaaaaaaaa", "bookmarks", now -1, false);
+    BookmarkRecord bookmarkB = new BookmarkRecord("baaaaaaaabbb", "bookmarks", now -3, false);
+    BookmarkRecord bookmarkC = new BookmarkRecord("aaaaaaaaaccc", "bookmarks", now -2, false);
+
+    folder.children   = childrenFromRecords(bookmarkA, bookmarkB, bookmarkC);
+    folder.sortIndex  = 150;
+    folder.title      = "Test items";
+    folder.parentID   = "toolbar";
+    folder.parentName = "Bookmarks Toolbar";
+    folder.type       = "folder";
+
+    bookmarkA.parentID    = folderGUID;
+    bookmarkA.bookmarkURI = "http://example.com/A";
+    bookmarkA.title       = "Title A";
+    bookmarkA.type        = "bookmark";
+
+    bookmarkB.parentID    = folderGUID;
+    bookmarkB.bookmarkURI = "http://example.com/B";
+    bookmarkB.title       = "Title B";
+    bookmarkB.type        = "bookmark";
+
+    bookmarkC.parentID    = folderGUID;
+    bookmarkC.bookmarkURI = "http://example.com/C";
+    bookmarkC.title       = "Title C";
+    bookmarkC.type        = "bookmark";
+
+    BookmarkRecord[] folderOnly = new BookmarkRecord[1];
+    BookmarkRecord[] children   = new BookmarkRecord[3];
+
+    folderOnly[0] = folder;
+
+    children[0] = bookmarkA;
+    children[1] = bookmarkB;
+    children[2] = bookmarkC;
+
+    wipe();
+    Log.d(getName(), "Storing just folder...");
+    storeRecordsInSession(repo, folderOnly);
+
+    // We don't have any children, despite our insistence upon storing.
+    assertChildrenAreOrdered(repo, folderGUID, new Record[] {});
+
+    // Now store the children.
+    Log.d(getName(), "Storing children...");
+    storeRecordsInSession(repo, children);
+
+    // Now we have children, but their order is not determined, because
+    // they were stored out-of-session with the original folder.
+    assertChildrenAreUnordered(repo, folderGUID, children);
+
+    // Now if we store the folder record again, they'll be put in the
+    // right place.
+    folder.lastModified++;
+    Log.d(getName(), "Storing just folder again...");
+    storeRecordsInSession(repo, folderOnly);
+    Log.d(getName(), "Fetching children yet again...");
+    assertChildrenAreOrdered(repo, folderGUID, children);
+
+    // Now let's see what happens when we see records in the same session.
+    BookmarkRecord[] parentMixed = new BookmarkRecord[4];
+    BookmarkRecord[] parentFirst = new BookmarkRecord[4];
+    BookmarkRecord[] parentLast  = new BookmarkRecord[4];
+
+    // None of our records have a position set.
+    assertTrue(bookmarkA.androidPosition <= 0);
+    assertTrue(bookmarkB.androidPosition <= 0);
+    assertTrue(bookmarkC.androidPosition <= 0);
+
+    parentMixed[1] = folder;
+    parentMixed[0] = bookmarkA;
+    parentMixed[2] = bookmarkC;
+    parentMixed[3] = bookmarkB;
+
+    parentFirst[0] = folder;
+    parentFirst[1] = bookmarkC;
+    parentFirst[2] = bookmarkA;
+    parentFirst[3] = bookmarkB;
+
+    parentLast[3]  = folder;
+    parentLast[0]  = bookmarkB;
+    parentLast[1]  = bookmarkA;
+    parentLast[2]  = bookmarkC;
+
+    wipe();
+    storeRecordsInSession(repo, parentMixed);
+    assertChildrenAreOrdered(repo, folderGUID, children);
+
+    wipe();
+    storeRecordsInSession(repo, parentFirst);
+    assertChildrenAreOrdered(repo, folderGUID, children);
+
+    wipe();
+    storeRecordsInSession(repo, parentLast);
+    assertChildrenAreOrdered(repo, folderGUID, children);
+
+    // Ensure that records are ordered even if we re-process the folder.
+    wipe();
+    storeRecordsInSession(repo, parentLast);
+    folder.lastModified++;
+    storeRecordsInSession(repo, folderOnly);
+    assertChildrenAreOrdered(repo, folderGUID, children);
+  }
+
+  public void testMergeFoldersPreservesSaneOrder() {
+    AndroidBrowserBookmarksRepository repo = new AndroidBrowserBookmarksRepository();
+
+    long now = System.currentTimeMillis();
+    final String folderGUID = "mobile";
+
+    wipe();
+    long mobile = setUpFennecMobileRecord();
+
+    // No children.
+    assertChildrenAreUnordered(repo, folderGUID, new Record[] {});
+
+    // Add some, as Fennec would.
+    fennecAddBookmark("Bookmark One", "http://example.com/fennec/One");
+    fennecAddBookmark("Bookmark Two", "http://example.com/fennec/Two");
+
+    Log.d(getName(), "Fetching children...");
+    JSONArray folderChildren = fetchChildrenForGUID(repo, folderGUID);
+
+    assertTrue(folderChildren != null);
+    Log.d(getName(), "Children are " + folderChildren.toJSONString());
+    assertEquals(2, folderChildren.size());
+    String guidOne = (String) folderChildren.get(0);
+    String guidTwo = (String) folderChildren.get(1);
+
+    // Make sure positions were saved.
+    assertChildrenAreDirect(mobile, new String[] {
+        guidOne,
+        guidTwo
+    });
+
+    // Add some through Sync.
+    BookmarkRecord folder    = new BookmarkRecord(folderGUID,     "bookmarks", now, false);
+    BookmarkRecord bookmarkA = new BookmarkRecord("daaaaaaaaaaa", "bookmarks", now, false);
+    BookmarkRecord bookmarkB = new BookmarkRecord("baaaaaaaabbb", "bookmarks", now, false);
+
+    folder.children   = childrenFromRecords(bookmarkA, bookmarkB);
+    folder.sortIndex  = 150;
+    folder.title      = "Mobile Bookmarks";
+    folder.parentID   = "places";
+    folder.parentName = "";
+    folder.type       = "folder";
+
+    bookmarkA.parentID    = folderGUID;
+    bookmarkA.bookmarkURI = "http://example.com/A";
+    bookmarkA.title       = "Title A";
+    bookmarkA.type        = "bookmark";
+
+    bookmarkB.parentID    = folderGUID;
+    bookmarkB.bookmarkURI = "http://example.com/B";
+    bookmarkB.title       = "Title B";
+    bookmarkB.type        = "bookmark";
+
+    BookmarkRecord[] parentMixed = new BookmarkRecord[3];
+    parentMixed[0] = bookmarkA;
+    parentMixed[1] = folder;
+    parentMixed[2] = bookmarkB;
+
+    storeRecordsInSession(repo, parentMixed);
+
+    BookmarkRecord expectedOne = new BookmarkRecord(guidOne, "bookmarks", now - 10, false);
+    BookmarkRecord expectedTwo = new BookmarkRecord(guidTwo, "bookmarks", now - 10, false);
+
+    // We want the server to win in this case, and otherwise to preserve order.
+    // TODO
+    assertChildrenAreOrdered(repo, folderGUID, new Record[] {
+        bookmarkA,
+        bookmarkB,
+        expectedOne,
+        expectedTwo
+    });
+
+    // Furthermore, the children of that folder should be correct in the DB.
+    final long folderId = storedIDs.get(folderGUID).longValue();
+    Log.d(getName(), "Folder " + folderGUID + " => " + folderId);
+
+    assertChildrenAreDirect(folderId, new String[] {
+        bookmarkA.guid,
+        bookmarkB.guid,
+        expectedOne.guid,
+        expectedTwo.guid
+    });
+  }
+
+  public Context getApplicationContext() {
+    return this.getInstrumentation().getTargetContext().getApplicationContext();
+  }
+
+  protected void performWait(Runnable runnable) throws AssertionFailedError {
+    AndroidBrowserRepositoryTestHelper.testWaiter.performWait(runnable);
+  }
+
+  protected void performNotify() {
+    AndroidBrowserRepositoryTestHelper.testWaiter.performNotify();
+  }
+
+  protected void performNotify(AssertionFailedError e) {
+    AndroidBrowserRepositoryTestHelper.testWaiter.performNotify(e);
+  }
+
+  protected void notifyException(String reason, Exception ex) {
+    final AssertionFailedError e = new AssertionFailedError(reason + " : " + ex.getMessage());
+    e.initCause(ex);
+    performNotify(e);
+  }
+
+  /**
+   * Create and begin a new session, handing control to the delegate when started.
+   * Returns when the delegate has notified.
+   *
+   * @param delegate
+   */
+  public void inBegunSession(final AndroidBrowserBookmarksRepository repo,
+                             final RepositorySessionBeginDelegate beginDelegate) {
+    Runnable go = new Runnable() {
+      @Override
+      public void run() {
+        RepositorySessionCreationDelegate delegate = new SimpleSuccessCreationDelegate() {
+          @Override
+          public void onSessionCreated(final RepositorySession session) {
+            session.begin(beginDelegate);
+          }
+        };
+        repo.createSession(delegate, getApplicationContext());
+      }
+    };
+    performWait(go);
+  }
+
+  /**
+   * Finish the provided session, notifying on success.
+   *
+   * @param session
+   */
+  public void finishAndNotify(final RepositorySession session) {
+    session.finish(new SimpleSuccessFinishDelegate() {
+      @Override
+      public void onFinishSucceeded(RepositorySession session,
+                                    RepositorySessionBundle bundle) {
+        performNotify();
+      }
+    });
+  }
+
+  /**
+   * Simple helper class for fetching a single record by GUID.
+   * The fetched record is stored in `fetchedRecord`.
+   *
+   */
+  public class SimpleFetchOneBeginDelegate extends SimpleSuccessBeginDelegate {
+    public final String guid;
+    public Record fetchedRecord = null;
+
+    public SimpleFetchOneBeginDelegate(String guid) {
+      this.guid = guid;
+    }
+
+    @Override
+    public void onBeginSucceeded(final RepositorySession session) {
+      RepositorySessionFetchRecordsDelegate fetchDelegate = new SimpleSuccessFetchDelegate() {
+
+        @Override
+        public void onFetchedRecord(Record record) {
+          fetchedRecord = record;
+        }
+
+        @Override
+        public void onFetchCompleted(long end) {
+          finishAndNotify(session);
+        }
+      };
+      session.fetch(new String[] { guid }, fetchDelegate);
+    }
+  }
+
+  final HashMap<String, Long> storedIDs = new HashMap<String, Long>();
+
+  /**
+   * Create a new session for the given repository, storing each record
+   * from the provided array. Notifies on failure or success.
+   *
+   * @param repo
+   * @param records
+   */
+  public void storeRecordsInSession(AndroidBrowserBookmarksRepository repo,
+                                    final BookmarkRecord[] records) {
+    SimpleSuccessBeginDelegate beginDelegate = new SimpleSuccessBeginDelegate() {
+      @Override
+      public void onBeginSucceeded(final RepositorySession session) {
+        RepositorySessionStoreDelegate storeDelegate = new SimpleSuccessStoreDelegate() {
+
+          @Override
+          public void onStoreCompleted(final long storeEnd) {
+            finishAndNotify(session);
+          }
+
+          @Override
+          public void onRecordStoreSucceeded(Record record) {
+            // Great.
+            storedIDs.put(record.guid, record.androidID);
+          }
+        };
+        session.setStoreDelegate(storeDelegate);
+        for (BookmarkRecord record : records) {
+          try {
+            session.store(record);
+          } catch (NoStoreDelegateException e) {
+            // Never happens.
+          }
+        }
+        session.storeDone();
+      }
+    };
+    inBegunSession(repo, beginDelegate);
+  }
+
+  public JSONArray fetchChildrenForGUID(AndroidBrowserBookmarksRepository repo,
+                                        final String guid) {
+    SimpleFetchOneBeginDelegate beginDelegate = new SimpleFetchOneBeginDelegate(guid);
+    inBegunSession(repo, beginDelegate);
+    assertTrue(beginDelegate.fetchedRecord != null);
+    return ((BookmarkRecord) (beginDelegate.fetchedRecord)).children;
+  }
+
+  @SuppressWarnings("unchecked")
+  protected JSONArray childrenFromRecords(BookmarkRecord... records) {
+    JSONArray children = new JSONArray();
+    for (BookmarkRecord record : records) {
+      children.add(record.guid);
+    }
+    return children;
+  }
+
+  protected Uri insertRow(ContentValues values) {
+    Uri uri = BrowserContract.Bookmarks.CONTENT_URI;
+    return getApplicationContext().getContentResolver().insert(uri, values);
+  }
+
+  protected ContentValues fennecMobileRecordWithoutTitle() {
+    ContentValues values = new ContentValues();
+    values.put(BrowserContract.SyncColumns.GUID, "mobile");
+    values.put(BrowserContract.Bookmarks.IS_FOLDER, 1);
+    values.put(BrowserContract.Bookmarks.POSITION, 0);
+
+    long now = System.currentTimeMillis();
+    values.put(BrowserContract.Bookmarks.DATE_CREATED, now);
+    values.put(BrowserContract.Bookmarks.DATE_MODIFIED, now);
+
+    return values;
+  }
+
+  protected long setUpFennecMobileRecordWithoutTitle() {
+    ContentValues values = fennecMobileRecordWithoutTitle();
+    return RepoUtils.getAndroidIdFromUri(insertRow(values));
+  }
+
+  protected long setUpFennecMobileRecord() {
+    ContentValues values = fennecMobileRecordWithoutTitle();
+    values.put(BrowserContract.Bookmarks.PARENT, 0);
+    String title = getApplicationContext().getResources().getString(R.string.bookmarks_folder_mobile);
+    values.put(BrowserContract.Bookmarks.TITLE, title);
+    return RepoUtils.getAndroidIdFromUri(insertRow(values));
+  }
+
+  //
+  // Fennec fake layer.
+  //
+  private Uri appendProfile(Uri uri) {
+    String defaultProfile = BrowserContract.DEFAULT_PROFILE;
+    return uri.buildUpon().appendQueryParameter(BrowserContract.PARAM_PROFILE, defaultProfile).build();
+  }
+
+  private long fennecGetMobileBookmarksFolderId(ContentResolver cr) {
+    Cursor c = null;
+    try {
+      c = cr.query(appendProfile(BrowserContract.Bookmarks.CONTENT_URI),
+          new String[] { BrowserContract.Bookmarks._ID },
+          BrowserContract.Bookmarks.GUID + " = ?",
+          new String[] { BrowserContract.Bookmarks.MOBILE_FOLDER_GUID },
+          null);
+
+      if (c.moveToFirst()) {
+        return c.getLong(c.getColumnIndexOrThrow(BrowserContract.Bookmarks._ID));
+      }
+      return -1;
+    } finally {
+      if (c != null) {
+        c.close();
+      }
+    }
+  }
+
+  public void fennecAddBookmark(String title, String uri) {
+    ContentResolver cr = getApplicationContext().getContentResolver();
+
+    long folderId = fennecGetMobileBookmarksFolderId(cr);
+    if (folderId < 0) {
+      return;
+    }
+
+    ContentValues values = new ContentValues();
+    values.put(BrowserContract.Bookmarks.TITLE, title);
+    values.put(BrowserContract.Bookmarks.URL, uri);
+    values.put(BrowserContract.Bookmarks.PARENT, folderId);
+
+    // Restore deleted record if possible
+    values.put(BrowserContract.Bookmarks.IS_DELETED, 0);
+
+    Log.i(getName(), "Adding bookmark " + title + ", " + uri + " in " + folderId);
+    int updated = cr.update(appendProfile(BrowserContract.Bookmarks.CONTENT_URI),
+        values,
+        BrowserContract.Bookmarks.URL + " = ?",
+            new String[] { uri });
+
+    if (updated == 0) {
+      Uri insert = cr.insert(appendProfile(BrowserContract.Bookmarks.CONTENT_URI), values);
+      long idFromUri = RepoUtils.getAndroidIdFromUri(insert);
+      Log.i(getName(), "Inserted " + uri + " as " + idFromUri);
+      Log.i(getName(), "Position is " + getPosition(idFromUri));
+    }
+  }
+
+  private long getPosition(long idFromUri) {
+    ContentResolver cr = getApplicationContext().getContentResolver();
+    Cursor c = cr.query(appendProfile(BrowserContract.Bookmarks.CONTENT_URI),
+                        new String[] { BrowserContract.Bookmarks.POSITION },
+                        BrowserContract.Bookmarks._ID + " = ?",
+                        new String[] { String.valueOf(idFromUri) },
+                        null);
+    if (!c.moveToFirst()) {
+      return -2;
+    }
+    return c.getLong(0);
+  }
+
+  protected AndroidBrowserBookmarksDataAccessor dataAccessor = null;
+  protected AndroidBrowserBookmarksDataAccessor getDataAccessor() {
+    if (dataAccessor == null) {
+      dataAccessor = new AndroidBrowserBookmarksDataAccessor(getApplicationContext());
+    }
+    return dataAccessor;
+  }
+
+  protected void wipe() {
+    Log.d(getName(), "Wiping.");
+    final ContentResolver cr = getApplicationContext().getContentResolver();
+    cr.delete(BrowserContract.Bookmarks.CONTENT_URI, null, null);
+  }
+
+  protected void assertChildrenAreOrdered(AndroidBrowserBookmarksRepository repo, String guid, Record[] expected) {
+    Log.d(getName(), "Fetching children...");
+    JSONArray folderChildren = fetchChildrenForGUID(repo, guid);
+
+    assertTrue(folderChildren != null);
+    Log.d(getName(), "Children are " + folderChildren.toJSONString());
+    assertEquals(expected.length, folderChildren.size());
+    for (int i = 0; i < expected.length; ++i) {
+      assertEquals(expected[i].guid, ((String) folderChildren.get(i)));
+    }
+  }
+
+  protected void assertChildrenAreUnordered(AndroidBrowserBookmarksRepository repo, String guid, Record[] expected) {
+    Log.d(getName(), "Fetching children...");
+    JSONArray folderChildren = fetchChildrenForGUID(repo, guid);
+
+    assertTrue(folderChildren != null);
+    Log.d(getName(), "Children are " + folderChildren.toJSONString());
+    assertEquals(expected.length, folderChildren.size());
+    for (Record record : expected) {
+      folderChildren.contains(record.guid);
+    }
+  }
+
+  /**
+   * Assert that the children of the provided ID are correct and positioned in the database.
+   * @param id
+   * @param guids
+   */
+  protected void assertChildrenAreDirect(long id, String[] guids) {
+    Log.d(getName(), "Fetching children directly from DB...");
+    AndroidBrowserBookmarksDataAccessor accessor = new AndroidBrowserBookmarksDataAccessor(getApplicationContext());
+    Cursor cur = null;
+    try {
+      cur = accessor.getChildren(id);
+    } catch (NullCursorException e) {
+      fail("Got null cursor.");
+    }
+    try {
+      assertTrue(cur.moveToFirst());
+      int i = 0;
+      final int guidCol = cur.getColumnIndex(BrowserContract.SyncColumns.GUID);
+      final int posCol = cur.getColumnIndex(BrowserContract.Bookmarks.POSITION);
+      while (!cur.isAfterLast()) {
+        assertTrue(i < guids.length);
+        final String guid = cur.getString(guidCol);
+        final int pos = cur.getInt(posCol);
+        Log.d(getName(), "Fetched child: " + guid + " has position " + pos);
+        assertEquals(guids[i], guid);
+        assertEquals(i,        pos);
+
+        ++i;
+        cur.moveToNext();
+      }
+      assertEquals(i, guids.length);
+    } finally {
+      cur.close();
+    }
+  }
+}
+
+/**
+TODO
+
+Test for storing a record that will reconcile to mobile; postcondition is
+that there's still a directory called mobile that includes all the items that
+it used to.
+
+mobile folder created without title.
+Unsorted put in mobile???
+Tests for children retrieval
+Tests for children merge
+Tests for modify retrieve parent when child added, removed, reordered (oh, reorder is hard! Any change, then. )
+Safety mode?
+Test storing folder first, contents first.
+Store folder in next session. Verify order recovery.
+
+
+*/

--- a/test/src/org/mozilla/android/sync/test/BookmarkPositioningTest.java
+++ b/test/src/org/mozilla/android/sync/test/BookmarkPositioningTest.java
@@ -577,7 +577,7 @@ mobile folder created without title.
 Unsorted put in mobile???
 Tests for children retrieval
 Tests for children merge
-Tests for modify retrieve parent when child added, removed, reordered (oh, reorder is hard! Any change, then. )
+Tests for modify retrieve parent when child added, removed, reordered (oh, reorder is hard! Any change, then.)
 Safety mode?
 Test storing folder first, contents first.
 Store folder in next session. Verify order recovery.

--- a/test/src/org/mozilla/android/sync/test/helpers/BookmarkHelpers.java
+++ b/test/src/org/mozilla/android/sync/test/helpers/BookmarkHelpers.java
@@ -7,7 +7,9 @@ import org.json.simple.JSONArray;
 import org.mozilla.gecko.sync.Utils;
 import org.mozilla.gecko.sync.repositories.NullCursorException;
 import org.mozilla.gecko.sync.repositories.android.AndroidBrowserBookmarksDataAccessor;
+import org.mozilla.gecko.sync.repositories.android.AndroidBrowserBookmarksRepositorySession;
 import org.mozilla.gecko.sync.repositories.domain.BookmarkRecord;
+import org.mozilla.gecko.sync.repositories.domain.Record;
 
 import android.content.Context;
 import android.database.Cursor;
@@ -275,5 +277,28 @@ public class BookmarkHelpers {
     } finally {
       cur.close();
     }
+  }
+
+  /**
+   * Return an ExpectFetchDelegate with special folders excluded.
+   * @param expected
+   * @return
+   */
+  public static ExpectFetchDelegate preparedExpectFetchDelegate(Record[] expected) {
+    ExpectFetchDelegate delegate = new ExpectFetchDelegate(expected);
+    delegate.ignore.addAll(AndroidBrowserBookmarksRepositorySession.SPECIAL_GUIDS_MAP.keySet());
+    return delegate;
+  }
+
+  public static ExpectGuidsSinceDelegate preparedExpectGuidsSinceDelegate(String[] expected) {
+    ExpectGuidsSinceDelegate delegate = new ExpectGuidsSinceDelegate(expected);
+    delegate.ignore.addAll(AndroidBrowserBookmarksRepositorySession.SPECIAL_GUIDS_MAP.keySet());
+    return delegate;
+  }
+
+  public static ExpectFetchSinceDelegate preparedExpectFetchSinceDelegate(long timestamp, String[] expected) {
+    ExpectFetchSinceDelegate delegate = new ExpectFetchSinceDelegate(timestamp, expected);
+    delegate.ignore.addAll(AndroidBrowserBookmarksRepositorySession.SPECIAL_GUIDS_MAP.keySet());
+    return delegate;
   }
 }

--- a/test/src/org/mozilla/android/sync/test/helpers/DefaultFetchDelegate.java
+++ b/test/src/org/mozilla/android/sync/test/helpers/DefaultFetchDelegate.java
@@ -9,9 +9,10 @@ import static junit.framework.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
-import org.mozilla.gecko.sync.repositories.android.RepoUtils;
 import org.mozilla.gecko.sync.repositories.delegates.DeferredRepositorySessionFetchRecordsDelegate;
 import org.mozilla.gecko.sync.repositories.delegates.RepositorySessionFetchRecordsDelegate;
 import org.mozilla.gecko.sync.repositories.domain.Record;
@@ -23,7 +24,8 @@ public class DefaultFetchDelegate extends DefaultDelegate implements RepositoryS
 
   private static final String LOG_TAG = "DefaultFetchDelegate";
   public ArrayList<Record> records = new ArrayList<Record>();
-  
+  public Set<String> ignore = new HashSet<String>();
+
   @Override
   public void onFetchFailed(Exception ex, Record record) {
     sharedFail("Shouldn't fail");
@@ -47,8 +49,7 @@ public class DefaultFetchDelegate extends DefaultDelegate implements RepositoryS
       int expectedCount = 0;
       Log.d(LOG_TAG, "Counting expected keys.");
       for (String key : expected.keySet()) {
-        if (RepoUtils.SPECIAL_GUIDS_MAP == null ||
-            !RepoUtils.SPECIAL_GUIDS_MAP.containsKey(key)) {
+        if (!ignore.contains(key)) {
           expectedCount++;
         }
       }
@@ -57,9 +58,8 @@ public class DefaultFetchDelegate extends DefaultDelegate implements RepositoryS
         Log.d(LOG_TAG, "Record.");
         Log.d(LOG_TAG, record.guid);
 
-        // Ignore special guids for bookmarks
-        if (RepoUtils.SPECIAL_GUIDS_MAP == null ||
-            !RepoUtils.SPECIAL_GUIDS_MAP.containsKey(record.guid)) {
+        // Ignore special GUIDs (e.g., for bookmarks).
+        if (!ignore.contains(record.guid)) {
           Record expect = expected.get(record.guid);
           if (expect == null) {
             Log.d(LOG_TAG, "Failing.");

--- a/test/src/org/mozilla/android/sync/test/helpers/ExpectFetchSinceDelegate.java
+++ b/test/src/org/mozilla/android/sync/test/helpers/ExpectFetchSinceDelegate.java
@@ -8,9 +8,7 @@ import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
 
 import java.util.Arrays;
-import java.util.Map;
 
-import org.mozilla.gecko.sync.repositories.android.RepoUtils;
 import org.mozilla.gecko.sync.repositories.domain.Record;
 
 import junit.framework.AssertionFailedError;
@@ -32,10 +30,9 @@ public class ExpectFetchSinceDelegate extends DefaultFetchDelegate {
     AssertionFailedError err = null;
     try {
 
-      Map<String, String> specialGuids = RepoUtils.SPECIAL_GUIDS_MAP;
       int countSpecials = 0;
       for (Record record : records) {
-        if (specialGuids == null || !specialGuids.containsKey(record.guid)) {
+        if (!ignore.contains(record.guid)) {
           assertFalse(-1 == Arrays.binarySearch(this.expected, record.guid));
         } else {
           countSpecials++;

--- a/test/src/org/mozilla/android/sync/test/helpers/ExpectGuidsSinceDelegate.java
+++ b/test/src/org/mozilla/android/sync/test/helpers/ExpectGuidsSinceDelegate.java
@@ -7,6 +7,8 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 import android.util.Log;
 
@@ -14,6 +16,7 @@ import junit.framework.AssertionFailedError;
 
 public class ExpectGuidsSinceDelegate extends DefaultGuidsSinceDelegate {
   private String[] expected;
+  public Set<String> ignore = new HashSet<String>();
 
   public ExpectGuidsSinceDelegate(String[] guids) {
     expected = guids;
@@ -25,11 +28,14 @@ public class ExpectGuidsSinceDelegate extends DefaultGuidsSinceDelegate {
   public void onGuidsSinceSucceeded(String[] guids) {
     AssertionFailedError err = null;
     try {
-      assertEquals(this.expected.length, guids.length);
-
-      for (String string : guids) {
-        assertFalse(-1 == Arrays.binarySearch(this.expected, string));
+      int notIgnored = 0;
+      for (String guid : guids) {
+        if (!ignore.contains(guid)) {
+          notIgnored++;
+          assertFalse(-1 == Arrays.binarySearch(this.expected, guid));
+        }
       }
+      assertEquals(this.expected.length, notIgnored);
     } catch (AssertionFailedError e) {
       err = e;
     }

--- a/test/src/org/mozilla/android/sync/test/helpers/ExpectNoGUIDsSinceDelegate.java
+++ b/test/src/org/mozilla/android/sync/test/helpers/ExpectNoGUIDsSinceDelegate.java
@@ -5,23 +5,29 @@ package org.mozilla.android.sync.test.helpers;
 
 import static junit.framework.Assert.assertEquals;
 
-import org.mozilla.gecko.sync.repositories.android.RepoUtils;
+import java.util.HashSet;
+import java.util.Set;
+
+import android.util.Log;
 
 import junit.framework.AssertionFailedError;
 
 public class ExpectNoGUIDsSinceDelegate extends DefaultGuidsSinceDelegate {
   
+  public Set<String> ignore = new HashSet<String>();
+
   @Override
   public void onGuidsSinceSucceeded(String[] guids) {
     AssertionFailedError err = null;
     try {
-      boolean bookmarks = false;
+      int nonIgnored = 0;
       for (int i = 0; i < guids.length; i++) {
-        if(RepoUtils.SPECIAL_GUIDS_MAP.containsKey(guids[i])) {
-          bookmarks = true;
+        Log.i("BOOM", "Got " + guids[i]);
+        if (!ignore.contains(guids[i])) {
+          nonIgnored++;
         }
       }
-      assertEquals(0, bookmarks ? guids.length - 5 : guids.length);
+      assertEquals(0, nonIgnored);
     } catch (AssertionFailedError e) {
       err = e;
     }

--- a/test/src/org/mozilla/android/sync/test/helpers/ExpectOnlySpecialFoldersDelegate.java
+++ b/test/src/org/mozilla/android/sync/test/helpers/ExpectOnlySpecialFoldersDelegate.java
@@ -1,0 +1,30 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+package org.mozilla.android.sync.test.helpers;
+
+import static junit.framework.Assert.assertTrue;
+
+import java.util.Set;
+
+import junit.framework.AssertionFailedError;
+
+import org.mozilla.gecko.sync.repositories.android.AndroidBrowserBookmarksRepositorySession;
+
+public class ExpectOnlySpecialFoldersDelegate extends DefaultGuidsSinceDelegate {
+
+  public Set<String> expected = AndroidBrowserBookmarksRepositorySession.SPECIAL_GUIDS_MAP.keySet();
+
+  @Override
+  public void onGuidsSinceSucceeded(String[] guids) {
+    AssertionFailedError err = null;
+    try {
+      for (int i = 0; i < guids.length; i++) {
+        assertTrue(expected.contains(guids[i]));
+      }
+    } catch (AssertionFailedError e) {
+      err = e;
+    }
+    testWaiter().performNotify(err);
+  }
+}

--- a/test/src/org/mozilla/android/sync/test/helpers/simple/SimpleSuccessBeginDelegate.java
+++ b/test/src/org/mozilla/android/sync/test/helpers/simple/SimpleSuccessBeginDelegate.java
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */package org.mozilla.android.sync.test.helpers.simple;
+
+import java.util.concurrent.ExecutorService;
+
+import junit.framework.AssertionFailedError;
+
+import org.mozilla.android.sync.test.AndroidBrowserRepositoryTestHelper;
+import org.mozilla.gecko.sync.repositories.delegates.RepositorySessionBeginDelegate;
+
+public abstract class SimpleSuccessBeginDelegate implements RepositorySessionBeginDelegate {
+  @Override
+  public void onBeginFailed(Exception ex) {
+    final AssertionFailedError e = new AssertionFailedError("Begin failed: " + ex.getMessage());
+    e.initCause(ex);
+    AndroidBrowserRepositoryTestHelper.testWaiter.performNotify(e);
+  }
+
+  @Override
+  public RepositorySessionBeginDelegate deferredBeginDelegate(ExecutorService executor) {
+    return this;
+  }
+}

--- a/test/src/org/mozilla/android/sync/test/helpers/simple/SimpleSuccessCreationDelegate.java
+++ b/test/src/org/mozilla/android/sync/test/helpers/simple/SimpleSuccessCreationDelegate.java
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.android.sync.test.helpers.simple;
+
+import junit.framework.AssertionFailedError;
+
+import org.mozilla.android.sync.test.AndroidBrowserRepositoryTestHelper;
+import org.mozilla.gecko.sync.repositories.delegates.RepositorySessionCreationDelegate;
+
+import android.util.Log;
+
+public abstract class SimpleSuccessCreationDelegate implements RepositorySessionCreationDelegate {
+  @Override
+  public void onSessionCreateFailed(Exception ex) {
+    Log.w("SimpleSuccessCreationDelegate", "Session creation failed.", ex);
+    final AssertionFailedError e = new AssertionFailedError("Session creation failed: " + ex.getMessage());
+    e.initCause(ex);
+    AndroidBrowserRepositoryTestHelper.testWaiter.performNotify(e);
+  }
+
+  @Override
+  public RepositorySessionCreationDelegate deferredCreationDelegate() {
+    return this;
+  }
+}

--- a/test/src/org/mozilla/android/sync/test/helpers/simple/SimpleSuccessFetchDelegate.java
+++ b/test/src/org/mozilla/android/sync/test/helpers/simple/SimpleSuccessFetchDelegate.java
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */package org.mozilla.android.sync.test.helpers.simple;
+
+import java.util.concurrent.ExecutorService;
+
+import junit.framework.AssertionFailedError;
+
+import org.mozilla.android.sync.test.AndroidBrowserRepositoryTestHelper;
+import org.mozilla.gecko.sync.repositories.delegates.RepositorySessionFetchRecordsDelegate;
+import org.mozilla.gecko.sync.repositories.domain.Record;
+
+public abstract class SimpleSuccessFetchDelegate implements
+    RepositorySessionFetchRecordsDelegate {
+  @Override
+  public void onFetchFailed(Exception ex, Record record) {
+    final AssertionFailedError e = new AssertionFailedError("Fetch failed: " + ex.getMessage());
+    e.initCause(ex);
+    AndroidBrowserRepositoryTestHelper.testWaiter.performNotify(e);
+  }
+
+  @Override
+  public void onFetchSucceeded(Record[] records, long end) {
+    for (Record record : records) {
+      this.onFetchedRecord(record);
+    }
+    this.onFetchCompleted(end);
+  }
+
+  @Override
+  public RepositorySessionFetchRecordsDelegate deferredFetchDelegate(ExecutorService executor) {
+    return this;
+  }
+}

--- a/test/src/org/mozilla/android/sync/test/helpers/simple/SimpleSuccessFinishDelegate.java
+++ b/test/src/org/mozilla/android/sync/test/helpers/simple/SimpleSuccessFinishDelegate.java
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */package org.mozilla.android.sync.test.helpers.simple;
+
+import java.util.concurrent.ExecutorService;
+
+import junit.framework.AssertionFailedError;
+
+import org.mozilla.android.sync.test.AndroidBrowserRepositoryTestHelper;
+import org.mozilla.gecko.sync.repositories.delegates.RepositorySessionFinishDelegate;
+
+public abstract class SimpleSuccessFinishDelegate implements RepositorySessionFinishDelegate {
+  @Override
+  public void onFinishFailed(Exception ex) {
+    final AssertionFailedError e = new AssertionFailedError("Finish failed: " + ex.getMessage());
+    e.initCause(ex);
+    AndroidBrowserRepositoryTestHelper.testWaiter.performNotify(e);
+  }
+
+  @Override
+  public RepositorySessionFinishDelegate deferredFinishDelegate(ExecutorService executor) {
+    return this;
+  }
+}

--- a/test/src/org/mozilla/android/sync/test/helpers/simple/SimpleSuccessStoreDelegate.java
+++ b/test/src/org/mozilla/android/sync/test/helpers/simple/SimpleSuccessStoreDelegate.java
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */package org.mozilla.android.sync.test.helpers.simple;
+
+import java.util.concurrent.ExecutorService;
+
+import junit.framework.AssertionFailedError;
+
+import org.mozilla.android.sync.test.AndroidBrowserRepositoryTestHelper;
+import org.mozilla.gecko.sync.repositories.delegates.RepositorySessionStoreDelegate;
+
+import android.util.Log;
+
+public abstract class SimpleSuccessStoreDelegate implements RepositorySessionStoreDelegate {
+  @Override
+  public void onRecordStoreFailed(Exception ex) {
+    Log.w("SimpleSuccessStoreDelegate", "Store failed.", ex);
+    final AssertionFailedError e = new AssertionFailedError("Store failed: " + ex.getMessage());
+    e.initCause(ex);
+    AndroidBrowserRepositoryTestHelper.testWaiter.performNotify(e);
+  }
+
+  @Override
+  public RepositorySessionStoreDelegate deferredStoreDelegate(ExecutorService executor) {
+    return this;
+  }
+}


### PR DESCRIPTION
Handling of deletion etc.

Prerequisite is bulk-reparenting (Bug 728783).

Note that this branch does not handle folder deletion. There are holes, remaining bugs I'm sure, test coverage isn't perfect, and some inefficiencies (though not as many as you might think).

Still, it's a vast improvement over what we have, so this will do for now.

This is designed to land in four chunks; if a commit doesn't have its own "Bug …" prefix, it's going to get collapsed up.

The chunks are not necessarily independent, but they have some amount of conceptual separation.
