### PR TITLE
Fix StoreTrackingTest.

### DIFF
--- a/src/main/java/org/mozilla/android/sync/test/helpers/WaitHelper.java
+++ b/src/main/java/org/mozilla/android/sync/test/helpers/WaitHelper.java
@@ -117,7 +117,9 @@ public class WaitHelper {
       throw new TimeoutError(waitTimeoutInMillis);
     } else if (result.error != null) {
       // Rethrow any assertion with which we were notified.
-      throw new InnerError(result.error);
+      InnerError innerError = new InnerError(result.error);
+      innerError.initCause(result.error);
+      throw innerError;
     } else {
       // Success!
     }

--- a/test/src/org/mozilla/android/sync/test/AndroidBrowserPasswordRepositoryTest.java
+++ b/test/src/org/mozilla/android/sync/test/AndroidBrowserPasswordRepositoryTest.java
@@ -5,7 +5,6 @@ package org.mozilla.android.sync.test;
 
 import org.mozilla.android.sync.test.helpers.PasswordHelpers;
 import org.mozilla.android.sync.test.helpers.WaitHelper;
-import org.mozilla.gecko.db.BrowserContract;
 import org.mozilla.gecko.sync.repositories.android.AndroidBrowserPasswordsDataAccessor;
 import org.mozilla.gecko.sync.repositories.android.AndroidBrowserPasswordsRepository;
 import org.mozilla.gecko.sync.repositories.android.AndroidBrowserRepository;

--- a/test/src/org/mozilla/android/sync/test/StoreTrackingTest.java
+++ b/test/src/org/mozilla/android/sync/test/StoreTrackingTest.java
@@ -221,6 +221,7 @@ public class StoreTrackingTest extends
       @Override
       public void run() {
         doTestNewSessionRetrieveByTime(r, expectedGUID);
+        performNotify();
       }
     });
 


### PR DESCRIPTION
There was a missing performNotify.  I improved the WaitHelper tests to demonstrate the expected behaviours -- you can nest waits, but you can perform at most one notify at the same "wait level".
