### PR TITLE
Bug 735996 - HTTP layer improvements

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/Logger.java
+++ b/src/main/java/org/mozilla/gecko/sync/Logger.java
@@ -71,7 +71,6 @@ public class Logger {
     if (out != null) {
       return out.booleanValue();
     }
-    Log.d("XXX", "Calling out to isLoggable for INFO!");
     out = Log.isLoggable(logTag, Log.INFO);
     isInfoLoggable.put(logTag, out);
     return out;
@@ -82,7 +81,6 @@ public class Logger {
     if (out != null) {
       return out.booleanValue();
     }
-    Log.d("XXX", "Calling out to isLoggable for DEBUG!");
     out = Log.isLoggable(logTag, Log.DEBUG);
     isDebugLoggable.put(logTag, out);
     return out;
@@ -93,7 +91,6 @@ public class Logger {
     if (out != null) {
       return out.booleanValue();
     }
-    Log.d("XXX", "Calling out to isLoggable for VERBOSE!");
     out = Log.isLoggable(logTag, Log.VERBOSE);
     isVerboseLoggable.put(logTag, out);
     return out;

--- a/src/main/java/org/mozilla/gecko/sync/net/BaseResource.java
+++ b/src/main/java/org/mozilla/gecko/sync/net/BaseResource.java
@@ -147,6 +147,7 @@ public class BaseResource implements Resource {
     HttpParams params = client.getParams();
     HttpConnectionParams.setConnectionTimeout(params, delegate.connectionTimeout());
     HttpConnectionParams.setSoTimeout(params, delegate.socketTimeout());
+    HttpConnectionParams.setStaleCheckingEnabled(params, false);
     HttpProtocolParams.setContentCharset(params, charset);
     HttpProtocolParams.setVersion(params, HttpVersion.HTTP_1_1);
     delegate.addHeaders(request, client);

--- a/src/main/java/org/mozilla/gecko/sync/net/BaseResource.java
+++ b/src/main/java/org/mozilla/gecko/sync/net/BaseResource.java
@@ -56,9 +56,13 @@ import ch.boye.httpclientandroidlib.util.EntityUtils;
 public class BaseResource implements Resource {
   private static final String ANDROID_LOOPBACK_IP = "10.0.2.2";
 
+  private static final int MAX_TOTAL_CONNECTIONS     = 20;
+  private static final int MAX_CONNECTIONS_PER_ROUTE = 10;
+
   public static boolean rewriteLocalhost = true;
 
   private static final String LOG_TAG = "BaseResource";
+
   protected URI uri;
   protected BasicHttpContext context;
   protected DefaultHttpClient client;
@@ -168,6 +172,9 @@ public class BaseResource implements Resource {
     schemeRegistry.register(new Scheme("https", 443, sf));
     schemeRegistry.register(new Scheme("http", 80, new PlainSocketFactory()));
     ThreadSafeClientConnManager cm = new ThreadSafeClientConnManager(schemeRegistry);
+
+    cm.setMaxTotal(MAX_TOTAL_CONNECTIONS);
+    cm.setDefaultMaxPerRoute(MAX_CONNECTIONS_PER_ROUTE);
     connManager = cm;
     return cm;
   }

--- a/src/main/java/org/mozilla/gecko/sync/net/ConnectionMonitorThread.java
+++ b/src/main/java/org/mozilla/gecko/sync/net/ConnectionMonitorThread.java
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.gecko.sync.net;
+
+import org.mozilla.gecko.sync.Logger;
+
+/**
+ * Every <code>REAP_INTERVAL</code> milliseconds, wake up
+ * and expire any connections that need cleaning up.
+ *
+ * When we're told to shut down, take the connection manager
+ * with us.
+ */
+public class ConnectionMonitorThread extends Thread {
+  private static final long REAP_INTERVAL = 5000;     // 5 seconds.
+  private static final String LOG_TAG = "ConnectionMonitorThread";
+
+  private volatile boolean stopping;
+
+  @Override
+  public void run() {
+    try {
+      while (!stopping) {
+        synchronized (this) {
+          wait(REAP_INTERVAL);
+          BaseResource.closeExpiredConnections();
+        }
+      }
+    } catch (InterruptedException e) {
+      Logger.trace(LOG_TAG, "Interrupted.");
+    }
+    BaseResource.shutdownConnectionManager();
+  }
+
+  public void shutdown() {
+    Logger.debug(LOG_TAG, "ConnectionMonitorThread told to shut down.");
+    stopping = true;
+    synchronized (this) {
+      notifyAll();
+    }
+  }
+}

--- a/src/main/java/org/mozilla/gecko/sync/net/SyncStorageCollectionRequest.java
+++ b/src/main/java/org/mozilla/gecko/sync/net/SyncStorageCollectionRequest.java
@@ -58,7 +58,6 @@ public class SyncStorageCollectionRequest extends SyncStorageRequest {
 
       HttpEntity entity = response.getEntity();
       Header contentType = entity.getContentType();
-      System.out.println("content type is " + contentType.getValue());
       if (!contentType.getValue().startsWith("application/newlines")) {
         // Not incremental!
         super.handleHttpResponse(response);

--- a/src/main/java/org/mozilla/gecko/sync/syncadapter/SyncAdapter.java
+++ b/src/main/java/org/mozilla/gecko/sync/syncadapter/SyncAdapter.java
@@ -21,6 +21,7 @@ import org.mozilla.gecko.sync.Utils;
 import org.mozilla.gecko.sync.crypto.KeyBundle;
 import org.mozilla.gecko.sync.delegates.ClientsDataDelegate;
 import org.mozilla.gecko.sync.delegates.GlobalSessionCallback;
+import org.mozilla.gecko.sync.net.ConnectionMonitorThread;
 import org.mozilla.gecko.sync.setup.Constants;
 import org.mozilla.gecko.sync.stage.GlobalSyncStage.Stage;
 
@@ -290,12 +291,20 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements GlobalSe
       // notify us in a failure case. Oh, concurrent programming.
       new Thread(fetchAuthToken).start();
 
+      // Start our stale connection monitor thread.
+      ConnectionMonitorThread stale = new ConnectionMonitorThread();
+      stale.start();
+
       Log.i(LOG_TAG, "Waiting on sync monitor.");
       try {
         syncMonitor.wait();
         long next = System.currentTimeMillis() + MINIMUM_SYNC_INTERVAL_MILLISECONDS;
         Log.i(LOG_TAG, "Setting minimum next sync time to " + next);
         extendEarliestNextSync(next);
+
+        // And we're done with HTTP stuff.
+        stale.shutdown();
+
       } catch (InterruptedException e) {
         Log.i(LOG_TAG, "Waiting on sync monitor interrupted.", e);
       }
@@ -329,6 +338,7 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements GlobalSe
     Log.i(LOG_TAG, "Performing sync.");
     this.syncResult   = syncResult;
     this.localAccount = account;
+
     // TODO: default serverURL.
     GlobalSession globalSession = new GlobalSession(SyncConfiguration.DEFAULT_USER_API,
                                                     serverURL, username, password, prefsPath,

--- a/src/test/java/org/mozilla/android/sync/net/test/TestSyncStorageRequest.java
+++ b/src/test/java/org/mozilla/android/sync/net/test/TestSyncStorageRequest.java
@@ -17,7 +17,6 @@ import org.mozilla.android.sync.test.helpers.BaseTestStorageRequestDelegate;
 import org.mozilla.android.sync.test.helpers.HTTPServerTestHelper;
 import org.mozilla.android.sync.test.helpers.MockServer;
 import org.mozilla.gecko.sync.net.BaseResource;
-import org.mozilla.gecko.sync.net.SyncResourceDelegate;
 import org.mozilla.gecko.sync.net.SyncStorageRecordRequest;
 import org.mozilla.gecko.sync.net.SyncStorageResponse;
 import org.simpleframework.http.Request;

--- a/src/test/java/org/mozilla/android/sync/test/TestServer11RepositorySession.java
+++ b/src/test/java/org/mozilla/android/sync/test/TestServer11RepositorySession.java
@@ -16,7 +16,6 @@ import org.mozilla.android.sync.test.helpers.MockRecord;
 import org.mozilla.android.sync.test.helpers.MockServer;
 import org.mozilla.gecko.sync.Utils;
 import org.mozilla.gecko.sync.net.BaseResource;
-import org.mozilla.gecko.sync.net.SyncResourceDelegate;
 import org.mozilla.gecko.sync.net.SyncStorageRecordRequest;
 import org.mozilla.gecko.sync.net.SyncStorageResponse;
 import org.mozilla.gecko.sync.repositories.Repository;

--- a/src/test/java/org/mozilla/android/sync/test/helpers/HTTPServerTestHelper.java
+++ b/src/test/java/org/mozilla/android/sync/test/helpers/HTTPServerTestHelper.java
@@ -55,6 +55,8 @@ public class HTTPServerTestHelper {
       connection.close();
       server = null;
       connection = null;
+      Logger.info(LOG_TAG, "Closing connection pool...");
+      BaseResource.shutdownConnectionManager();
       Logger.info(LOG_TAG, "Stopping HTTP server on port " + port + "... DONE");
     } catch (IOException ex) {
       Logger.error(LOG_TAG, "Error stopping HTTP server on port " + port + "... DONE", ex);


### PR DESCRIPTION
Spotted a few of these as I was working on the clients stuff.
- Set an AuthCache to avoid annoying log messages.
- Don't check for stale connections on every request (10-100ms overhead); have a reaper thread do the work.
- Adjust connection pool limits.
- Terminate connection pool at the end of a sync.
- Close streams, don't completely consume them.
- Misc.
