### PR TITLE
Bug 705767: Validate credentials before completing classic setup + rebase

### DIFF
--- a/res/layout/sync_account.xml
+++ b/res/layout/sync_account.xml
@@ -61,6 +61,7 @@
     android:orientation="horizontal" >
 
     <Button
+      android:id="@+id/accountCancelButton"
       style="@style/SyncButton"
       android:onClick="cancelClickHandler"
       android:text="@string/sync_button_cancel" />

--- a/res/layout/sync_setup.xml
+++ b/res/layout/sync_setup.xml
@@ -76,8 +76,7 @@
     style="@style/SyncBottom"
     android:orientation="horizontal" >
     <Button
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
+      style="@style/SyncButton"
       android:onClick="cancelClickHandler"
       android:text="@string/sync_button_cancel" />
   </LinearLayout>

--- a/res/layout/sync_setup_failure.xml
+++ b/res/layout/sync_setup_failure.xml
@@ -23,22 +23,17 @@
     android:orientation="horizontal" >
 
     <Button
-      android:layout_width="fill_parent"
-      android:layout_height="wrap_content"
-      android:layout_weight="1"
+      style="@style/SyncButton"
       android:onClick="tryAgainClickHandler"
       android:text="@string/sync_button_tryagain" />
 
     <Button
-      android:layout_width="fill_parent"
-      android:layout_height="wrap_content"
-      android:layout_weight="1"
+      style="@style/SyncButton"
       android:onClick="manualClickHandler"
       android:text="@string/sync_button_manual" />
+
      <Button
-      android:layout_width="fill_parent"
-      android:layout_height="wrap_content"
-      android:layout_weight="1"
+      style="@style/SyncButton"
       android:onClick="cancelClickHandler"
       android:text="@string/sync_button_cancel" />
   </LinearLayout>

--- a/res/values/sync_styles.xml
+++ b/res/values/sync_styles.xml
@@ -63,6 +63,7 @@
     <style name="SyncBottom">
     <item name="android:layout_width">fill_parent</item>
     <item name="android:layout_height">wrap_content</item>
+    <item name="android:layout_gravity">center</item>
     <item name="android:gravity">center</item>
     <item name="android:layout_alignParentBottom">true</item>
     <item name="android:background">@android:drawable/bottom_bar</item>

--- a/res/values/sync_styles.xml
+++ b/res/values/sync_styles.xml
@@ -39,6 +39,7 @@
     <item name="android:layout_width">fill_parent</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:singleLine">true</item>
+    <item name="android:inputType">textNoSuggestions</item>
   </style>
   <style name="SyncEditPin" parent="@style/SyncEditItem">
     <item name="android:layout_width">wrap_content</item>

