### PR TITLE
Bug 734469 - Clients stage table missing during sync.

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserHistoryDataAccessor.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserHistoryDataAccessor.java
@@ -121,4 +121,7 @@ public class AndroidBrowserHistoryDataAccessor extends AndroidBrowserRepositoryD
     dataExtender.delete(guid);
   }
 
+  public void closeExtender() {
+    dataExtender.close();
+  }
 }

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserHistoryRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserHistoryRepositorySession.java
@@ -6,8 +6,10 @@ package org.mozilla.gecko.sync.repositories.android;
 
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
+import org.mozilla.gecko.sync.repositories.InactiveSessionException;
 import org.mozilla.gecko.sync.repositories.NullCursorException;
 import org.mozilla.gecko.sync.repositories.Repository;
+import org.mozilla.gecko.sync.repositories.delegates.RepositorySessionFinishDelegate;
 import org.mozilla.gecko.sync.repositories.domain.HistoryRecord;
 import org.mozilla.gecko.sync.repositories.domain.Record;
 
@@ -95,5 +97,17 @@ public class AndroidBrowserHistoryRepositorySession extends AndroidBrowserReposi
   @Override
   protected Record prepareRecord(Record record) {
     return record;
+  }
+  
+  @Override
+  public void abort() {
+    ((AndroidBrowserHistoryDataAccessor) dbHelper).closeExtender();
+    super.abort();
+  }
+
+  @Override
+  public void finish(final RepositorySessionFinishDelegate delegate) throws InactiveSessionException {
+    ((AndroidBrowserHistoryDataAccessor) dbHelper).closeExtender();
+    super.finish(delegate);
   }
 }

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserRepositorySession.java
@@ -649,4 +649,9 @@ public abstract class AndroidBrowserRepositorySession extends StoreTrackingRepos
       delegate.onWipeSucceeded();
     }
   }
+
+  // For testing purposes.
+  public AndroidBrowserRepositoryDataAccessor getDBHelper() {
+    return dbHelper;
+  }
 }

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/CachedSQLiteOpenHelper.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/CachedSQLiteOpenHelper.java
@@ -18,8 +18,8 @@ public abstract class CachedSQLiteOpenHelper extends SQLiteOpenHelper {
 
   // Cache these so we don't have to track them across cursors. Call `close`
   // when you're done.
-  private static SQLiteDatabase readableDatabase;
-  private static SQLiteDatabase writableDatabase;
+  private SQLiteDatabase readableDatabase;
+  private SQLiteDatabase writableDatabase;
 
   synchronized protected SQLiteDatabase getCachedReadableDatabase() {
     if (readableDatabase == null) {

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/CachedSQLiteOpenHelper.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/CachedSQLiteOpenHelper.java
@@ -52,4 +52,10 @@ public abstract class CachedSQLiteOpenHelper extends SQLiteOpenHelper {
     }
     super.close();
   }
+
+  // Used for testing.
+  public boolean isClosed() {
+    return readableDatabase == null &&
+           writableDatabase == null;
+  }
 }

--- a/test/src/org/mozilla/android/sync/test/TestCachedSQLiteOpenHelper.java
+++ b/test/src/org/mozilla/android/sync/test/TestCachedSQLiteOpenHelper.java
@@ -1,0 +1,56 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+package org.mozilla.android.sync.test;
+
+import org.mozilla.android.sync.test.helpers.HistoryHelpers;
+import org.mozilla.gecko.sync.repositories.NullCursorException;
+import org.mozilla.gecko.sync.repositories.android.AndroidBrowserHistoryDataExtender;
+import org.mozilla.gecko.sync.repositories.android.ClientsDatabase;
+import org.mozilla.gecko.sync.repositories.domain.ClientRecord;
+import org.mozilla.gecko.sync.repositories.domain.HistoryRecord;
+import org.mozilla.gecko.sync.setup.Constants;
+
+import android.database.Cursor;
+import android.test.AndroidTestCase;
+
+public class TestCachedSQLiteOpenHelper extends AndroidTestCase {
+
+  protected ClientsDatabase clientsDB;
+  protected AndroidBrowserHistoryDataExtender extender;
+
+  public void setUp() {
+    clientsDB = new ClientsDatabase(mContext);
+    extender = new AndroidBrowserHistoryDataExtender(mContext);
+  }
+
+  public void tearDown() {
+    clientsDB.close();
+    extender.close();
+  }
+
+  public void testUnclosedDatabasesDontInteract() throws NullCursorException {
+    // clientsDB gracefully does its thing and closes.
+    clientsDB.wipe();
+    ClientRecord record = new ClientRecord();
+    String profileConst = Constants.PROFILE_ID;
+    clientsDB.store(profileConst, record);
+    clientsDB.close();
+
+    // extender does its thing but still hasn't closed.
+    HistoryRecord h = HistoryHelpers.createHistory1();
+    extender.store(h.guid, h.visits);
+
+    // Ensure items in the clientsDB are still accessible nonetheless.
+    Cursor cur = null;
+    try {
+      cur = clientsDB.fetchAll();
+      assertTrue(cur.moveToFirst());
+      assertEquals(1, cur.getCount());
+    } finally {
+      if (cur != null) {
+        cur.close();
+      }
+    }
+  }
+}

--- a/test/src/org/mozilla/android/sync/test/TestClientsDatabase.java
+++ b/test/src/org/mozilla/android/sync/test/TestClientsDatabase.java
@@ -13,9 +13,15 @@ import android.database.Cursor;
 import android.test.AndroidTestCase;
 
 public class TestClientsDatabase extends AndroidTestCase {
-  public void testStoreAndFetch() {
-    ClientsDatabase db = new ClientsDatabase(mContext);
+
+  protected ClientsDatabase db;
+
+  public void setUp() {
+    db = new ClientsDatabase(mContext);
     db.wipe();
+  }
+
+  public void testStoreAndFetch() {
     ClientRecord record = new ClientRecord();
     String profileConst = ClientsDatabaseAccessor.PROFILE_ID;
     db.store(profileConst, record);
@@ -42,13 +48,10 @@ public class TestClientsDatabase extends AndroidTestCase {
       if (cur != null) {
         cur.close();
       }
-      db.close();
     }
   }
 
   public void testDelete() {
-    ClientsDatabase db = new ClientsDatabase(mContext);
-    db.wipe();
     ClientRecord record1 = new ClientRecord();
     ClientRecord record2 = new ClientRecord();
     String profileConst = ClientsDatabaseAccessor.PROFILE_ID;
@@ -84,13 +87,10 @@ public class TestClientsDatabase extends AndroidTestCase {
       if (cur != null) {
         cur.close();
       }
-      db.close();
     }
   }
 
   public void testWipe() {
-    ClientsDatabase db = new ClientsDatabase(mContext);
-    db.wipe();
     ClientRecord record1 = new ClientRecord();
     ClientRecord record2 = new ClientRecord();
     String profileConst = ClientsDatabaseAccessor.PROFILE_ID;
@@ -123,7 +123,6 @@ public class TestClientsDatabase extends AndroidTestCase {
       if (cur != null) {
         cur.close();
       }
-      db.close();
     }
   }
 }

--- a/test/src/org/mozilla/android/sync/test/TestClientsDatabaseAccessor.java
+++ b/test/src/org/mozilla/android/sync/test/TestClientsDatabaseAccessor.java
@@ -17,17 +17,23 @@ import android.test.AndroidTestCase;
 public class TestClientsDatabaseAccessor extends AndroidTestCase {
 
   public class StubbedClientsDatabaseAccessor extends ClientsDatabaseAccessor {
-
     public StubbedClientsDatabaseAccessor(Context mContext) {
       super(mContext);
     }
   }
 
-  public void testStoreArrayListAndFetch() throws NullCursorException {
-    StubbedClientsDatabaseAccessor db =
-        new StubbedClientsDatabaseAccessor(mContext);
-    db.wipe();
+  StubbedClientsDatabaseAccessor db;
 
+  public void setUp() {
+    db = new StubbedClientsDatabaseAccessor(mContext);
+    db.wipe();
+  }
+
+  public void tearDown() {
+    db.close();
+  }
+
+  public void testStoreArrayListAndFetch() throws NullCursorException {
     ArrayList<ClientRecord> list = new ArrayList<ClientRecord>();
     ClientRecord record1 = new ClientRecord(Utils.generateGuid());
     ClientRecord record2 = new ClientRecord(Utils.generateGuid());
@@ -50,10 +56,6 @@ public class TestClientsDatabaseAccessor extends AndroidTestCase {
   }
 
   public void testNumClients() {
-    StubbedClientsDatabaseAccessor db =
-        new StubbedClientsDatabaseAccessor(mContext);
-    db.wipe();
-
     final int COUNT = 5;
     ArrayList<ClientRecord> list = new ArrayList<ClientRecord>();
     for (int i = 0; i < 5; i++) {
@@ -64,10 +66,6 @@ public class TestClientsDatabaseAccessor extends AndroidTestCase {
   }
 
   public void testFetchAll() throws NullCursorException {
-    StubbedClientsDatabaseAccessor db =
-        new StubbedClientsDatabaseAccessor(mContext);
-    db.wipe();
-
     ArrayList<ClientRecord> list = new ArrayList<ClientRecord>();
     ClientRecord record1 = new ClientRecord(Utils.generateGuid());
     ClientRecord record2 = new ClientRecord(Utils.generateGuid());

--- a/test/src/org/mozilla/gecko/sync/repositories/android/test/AndroidBrowserHistoryDataExtenderTest.java
+++ b/test/src/org/mozilla/gecko/sync/repositories/android/test/AndroidBrowserHistoryDataExtenderTest.java
@@ -31,6 +31,10 @@ public class AndroidBrowserHistoryDataExtenderTest extends AndroidSyncTestCase {
     extender.wipe();
   }
 
+  public void tearDown() {
+    extender.close();
+  }
+
   public void testStoreFetch() throws NullCursorException, NonObjectJSONException, IOException, ParseException {
     String guid = Utils.generateGuid();
     extender.store(Utils.generateGuid(), null);
@@ -87,7 +91,6 @@ public class AndroidBrowserHistoryDataExtenderTest extends AndroidSyncTestCase {
       if (cur != null) {
         cur.close();
       }
-      extender.close();
     }
   }
 
@@ -114,7 +117,6 @@ public class AndroidBrowserHistoryDataExtenderTest extends AndroidSyncTestCase {
       if (cur != null) {
         cur.close();
       }
-      extender.close();
     }
   }
 }


### PR DESCRIPTION
Main issue was static cached references to readableDatabase & writableDatabase. Since the history dataExtender did not close() after it was done its work, the clients database was trying to use the cached version of the history database which, of course, didn't have a clients table (eeeekkk!!)

That was such a fun bug :D I love how it threw me off so much :D