--- a/src/main/java/org/mozilla/gecko/sync/setup/AccountCreator.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/AccountCreator.java
@@ -34,7 +34,7 @@ public class AccountCreator {
     Logger.info(LOG_TAG, "Adding account for " + Constants.ACCOUNTTYPE_SYNC);
     boolean result = false;
     try { // Bug 709879: Handle error during creation of account.
-      accountManager.addAccountExplicitly(account, password, userbundle);
+      result = accountManager.addAccountExplicitly(account, password, userbundle);
     } catch (SQLiteDiskIOException e) {
       Logger.warn(LOG_TAG, "Could not add account: SQLite error.", e);
       return null;

--- a/src/main/java/org/mozilla/gecko/sync/setup/AccountCreator.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/AccountCreator.java
@@ -1,0 +1,65 @@
+package org.mozilla.gecko.sync.setup;
+
+import org.mozilla.gecko.sync.Logger;
+import org.mozilla.gecko.sync.Utils;
+import org.mozilla.gecko.sync.repositories.android.Authorities;
+
+import android.accounts.Account;
+import android.accounts.AccountManager;
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+
+public class AccountCreator {
+  private static final String LOG_TAG = "AccountCreator";
+
+  public static Intent createAccount(Context context,
+      AccountManager accountManager, String username, String syncKey,
+      String password, String serverURL) {
+
+    final Account account = new Account(username, Constants.ACCOUNTTYPE_SYNC);
+    final Bundle userbundle = new Bundle();
+
+    // Add sync key and server URL.
+    userbundle.putString(Constants.OPTION_SYNCKEY, syncKey);
+    if (serverURL != null) {
+      Logger.info(LOG_TAG, "Setting explicit server URL: " + serverURL);
+      userbundle.putString(Constants.OPTION_SERVER, serverURL);
+    } else {
+      userbundle.putString(Constants.OPTION_SERVER, Constants.AUTH_NODE_DEFAULT);
+    }
+    Logger.info(LOG_TAG, "Adding account for " + Constants.ACCOUNTTYPE_SYNC);
+    boolean result = accountManager.addAccountExplicitly(account, password,
+        userbundle);
+
+    Logger.info(LOG_TAG, "Account: " + account.toString() +
+                         " added successfully? " + result);
+    if (!result) {
+      Logger.error(LOG_TAG, "Error adding account!");
+    }
+
+    // Set components to sync (default: all).
+    ContentResolver.setMasterSyncAutomatically(true);
+    ContentResolver.setSyncAutomatically(account,
+        Authorities.BROWSER_AUTHORITY, true);
+
+    // TODO: add other ContentProviders as needed (e.g. passwords)
+    // TODO: for each, also add to res/xml to make visible in account settings
+    Logger.debug(LOG_TAG, "Finished setting syncables.");
+
+    // TODO: correctly implement Sync Options.
+    Logger.info(LOG_TAG, "Clearing preferences for this account.");
+    try {
+      Utils.getSharedPreferences(context, username, serverURL).edit().clear().commit();
+    } catch (Exception e) {
+      Logger.error(LOG_TAG, "Could not clear prefs path!", e);
+    }
+
+    final Intent intent = new Intent();
+    intent.putExtra(AccountManager.KEY_ACCOUNT_NAME, username);
+    intent.putExtra(AccountManager.KEY_ACCOUNT_TYPE, Constants.ACCOUNTTYPE_SYNC);
+    intent.putExtra(AccountManager.KEY_AUTHTOKEN,    Constants.ACCOUNTTYPE_SYNC);
+    return intent;
+  }
+}

--- a/src/main/java/org/mozilla/gecko/sync/setup/Constants.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/Constants.java
@@ -56,6 +56,17 @@ public class Constants {
     Intent.FLAG_ACTIVITY_REORDER_TO_FRONT |
     Intent.FLAG_ACTIVITY_NO_ANIMATION;
 
+  // Constants for Account Authentication.
+  public static final String AUTH_NODE_DEFAULT    = "https://auth.services.mozilla.com/";
+  public static final String AUTH_NODE_PATHNAME   = "user/";
+  public static final String AUTH_NODE_VERSION    = "1.0/";
+  public static final String AUTH_NODE_SUFFIX     = "node/weave";
+  public static final String AUTH_SERVER_VERSION  = "1.1/";
+  public static final String AUTH_SERVER_SUFFIX   = "info/collections/";
+
+  // Account Authentication Errors.
+  public static final String AUTH_ERROR_NOUSER    = "auth.error.badcredentials";
+
   // Links for J-PAKE setup help pages.
   public static final String LINK_FIND_CODE       = "https://support.mozilla.org/kb/find-code-to-add-device-to-firefox-sync";
   public static final String LINK_FIND_ADD_DEVICE = "https://support.mozilla.org/kb/add-a-device-to-firefox-sync";

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
@@ -156,11 +156,8 @@ public class AccountActivity extends AccountAuthenticatorActivity {
   }
 
   private void clearCredentials() {
-    // Start with an empty form
-    usernameInput.setText("");
+    // Only clear password. Re-typing the sync key or email is annoying.
     passwordInput.setText("");
-    passwordInput.setText("");
-    // Don't clear sync key until exiting.
   }
 
   /*

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
@@ -43,6 +43,7 @@ import java.util.Locale;
 import org.mozilla.gecko.R;
 import org.mozilla.gecko.sync.setup.AccountCreator;
 import org.mozilla.gecko.sync.setup.Constants;
+import org.mozilla.gecko.sync.setup.auth.AccountAuthenticator;
 
 import android.accounts.AccountAuthenticatorActivity;
 import android.accounts.AccountManager;
@@ -158,11 +159,10 @@ public class AccountActivity extends AccountAuthenticatorActivity {
       }
     }
     enableCredEntry(false);
+    activateView(connectButton, false);
 
-    // TODO : Authenticate with Sync Service, once implemented, with
-    // onAuthSuccess as callback
-
-    authCallback();
+    AccountAuthenticator accountAuth = new AccountAuthenticator(this);
+    accountAuth.authenticate(server, username, password);
   }
 
   /* Helper UI functions */
@@ -208,19 +208,25 @@ public class AccountActivity extends AccountAuthenticatorActivity {
   /*
    * Callback that handles auth based on success/failure
    */
-  private void authCallback() {
-    // Create and add account to AccountManager
-    // TODO: only allow one account to be added?
+  public void authCallback(boolean isSuccess) {
+    if (!isSuccess) {
+      Log.d(LOG_TAG, "not successful");
+      runOnUiThread(new Runnable() {
+        @Override
+        public void run() {
+          authFailure();
+        }
+      });
+      return;
+    }
+
+    // Successful authentication. Create and add account to AccountManager.
+    // Note: Sync key may incorrect!
     Log.d(LOG_TAG, "Using account manager " + mAccountManager);
     final Intent intent = AccountCreator.createAccount(mContext, mAccountManager,
                                         username,
                                         key, password, server);
     setAccountAuthenticatorResult(intent.getExtras());
-
-    // TODO: Currently, we do not actually authenticate username/pass against
-    // Moz sync server.
-
-    // Successful authentication result
     setResult(RESULT_OK, intent);
 
     runOnUiThread(new Runnable() {
@@ -231,14 +237,21 @@ public class AccountActivity extends AccountAuthenticatorActivity {
     });
   }
 
-  private void authFailure() {
+  /**
+   * Feedback to user of account setup failure.
+   */
+  public void authFailure() {
     enableCredEntry(true);
     Intent intent = new Intent(mContext, SetupFailureActivity.class);
     intent.setFlags(Constants.FLAG_ACTIVITY_REORDER_TO_FRONT_NO_ANIMATION);
     startActivity(intent);
   }
 
-  private void authSuccess() {
+  /**
+   * Feedback to user of account setup success.
+   */
+  public void authSuccess() {
+    // Display feedback of successful account setup.
     Intent intent = new Intent(mContext, SetupSuccessActivity.class);
     intent.setFlags(Constants.FLAG_ACTIVITY_REORDER_TO_FRONT_NO_ANIMATION);
     startActivity(intent);

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
@@ -193,6 +193,12 @@ public class AccountActivity extends AccountAuthenticatorActivity {
       @Override
       public void onClick(View v) {
         cancelConnectHandler(v);
+        // Set cancel click handler to leave account setup.
+        cancelButton.setOnClickListener(new OnClickListener() {
+          public void onClick(View v) {
+            cancelClickHandler(v);
+          }
+        });
       }
     });
 

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
@@ -41,14 +41,11 @@ package org.mozilla.gecko.sync.setup.activities;
 import java.util.Locale;
 
 import org.mozilla.gecko.R;
-import org.mozilla.gecko.sync.Utils;
-import org.mozilla.gecko.sync.repositories.android.Authorities;
+import org.mozilla.gecko.sync.setup.AccountCreator;
 import org.mozilla.gecko.sync.setup.Constants;
 
-import android.accounts.Account;
 import android.accounts.AccountAuthenticatorActivity;
 import android.accounts.AccountManager;
-import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
@@ -65,14 +62,12 @@ import android.widget.EditText;
 public class AccountActivity extends AccountAuthenticatorActivity {
   private final static String LOG_TAG        = "AccountActivity";
 
-  private final static String DEFAULT_SERVER = "https://auth.services.mozilla.com/";
-
   private AccountManager      mAccountManager;
   private Context             mContext;
   private String              username;
   private String              password;
   private String              key;
-  private String              server;
+  private String              server = Constants.AUTH_NODE_DEFAULT;
 
   // UI elements.
   private EditText            serverInput;
@@ -205,13 +200,10 @@ public class AccountActivity extends AccountAuthenticatorActivity {
     // Create and add account to AccountManager
     // TODO: only allow one account to be added?
     Log.d(LOG_TAG, "Using account manager " + mAccountManager);
-    final Intent intent = createAccount(mContext, mAccountManager,
+    final Intent intent = AccountCreator.createAccount(mContext, mAccountManager,
                                         username,
                                         key, password, server);
     setAccountAuthenticatorResult(intent.getExtras());
-
-    // Testing out the authFailure case
-    // authFailure();
 
     // TODO: Currently, we do not actually authenticate username/pass against
     // Moz sync server.
@@ -227,58 +219,6 @@ public class AccountActivity extends AccountAuthenticatorActivity {
     });
   }
 
-  // TODO: lift this out.
-  public static Intent createAccount(Context context,
-                                     AccountManager accountManager,
-                                     String username,
-                                     String syncKey,
-                                     String password,
-                                     String serverURL) {
-
-    final Account account = new Account(username, Constants.ACCOUNTTYPE_SYNC);
-    final Bundle userbundle = new Bundle();
-
-    // Add sync key and server URL.
-    userbundle.putString(Constants.OPTION_SYNCKEY, syncKey);
-    if (serverURL != null) {
-      Log.i(LOG_TAG, "Setting explicit server URL: " + serverURL);
-      userbundle.putString(Constants.OPTION_SERVER, serverURL);
-    } else {
-      userbundle.putString(Constants.OPTION_SERVER, DEFAULT_SERVER);
-    }
-    Log.d(LOG_TAG, "Adding account for " + Constants.ACCOUNTTYPE_SYNC);
-    boolean result = accountManager.addAccountExplicitly(account, password, userbundle);
-
-    Log.d(LOG_TAG, "Account: " + account + " added successfully? " + result);
-    if (!result) {
-      Log.e(LOG_TAG, "Error adding account!");
-    }
-
-    // Set components to sync (default: all).
-    ContentResolver.setMasterSyncAutomatically(true);
-    ContentResolver.setSyncAutomatically(account, Authorities.BROWSER_AUTHORITY, true);
-    ContentResolver.setIsSyncable(account, Authorities.BROWSER_AUTHORITY, 1);
-
-    // TODO: add other ContentProviders as needed (e.g. passwords)
-    // TODO: for each, also add to res/xml to make visible in account settings
-    Log.d(LOG_TAG, "Finished setting syncables.");
-
-    // TODO: correctly implement Sync Options.
-    Log.i(LOG_TAG, "Clearing preferences for this account.");
-    try {
-      Utils.getSharedPreferences(context, username, serverURL).edit().clear().commit();
-    } catch (Exception e) {
-      Log.e(LOG_TAG, "Could not clear prefs path!", e);
-    }
-
-    final Intent intent = new Intent();
-    intent.putExtra(AccountManager.KEY_ACCOUNT_NAME, username);
-    intent.putExtra(AccountManager.KEY_ACCOUNT_TYPE, Constants.ACCOUNTTYPE_SYNC);
-    intent.putExtra(AccountManager.KEY_AUTHTOKEN, Constants.ACCOUNTTYPE_SYNC);
-    return intent;
-  }
-
-  @SuppressWarnings("unused")
   private void authFailure() {
     enableCredEntry(true);
     Intent intent = new Intent(mContext, SetupFailureActivity.class);

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
@@ -54,6 +54,7 @@ import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.Log;
 import android.view.View;
+import android.view.View.OnClickListener;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
@@ -77,6 +78,9 @@ public class AccountActivity extends AccountAuthenticatorActivity {
   private EditText            synckeyInput;
   private CheckBox            serverCheckbox;
   private Button              connectButton;
+  private Button              cancelButton;
+
+  private AccountAuthenticator accountAuthenticator;
 
   @Override
   public void onCreate(Bundle savedInstanceState) {
@@ -101,6 +105,7 @@ public class AccountActivity extends AccountAuthenticatorActivity {
     serverInput.addTextChangedListener(inputValidator);
 
     connectButton = (Button) findViewById(R.id.accountConnectButton);
+    cancelButton = (Button) findViewById(R.id.accountCancelButton);
     serverCheckbox = (CheckBox) findViewById(R.id.checkbox_server);
 
     serverCheckbox.setOnCheckedChangeListener(new OnCheckedChangeListener() {
@@ -121,17 +126,41 @@ public class AccountActivity extends AccountAuthenticatorActivity {
   }
 
   @Override
-  public void onStart() {
-    super.onStart();
+  public void onResume() {
+    super.onResume();
+    clearCredentials();
+    usernameInput.requestFocus();
+    enableCredEntry(true);
+    cancelButton.setOnClickListener(new OnClickListener() {
+
+      @Override
+      public void onClick(View v) {
+        cancelClickHandler(v);
+      }
+
+    });
+  }
+  public void cancelClickHandler(View target) {
+    finish();
+  }
+
+  public void cancelConnectHandler(View target) {
+    if (accountAuthenticator != null) {
+      accountAuthenticator.isCanceled = true;
+      accountAuthenticator = null;
+    }
+    enableCredEntry(true);
+    activateView(connectButton, true);
+    clearCredentials();
+    usernameInput.requestFocus();
+  }
+
+  private void clearCredentials() {
     // Start with an empty form
     usernameInput.setText("");
     passwordInput.setText("");
-    synckeyInput.setText("");
     passwordInput.setText("");
-  }
-
-  public void cancelClickHandler(View target) {
-    finish();
+    // Don't clear sync key until exiting.
   }
 
   /*
@@ -160,9 +189,16 @@ public class AccountActivity extends AccountAuthenticatorActivity {
     }
     enableCredEntry(false);
     activateView(connectButton, false);
+    cancelButton.setOnClickListener(new OnClickListener() {
 
-    AccountAuthenticator accountAuth = new AccountAuthenticator(this);
-    accountAuth.authenticate(server, username, password);
+      @Override
+      public void onClick(View v) {
+        cancelConnectHandler(v);
+      }
+    });
+
+    accountAuthenticator = new AccountAuthenticator(this);
+    accountAuthenticator.authenticate(server, username, password);
   }
 
   /* Helper UI functions */
@@ -170,6 +206,7 @@ public class AccountActivity extends AccountAuthenticatorActivity {
     usernameInput.setEnabled(toEnable);
     passwordInput.setEnabled(toEnable);
     synckeyInput.setEnabled(toEnable);
+    serverCheckbox.setEnabled(toEnable);
     if (!toEnable) {
       serverInput.setEnabled(toEnable);
     } else {
@@ -241,7 +278,6 @@ public class AccountActivity extends AccountAuthenticatorActivity {
    * Feedback to user of account setup failure.
    */
   public void authFailure() {
-    enableCredEntry(true);
     Intent intent = new Intent(mContext, SetupFailureActivity.class);
     intent.setFlags(Constants.FLAG_ACTIVITY_REORDER_TO_FRONT_NO_ANIMATION);
     startActivity(intent);

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
@@ -141,9 +141,21 @@ public class AccountActivity extends AccountAuthenticatorActivity {
     Log.d(LOG_TAG, "connectClickHandler for view " + target);
     username = usernameInput.getText().toString().toLowerCase(Locale.US);
     password = passwordInput.getText().toString();
-    key = synckeyInput.getText().toString();
+    key      = synckeyInput.getText().toString();
+
     if (serverCheckbox.isChecked()) {
-      server = serverInput.getText().toString();
+      String userServer = serverInput.getText().toString();
+      if (userServer != null) {
+        userServer = userServer.trim();
+        if (userServer.length() != 0) {
+          if (!userServer.startsWith("https://") &&
+              !userServer.startsWith("http://")) {
+            // Assume HTTPS if not specified.
+            userServer = "https://" + userServer;
+          }
+          server = userServer;
+        }
+      }
     }
     enableCredEntry(false);
 

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupFailureActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupFailureActivity.java
@@ -69,6 +69,7 @@ public class SetupFailureActivity extends Activity {
 
   public void cancelClickHandler(View target) {
     setResult(RESULT_CANCELED);
+    moveTaskToBack(true);
     finish();
   }
 }

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSyncActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSyncActivity.java
@@ -12,6 +12,7 @@ import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.ThreadPool;
 import org.mozilla.gecko.sync.jpake.JPakeClient;
 import org.mozilla.gecko.sync.jpake.JPakeNoActivePairingException;
+import org.mozilla.gecko.sync.setup.AccountCreator;
 import org.mozilla.gecko.sync.setup.Constants;
 
 import android.accounts.Account;
@@ -362,7 +363,7 @@ public class SetupSyncActivity extends AccountAuthenticatorActivity {
       String serverURL    = (String) jCreds.get(Constants.JSON_KEY_SERVER);
 
       Logger.debug(LOG_TAG, "Using account manager " + mAccountManager);
-      final Intent intent = AccountActivity.createAccount(mContext, mAccountManager,
+      final Intent intent = AccountCreator.createAccount(mContext, mAccountManager,
                                                           accountName,
                                                           syncKey, password, serverURL);
       setAccountAuthenticatorResult(intent.getExtras());

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/AccountAuthenticator.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/AccountAuthenticator.java
@@ -5,11 +5,10 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.ThreadPool;
 import org.mozilla.gecko.sync.Utils;
 import org.mozilla.gecko.sync.setup.activities.AccountActivity;
-
-import android.util.Log;
 
 public class AccountAuthenticator {
   private final String LOG_TAG = "AccountSetupAuthenticator";
@@ -57,7 +56,7 @@ public class AccountAuthenticator {
     } catch (UnsupportedEncodingException e) {
       abort("Username hash error.", e);
     }
-    Log.d(LOG_TAG, "usernameHash:" + usernameHash);
+    Logger.debug(LOG_TAG, "usernameHash:" + usernameHash);
 
     // Start first stage of authentication.
     runNextStage();
@@ -77,7 +76,7 @@ public class AccountAuthenticator {
     try {
       stages.get(stageIndex).execute(this);
     } catch (Exception e) {
-      Log.w(LOG_TAG, "Exception in stage " + stages.get(stageIndex));
+      Logger.warn(LOG_TAG, "Exception in stage " + stages.get(stageIndex));
       abort("Stage exception.", e);
     }
   }
@@ -94,7 +93,7 @@ public class AccountAuthenticator {
     if (isCanceled) {
       return;
     }
-    Log.w(LOG_TAG, reason, e);
+    Logger.warn(LOG_TAG, reason, e);
     activityCallback.authCallback(false);
   }
 

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/AccountAuthenticator.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/AccountAuthenticator.java
@@ -26,6 +26,7 @@ public class AccountAuthenticator {
   public String nodeServer;
 
   public boolean isSuccess = false;
+  public boolean isCanceled = false;
 
   public AccountAuthenticator(AccountActivity activity) {
     activityCallback = activity;
@@ -64,6 +65,9 @@ public class AccountAuthenticator {
    * Run next stage of authentication.
    */
   public void runNextStage() {
+    if (isCanceled) {
+      return;
+    }
     if (++stageIndex == stages.size()) {
       activityCallback.authCallback(isSuccess);
       return;
@@ -85,6 +89,9 @@ public class AccountAuthenticator {
    *    Reason for abort.
    */
   public void abort(String reason, Exception e) {
+    if (isCanceled) {
+      return;
+    }
     Log.w(LOG_TAG, reason, e);
     activityCallback.authCallback(false);
   }

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/AccountAuthenticator.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/AccountAuthenticator.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.gecko.sync.setup.auth;
 
 import java.io.UnsupportedEncodingException;

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/AccountAuthenticator.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/AccountAuthenticator.java
@@ -1,0 +1,92 @@
+package org.mozilla.gecko.sync.setup.auth;
+
+import java.io.UnsupportedEncodingException;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.mozilla.gecko.sync.Utils;
+import org.mozilla.gecko.sync.setup.activities.AccountActivity;
+
+import android.util.Log;
+
+public class AccountAuthenticator {
+  private final String LOG_TAG = "AccountSetupAuthenticator";
+
+  private AccountActivity activityCallback;
+  private List<AuthenticatorStage> stages;
+
+  private int stageIndex = -1; // Stages not started.
+
+  // Values for authentication.
+  public String password;
+  public String usernameHash;
+
+  public String authServer;
+  public String nodeServer;
+
+  public boolean isSuccess = false;
+
+  public AccountAuthenticator(AccountActivity activity) {
+    activityCallback = activity;
+    prepareStages();
+  }
+
+  private void prepareStages() {
+    stages = new ArrayList<AuthenticatorStage>();
+    stages.add(new FetchUserNodeStage());
+    stages.add(new AuthenticateAccountStage());
+  }
+
+  public void authenticate(String server, String username, String password) {
+    // Set authentication values.
+    if (!server.endsWith("/")) {
+      server += "/";
+    }
+    nodeServer = server;
+    this.password = password;
+
+    // Calculate and save username hash.
+    try {
+      usernameHash = Utils.sha1Base32(username.toLowerCase()).toLowerCase();
+    } catch (NoSuchAlgorithmException e) {
+      abort("Username hash error.", e);
+    } catch (UnsupportedEncodingException e) {
+      abort("Username hash error.", e);
+    }
+    Log.d(LOG_TAG, "usernameHash:" + usernameHash);
+
+    // Start first stage of authentication.
+    runNextStage();
+  }
+
+  /**
+   * Run next stage of authentication.
+   */
+  public void runNextStage() {
+    if (++stageIndex == stages.size()) {
+      activityCallback.authCallback(isSuccess);
+      return;
+    }
+    try {
+      stages.get(stageIndex).execute(this);
+    } catch (Exception e) {
+      Log.w(LOG_TAG, "Exception in stage " + stages.get(stageIndex));
+      abort("Stage exception.", e);
+    }
+  }
+
+  /**
+   * Abort authentication.
+   *
+   * @param e
+   *    Exception causing abort.
+   * @param reason
+   *    Reason for abort.
+   */
+  public void abort(String reason, Exception e) {
+    Log.w(LOG_TAG, reason, e);
+    activityCallback.authCallback(false);
+  }
+
+}

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/AccountAuthenticator.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/AccountAuthenticator.java
@@ -5,6 +5,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.mozilla.gecko.sync.ThreadPool;
 import org.mozilla.gecko.sync.Utils;
 import org.mozilla.gecko.sync.setup.activities.AccountActivity;
 
@@ -35,6 +36,7 @@ public class AccountAuthenticator {
 
   private void prepareStages() {
     stages = new ArrayList<AuthenticatorStage>();
+    stages.add(new EnsureUserExistenceStage());
     stages.add(new FetchUserNodeStage());
     stages.add(new AuthenticateAccountStage());
   }
@@ -96,4 +98,8 @@ public class AccountAuthenticator {
     activityCallback.authCallback(false);
   }
 
+  /* Helper functions */
+  public static void runOnThread(Runnable run) {
+    ThreadPool.run(run);
+  }
 }

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/AuthenticateAccountStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/AuthenticateAccountStage.java
@@ -68,6 +68,7 @@ public class AuthenticateAccountStage implements AuthenticatorStage {
     String authHash = Base64.encodeToString((aa.usernameHash + ":" + aa.password).getBytes(), Base64.DEFAULT);
     String authRequestUrl = aa.authServer + Constants.AUTH_SERVER_VERSION + aa.usernameHash + "/" + Constants.AUTH_SERVER_SUFFIX;
     authenticateAccount(callbackDelegate, authRequestUrl, authHash);
+
   }
 
   private void authenticateAccount(final AuthenticateAccountStageDelegate callbackDelegate, final String authRequestUrl, final String authHeader) throws URISyntaxException {

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/AuthenticateAccountStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/AuthenticateAccountStage.java
@@ -1,0 +1,140 @@
+package org.mozilla.gecko.sync.setup.auth;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.GeneralSecurityException;
+
+import org.mozilla.gecko.sync.ThreadPool;
+import org.mozilla.gecko.sync.net.BaseResource;
+import org.mozilla.gecko.sync.net.SyncResourceDelegate;
+import org.mozilla.gecko.sync.net.SyncStorageRequest;
+import org.mozilla.gecko.sync.setup.Constants;
+
+import android.util.Base64;
+import android.util.Log;
+import ch.boye.httpclientandroidlib.HeaderIterator;
+import ch.boye.httpclientandroidlib.HttpResponse;
+import ch.boye.httpclientandroidlib.client.ClientProtocolException;
+import ch.boye.httpclientandroidlib.client.methods.HttpRequestBase;
+import ch.boye.httpclientandroidlib.conn.params.ConnConnectionPNames;
+import ch.boye.httpclientandroidlib.impl.client.DefaultHttpClient;
+import ch.boye.httpclientandroidlib.message.BasicHeader;
+
+public class AuthenticateAccountStage implements AuthenticatorStage {
+  private final String LOG_TAG = "AuthenticateAccountStage";
+
+  public interface AuthenticateAccountStageDelegate {
+    public void handleSuccess(boolean isSuccess);
+    public void handleFailure(HttpResponse response);
+    public void handleError(Exception e);
+  }
+
+  @Override
+  public void execute(final AccountAuthenticator aa) throws URISyntaxException, UnsupportedEncodingException {
+    AuthenticateAccountStageDelegate callbackDelegate = new AuthenticateAccountStageDelegate() {
+
+      @Override
+      public void handleSuccess(boolean isSuccess) {
+        aa.isSuccess = isSuccess;
+        aa.runNextStage();
+      }
+
+      @Override
+      public void handleFailure(HttpResponse response) {
+        Log.d(LOG_TAG, "handleFailure");
+        aa.abort(response.toString(), new Exception(response.getStatusLine().getStatusCode() + " error."));
+        try {
+          BufferedReader reader = new BufferedReader(new InputStreamReader(response.getEntity().getContent(), "UTF-8"));
+          Log.w(LOG_TAG, "content: " + reader.readLine());
+          SyncResourceDelegate.consumeReader(reader);
+          reader.close();
+          SyncResourceDelegate.consumeEntity(response.getEntity());
+        } catch (IllegalStateException e) {
+          Log.d(LOG_TAG, "Error reading content.", e);
+        } catch (IOException e) {
+          Log.d(LOG_TAG, "Error reading content.", e);
+        }
+      }
+
+      @Override
+      public void handleError(Exception e) {
+        Log.d(LOG_TAG, "handleError");
+        aa.abort("HTTP failure.", e);
+      }
+    };
+
+    // Calculate BasicAuth hash of username/password.
+    String authHash = Base64.encodeToString((aa.usernameHash + ":" + aa.password).getBytes(), Base64.DEFAULT);
+    String authRequestUrl = aa.authServer + Constants.AUTH_SERVER_VERSION + aa.usernameHash + "/" + Constants.AUTH_SERVER_SUFFIX;
+    authenticateAccount(callbackDelegate, authRequestUrl, authHash);
+  }
+
+  private void authenticateAccount(final AuthenticateAccountStageDelegate callbackDelegate, final String authRequestUrl, final String authHeader) throws URISyntaxException {
+    final BaseResource httpResource = new BaseResource(authRequestUrl);
+    httpResource.delegate = new SyncResourceDelegate(httpResource) {
+
+      @Override
+      public void addHeaders(HttpRequestBase request, DefaultHttpClient client) {
+
+        client.log.enableDebug(true);
+        request.setHeader(new BasicHeader("User-Agent", SyncStorageRequest.USER_AGENT));
+        // Host header is not set for some reason, so do it explicitly.
+        try {
+          URI authServerUri = new URI(authRequestUrl);
+          request.setHeader(new BasicHeader("Host", authServerUri.getHost()));
+        } catch (URISyntaxException e) {
+          Log.e(LOG_TAG, "Malformed uri, will be caught elsewhere.", e);
+        }
+        request.setHeader(new BasicHeader("Authorization", "Basic " + authHeader));
+      }
+
+      @Override
+      public void handleHttpResponse(HttpResponse response) {
+        int statusCode = response.getStatusLine().getStatusCode();
+        switch(statusCode) {
+        case 200:
+          callbackDelegate.handleSuccess(true);
+          SyncResourceDelegate.consumeEntity(response.getEntity());
+          break;
+        case 401:
+          callbackDelegate.handleSuccess(false);
+          SyncResourceDelegate.consumeEntity(response.getEntity());
+          break;
+        default:
+          callbackDelegate.handleFailure(response);
+        }
+      }
+
+      @Override
+      public void handleHttpProtocolException(ClientProtocolException e) {
+        Log.e(LOG_TAG, "Client protocol error.");
+        callbackDelegate.handleError(e);
+      }
+
+      @Override
+      public void handleHttpIOException(IOException e) {
+        callbackDelegate.handleError(e);
+      }
+
+      @Override
+      public void handleTransportException(GeneralSecurityException e) {
+        callbackDelegate.handleError(e);
+      }
+    };
+
+    runOnThread(new Runnable() {
+      @Override
+      public void run() {
+        httpResource.get();
+      }
+    });
+  }
+
+  private static void runOnThread(Runnable run) {
+    ThreadPool.run(run);
+  }
+}

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/AuthenticateAccountStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/AuthenticateAccountStage.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.gecko.sync.setup.auth;
 
 import java.io.BufferedReader;

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/AuthenticateAccountStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/AuthenticateAccountStage.java
@@ -8,6 +8,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 
+import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.ThreadPool;
 import org.mozilla.gecko.sync.net.BaseResource;
 import org.mozilla.gecko.sync.net.SyncResourceDelegate;
@@ -15,12 +16,9 @@ import org.mozilla.gecko.sync.net.SyncStorageRequest;
 import org.mozilla.gecko.sync.setup.Constants;
 
 import android.util.Base64;
-import android.util.Log;
-import ch.boye.httpclientandroidlib.HeaderIterator;
 import ch.boye.httpclientandroidlib.HttpResponse;
 import ch.boye.httpclientandroidlib.client.ClientProtocolException;
 import ch.boye.httpclientandroidlib.client.methods.HttpRequestBase;
-import ch.boye.httpclientandroidlib.conn.params.ConnConnectionPNames;
 import ch.boye.httpclientandroidlib.impl.client.DefaultHttpClient;
 import ch.boye.httpclientandroidlib.message.BasicHeader;
 
@@ -45,24 +43,24 @@ public class AuthenticateAccountStage implements AuthenticatorStage {
 
       @Override
       public void handleFailure(HttpResponse response) {
-        Log.d(LOG_TAG, "handleFailure");
+        Logger.debug(LOG_TAG, "handleFailure");
         aa.abort(response.toString(), new Exception(response.getStatusLine().getStatusCode() + " error."));
         try {
           BufferedReader reader = new BufferedReader(new InputStreamReader(response.getEntity().getContent(), "UTF-8"));
-          Log.w(LOG_TAG, "content: " + reader.readLine());
+          Logger.warn(LOG_TAG, "content: " + reader.readLine());
           SyncResourceDelegate.consumeReader(reader);
           reader.close();
           SyncResourceDelegate.consumeEntity(response.getEntity());
         } catch (IllegalStateException e) {
-          Log.d(LOG_TAG, "Error reading content.", e);
+          Logger.debug(LOG_TAG, "Error reading content.", e);
         } catch (IOException e) {
-          Log.d(LOG_TAG, "Error reading content.", e);
+          Logger.debug(LOG_TAG, "Error reading content.", e);
         }
       }
 
       @Override
       public void handleError(Exception e) {
-        Log.d(LOG_TAG, "handleError");
+        Logger.debug(LOG_TAG, "handleError");
         aa.abort("HTTP failure.", e);
       }
     };
@@ -87,7 +85,7 @@ public class AuthenticateAccountStage implements AuthenticatorStage {
           URI authServerUri = new URI(authRequestUrl);
           request.setHeader(new BasicHeader("Host", authServerUri.getHost()));
         } catch (URISyntaxException e) {
-          Log.e(LOG_TAG, "Malformed uri, will be caught elsewhere.", e);
+          Logger.error(LOG_TAG, "Malformed uri, will be caught elsewhere.", e);
         }
         request.setHeader(new BasicHeader("Authorization", "Basic " + authHeader));
       }
@@ -111,7 +109,7 @@ public class AuthenticateAccountStage implements AuthenticatorStage {
 
       @Override
       public void handleHttpProtocolException(ClientProtocolException e) {
-        Log.e(LOG_TAG, "Client protocol error.");
+        Logger.error(LOG_TAG, "Client protocol error.");
         callbackDelegate.handleError(e);
       }
 

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/AuthenticatorStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/AuthenticatorStage.java
@@ -1,0 +1,8 @@
+package org.mozilla.gecko.sync.setup.auth;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URISyntaxException;
+
+public interface AuthenticatorStage {
+  public void execute(AccountAuthenticator aa) throws URISyntaxException, UnsupportedEncodingException;
+}

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/AuthenticatorStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/AuthenticatorStage.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.gecko.sync.setup.auth;
 
 import java.io.UnsupportedEncodingException;

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/EnsureUserExistenceStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/EnsureUserExistenceStage.java
@@ -8,7 +8,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 
-import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.net.BaseResource;
 import org.mozilla.gecko.sync.net.SyncResourceDelegate;
 import org.mozilla.gecko.sync.setup.Constants;
@@ -60,14 +59,14 @@ public class EnsureUserExistenceStage implements AuthenticatorStage {
             InputStream content = response.getEntity().getContent();
             BufferedReader reader = new BufferedReader(new InputStreamReader(content, "UTF-8"), 1024);
             String inUse = reader.readLine();
-            Logger.debug(LOG_TAG, "username inUse:" + inUse);
+            SyncResourceDelegate.consumeReader(reader);
+            reader.close();
+            // Removed Logger.debug inUse, because stalling.
             if (inUse.equals("1")) { // Username exists.
               callbackDelegate.handleSuccess();
             } else { // User does not exist.
               callbackDelegate.handleFailure();
             }
-            SyncResourceDelegate.consumeReader(reader);
-            reader.close();
           } catch (IllegalStateException e) {
             callbackDelegate.handleError(e);
           } catch (IOException e) {

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/EnsureUserExistenceStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/EnsureUserExistenceStage.java
@@ -8,11 +8,11 @@ import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 
+import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.net.BaseResource;
 import org.mozilla.gecko.sync.net.SyncResourceDelegate;
 import org.mozilla.gecko.sync.setup.Constants;
 
-import android.util.Log;
 import ch.boye.httpclientandroidlib.HttpResponse;
 import ch.boye.httpclientandroidlib.client.ClientProtocolException;
 
@@ -60,7 +60,7 @@ public class EnsureUserExistenceStage implements AuthenticatorStage {
             InputStream content = response.getEntity().getContent();
             BufferedReader reader = new BufferedReader(new InputStreamReader(content, "UTF-8"), 1024);
             String inUse = reader.readLine();
-            Log.d(LOG_TAG, "username inUse:" + inUse);
+            Logger.debug(LOG_TAG, "username inUse:" + inUse);
             if (inUse.equals("1")) { // Username exists.
               callbackDelegate.handleSuccess();
             } else { // User does not exist.

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/EnsureUserExistenceStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/EnsureUserExistenceStage.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.gecko.sync.setup.auth;
 
 import java.io.BufferedReader;

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/FetchUserNodeStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/FetchUserNodeStage.java
@@ -7,11 +7,11 @@ import java.io.InputStreamReader;
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 
+import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.net.BaseResource;
 import org.mozilla.gecko.sync.net.SyncResourceDelegate;
 import org.mozilla.gecko.sync.setup.Constants;
 
-import android.util.Log;
 import ch.boye.httpclientandroidlib.HttpResponse;
 import ch.boye.httpclientandroidlib.client.ClientProtocolException;
 
@@ -32,7 +32,7 @@ public class FetchUserNodeStage implements AuthenticatorStage {
       @Override
       public void handleSuccess(String server) {
         if (server == null) { // No separate auth node; use server url.
-          Log.d(LOG_TAG, "Using server as auth node.");
+          Logger.debug(LOG_TAG, "Using server as auth node.");
           aa.authServer = aa.nodeServer;
           aa.runNextStage();
           return;
@@ -47,7 +47,7 @@ public class FetchUserNodeStage implements AuthenticatorStage {
       @Override
       public void handleFailure(HttpResponse response) {
         int statusCode = response.getStatusLine().getStatusCode();
-        Log.d(LOG_TAG, "Failed to authenticate with status " + statusCode);
+        Logger.debug(LOG_TAG, "Failed to authenticate with status " + statusCode);
         aa.abort(response.toString(), new Exception("HTTP " + statusCode + " error."));
       }
 
@@ -57,7 +57,7 @@ public class FetchUserNodeStage implements AuthenticatorStage {
       }
     };
     String nodeRequestUrl = aa.nodeServer + Constants.AUTH_NODE_PATHNAME + Constants.AUTH_NODE_VERSION + aa.usernameHash + "/" + Constants.AUTH_NODE_SUFFIX;
-    Log.d(LOG_TAG, "nodeUrl: " + nodeRequestUrl);
+    Logger.debug(LOG_TAG, "nodeUrl: " + nodeRequestUrl);
     makeFetchNodeRequest(callbackDelegate, nodeRequestUrl);
   }
 

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/FetchUserNodeStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/FetchUserNodeStage.java
@@ -1,0 +1,119 @@
+package org.mozilla.gecko.sync.setup.auth;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URISyntaxException;
+import java.security.GeneralSecurityException;
+
+import org.mozilla.gecko.sync.ThreadPool;
+import org.mozilla.gecko.sync.net.BaseResource;
+import org.mozilla.gecko.sync.net.SyncResourceDelegate;
+import org.mozilla.gecko.sync.setup.Constants;
+
+import android.util.Log;
+import ch.boye.httpclientandroidlib.HttpResponse;
+import ch.boye.httpclientandroidlib.client.ClientProtocolException;
+
+public class FetchUserNodeStage implements AuthenticatorStage {
+  private final String LOG_TAG = "FetchUserNodeStage";
+
+  public interface FetchNodeStageDelegate {
+    public void handleSuccess(String url);
+    public void handleFailure(HttpResponse response);
+    public void handleError(Exception e);
+  }
+
+  @Override
+  public void execute(final AccountAuthenticator aa) throws URISyntaxException {
+
+    FetchNodeStageDelegate callbackDelegate = new FetchNodeStageDelegate() {
+
+      @Override
+      public void handleSuccess(String server) {
+        if (!server.endsWith("/")) {
+          server += "/";
+        }
+        aa.authServer = server;
+        aa.runNextStage();
+      }
+
+      @Override
+      public void handleFailure(HttpResponse response) {
+        if (response.getStatusLine().getStatusCode() == 404) {
+          aa.abort(response.toString(), new Exception(LOG_TAG + " 404 no such user."));
+        } else {
+          aa.abort(response.toString(), new Exception(response.getStatusLine().getStatusCode() + " error."));
+        }
+      }
+
+      @Override
+      public void handleError(Exception e) {
+        aa.abort("HTTP failure.", e);
+      }
+    };
+    String nodeRequestUrl = aa.nodeServer + Constants.AUTH_NODE_PATHNAME + Constants.AUTH_NODE_VERSION + aa.usernameHash + "/" + Constants.AUTH_NODE_SUFFIX;
+    Log.d(LOG_TAG, "nodeUrl: " + nodeRequestUrl);
+    makeFetchNodeRequest(callbackDelegate, nodeRequestUrl);
+  }
+
+  private void makeFetchNodeRequest(final FetchNodeStageDelegate callbackDelegate, String fetchNodeUrl) throws URISyntaxException {
+    // Fetch node containing user.
+    final BaseResource httpResource = new BaseResource(fetchNodeUrl);
+    httpResource.delegate = new SyncResourceDelegate(httpResource) {
+
+      @Override
+      public void handleHttpResponse(HttpResponse response) {
+        int statusCode = response.getStatusLine().getStatusCode();
+        switch(statusCode) {
+        case 200:
+          try {
+            InputStream content = response.getEntity().getContent();
+            BufferedReader reader = new BufferedReader(new InputStreamReader(content, "UTF-8"), 1024);
+            String server = reader.readLine();
+            callbackDelegate.handleSuccess(server);
+            SyncResourceDelegate.consumeReader(reader);
+            reader.close();
+          } catch (IllegalStateException e) {
+            callbackDelegate.handleError(e);
+          } catch (IOException e) {
+            callbackDelegate.handleError(e);
+          }
+          break;
+        default:
+          // No other acceptable states.
+          callbackDelegate.handleFailure(response);
+        }
+        SyncResourceDelegate.consumeEntity(response.getEntity());
+      }
+
+      @Override
+      public void handleHttpProtocolException(ClientProtocolException e) {
+        callbackDelegate.handleError(e);
+      }
+
+      @Override
+      public void handleHttpIOException(IOException e) {
+        callbackDelegate.handleError(e);
+      }
+
+      @Override
+      public void handleTransportException(GeneralSecurityException e) {
+        callbackDelegate.handleError(e);
+      }
+
+    };
+    runOnThread(new Runnable() {
+
+      @Override
+      public void run() {
+        httpResource.get();
+      }
+    });
+  }
+
+  private static void runOnThread(Runnable run) {
+    ThreadPool.run(run);
+  }
+}

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/FetchUserNodeStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/FetchUserNodeStage.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.gecko.sync.setup.auth;
 
 import java.io.BufferedReader;

--- a/src/main/java/org/mozilla/gecko/sync/stage/EnsureClusterURLStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/EnsureClusterURLStage.java
@@ -109,12 +109,13 @@ public class EnsureClusterURLStage implements GlobalSyncStage {
         case 404:
           Log.i(LOG_TAG, "Got " + status + " for cluster URL request.");
           delegate.handleFailure(response);
+          SyncResourceDelegate.consumeEntity(response.getEntity());
           break;
         default:
           Log.w(LOG_TAG, "Got " + status + " fetching node/weave. Returning failure.");
           delegate.handleFailure(response);
+          SyncResourceDelegate.consumeEntity(response.getEntity());
         }
-        SyncResourceDelegate.consumeEntity(response.getEntity());
       }
 
       @Override

--- a/src/main/java/org/mozilla/gecko/sync/stage/EnsureClusterURLStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/EnsureClusterURLStage.java
@@ -109,13 +109,12 @@ public class EnsureClusterURLStage implements GlobalSyncStage {
         case 404:
           Log.i(LOG_TAG, "Got " + status + " for cluster URL request.");
           delegate.handleFailure(response);
-          SyncResourceDelegate.consumeEntity(response.getEntity());
           break;
         default:
           Log.w(LOG_TAG, "Got " + status + " fetching node/weave. Returning failure.");
           delegate.handleFailure(response);
-          SyncResourceDelegate.consumeEntity(response.getEntity());
         }
+        SyncResourceDelegate.consumeEntity(response.getEntity());
       }
 
       @Override


### PR DESCRIPTION
One last issue I haven't been able to fix - a failed auth attempt 401 causes the HttpRequest connection to be "kept alive indefinitely." The subsequent auth request will always hang.

Logcat:

02-23 14:32:02.906: I/BaseResource(4246): Response: HTTP/1.1 401 Unauthorized
02-23 14:32:12.286: I/BaseResource(4246): HTTP GET https://auth.services.mozilla.com/user/1.0/7i77ycjdvltg7xfbsooj3acmdh6mbzbz
02-23 14:32:12.286: D/class ch.boye.httpclientandroidlib.impl.client.DefaultHttpClient(4246): Stale connection check
02-23 14:32:12.286: D/class ch.boye.httpclientandroidlib.client.protocol.RequestAuthCache(4246): Auth cache not set in the context
02-23 14:32:12.528: I/BaseResource(4246): Response: HTTP/1.1 200 OK
02-23 14:32:12.536: I/BaseResource(4246): HTTP GET https://auth.services.mozilla.com/user/1.0/7i77ycjdvltg7xfbsooj3acmdh6mbzbz/node/weave
02-23 14:32:12.546: D/class ch.boye.httpclientandroidlib.impl.client.DefaultHttpClient(4246): Stale connection check
02-23 14:32:12.556: D/class ch.boye.httpclientandroidlib.client.protocol.RequestAuthCache(4246): Auth cache not set in the context
02-23 14:32:12.676: I/BaseResource(4246): Response: HTTP/1.1 200 OK
02-23 14:32:12.686: I/BaseResource(4246): HTTP GET https://scl2-sync395.services.mozilla.com/1.1/7i77ycjdvltg7xfbsooj3acmdh6mbzbz/info/collections/
02-23 14:32:12.706: D/class ch.boye.httpclientandroidlib.impl.client.DefaultHttpClient(4246): Stale connection check
02-23 14:32:12.716: D/class ch.boye.httpclientandroidlib.client.protocol.RequestAuthCache(4246): Auth cache not set in the context
02-23 14:32:12.716: D/class ch.boye.httpclientandroidlib.impl.client.DefaultHttpClient(4246): Attempt 1 to execute request
02-23 14:32:12.726: D/class ch.boye.httpclientandroidlib.impl.conn.DefaultClientConnection(4246): Connection closed
02-23 14:32:12.726: D/class ch.boye.httpclientandroidlib.impl.conn.DefaultClientConnection(4246): Connection shut down

(followed by hang)
