### PR TITLE
Bug 715792 - Process client record commands.

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/CommandProcessor.java
+++ b/src/main/java/org/mozilla/gecko/sync/CommandProcessor.java
@@ -1,0 +1,83 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.gecko.sync;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.json.simple.JSONArray;
+
+public class CommandProcessor {
+  private static final String LOG_TAG = "Command";
+  protected ConcurrentHashMap<String, CommandRunner> commands = new ConcurrentHashMap<String, CommandRunner>();
+
+  private final static CommandProcessor processor = new CommandProcessor();
+
+  public static CommandProcessor getProcessor() {
+    return processor;
+  }
+
+  public static class Command {
+    public final String commandType;
+    public final List<String> args;
+
+    public Command(String commandType, List<String> args) {
+      this.commandType = commandType;
+      this.args = args;
+    }
+  }
+
+  public void registerCommand(String commandType, CommandRunner command) {
+    commands.put(commandType, command);
+  }
+
+  public void processCommand(ExtendedJSONObject unparsedCommand) {
+    Command command = parseCommand(unparsedCommand);
+    if (command == null) {
+      Logger.debug(LOG_TAG, "Invalid command: " + unparsedCommand + " will not be processed.");
+      return;
+    }
+
+    CommandRunner executableCommand = commands.get(command.commandType);
+    if (executableCommand == null) {
+      Logger.debug(LOG_TAG, "Command \"" + command.commandType + "\" not registered and will not be processed.");
+      return;
+    }
+
+    executableCommand.executeCommand(command.args);
+  }
+
+  /**
+   * Parse a JSON command into a ParsedCommand object for easier handling.
+   *
+   * @param unparsedCommand - command as ExtendedJSONObject
+   * @return - null if command is invalid, else return ParsedCommand with
+   *           no null attributes.
+   */
+  protected Command parseCommand(ExtendedJSONObject unparsedCommand) {
+    String type = (String) unparsedCommand.get("command");
+    if (type == null) {
+      return null;
+    }
+
+    try {
+      JSONArray unparsedArgs = unparsedCommand.getArray("args");
+      if (unparsedArgs == null) {
+        return null;
+      }
+      ArrayList<String> args = new ArrayList<String>(unparsedArgs.size());
+
+      for (int i = 0; i < unparsedArgs.size(); i++) {
+        args.add(unparsedArgs.get(i).toString());
+      }
+
+      return new Command(type, args);
+    } catch (NonArrayJSONException e) {
+      Logger.debug(LOG_TAG, "Unable to parse args array. Invalid command");
+      return null;
+    }
+  }
+}

--- a/src/main/java/org/mozilla/gecko/sync/CommandRunner.java
+++ b/src/main/java/org/mozilla/gecko/sync/CommandRunner.java
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.gecko.sync;
+
+import java.util.List;
+
+public interface CommandRunner {
+  public void executeCommand(List<String> args);
+}

--- a/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
+++ b/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
@@ -9,6 +9,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.json.simple.parser.ParseException;
@@ -155,7 +156,26 @@ public class GlobalSession implements CredentialsSource, PrefsSource {
     config.password      = password;
     config.syncKeyBundle = syncKeyBundle;
 
+    registerCommands();
     prepareStages();
+  }
+
+  protected void registerCommands() {
+    CommandProcessor processor = CommandProcessor.getProcessor();
+
+    processor.registerCommand("resetEngine", new CommandRunner() {
+      @Override
+      public void executeCommand(List<String> args) {
+        resetClient(new String[] { args.get(0) });
+      }
+    });
+
+    processor.registerCommand("resetAll", new CommandRunner() {
+      @Override
+      public void executeCommand(List<String> args) {
+        resetClient(null);
+      }
+    });
   }
 
   protected void prepareStages() {
@@ -415,7 +435,7 @@ public class GlobalSession implements CredentialsSource, PrefsSource {
     String localSyncID = this.getSyncID();
     if (!remoteSyncID.equals(localSyncID)) {
       // Sync ID has changed. Reset timestamps and fetch new keys.
-      resetClient();
+      resetClient(null);
       if (config.collectionKeys != null) {
         config.collectionKeys.clear();
       }
@@ -468,7 +488,7 @@ public class GlobalSession implements CredentialsSource, PrefsSource {
 
       @Override
       public void onWiped(long timestamp) {
-        session.resetClient();
+        session.resetClient(null);
         session.config.collectionKeys.clear();      // TODO: make sure we clear our keys timestamp.
         session.config.persistToPrefs();
 
@@ -643,10 +663,12 @@ public class GlobalSession implements CredentialsSource, PrefsSource {
    * Reset our state. Clear our sync ID, reset each engine, drop any
    * cached records.
    */
-  private void resetClient() {
+  private void resetClient(String[] engines) {
+    if (engines == null) {
+      // Set `engines` to be *all* the engines.
+    }
     // TODO: futz with config?!
     // TODO: engines?!
-
   }
 
   /**

--- a/src/main/java/org/mozilla/gecko/sync/stage/SyncClientsEngineStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/SyncClientsEngineStage.java
@@ -10,7 +10,10 @@ import java.net.URISyntaxException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.mozilla.gecko.sync.CommandProcessor;
 import org.mozilla.gecko.sync.CryptoRecord;
+import org.mozilla.gecko.sync.ExtendedJSONObject;
 import org.mozilla.gecko.sync.GlobalSession;
 import org.mozilla.gecko.sync.HTTPFailureException;
 import org.mozilla.gecko.sync.Logger;
@@ -278,8 +281,12 @@ public class SyncClientsEngineStage implements GlobalSyncStage {
     }
 
     commandsProcessedShouldUpload = true;
+    CommandProcessor processor = CommandProcessor.getProcessor();
 
     // TODO: Bug 715792 - Process commands here.
+    for (int i = 0; i < commands.size(); i++) {
+      processor.processCommand(new ExtendedJSONObject((JSONObject)commands.get(i)));
+    }
   }
 
   protected void checkAndUpload() {

--- a/src/main/java/org/mozilla/gecko/sync/syncadapter/SyncAdapter.java
+++ b/src/main/java/org/mozilla/gecko/sync/syncadapter/SyncAdapter.java
@@ -7,12 +7,16 @@ package org.mozilla.gecko.sync.syncadapter;
 import java.io.IOException;
 import java.net.URI;
 import java.security.NoSuchAlgorithmException;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.json.simple.parser.ParseException;
 import org.mozilla.gecko.sync.AlreadySyncingException;
+import org.mozilla.gecko.sync.CommandRunner;
+import org.mozilla.gecko.sync.CommandProcessor;
 import org.mozilla.gecko.sync.GlobalConstants;
 import org.mozilla.gecko.sync.GlobalSession;
+import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.NonObjectJSONException;
 import org.mozilla.gecko.sync.SyncConfiguration;
 import org.mozilla.gecko.sync.SyncConfigurationException;
@@ -62,6 +66,15 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements GlobalSe
     mContext = context;
     Log.d(LOG_TAG, "AccountManager.get(" + mContext + ")");
     mAccountManager = AccountManager.get(context);
+
+    // Register the displayURI command here so our SyncService
+    // can receive notifications to open a URI.
+    CommandProcessor.getProcessor().registerCommand("displayURI", new CommandRunner() {
+      @Override
+      public void executeCommand(List<String> args) {
+        displayURI(args.get(0), args.get(1));
+      }
+    });
   }
 
   private SharedPreferences getGlobalPrefs() {
@@ -479,5 +492,10 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements GlobalSe
   @Override
   public void informUnauthorizedResponse(GlobalSession session, URI oldClusterURL) {
     setClusterURLIsStale(true);
+  }
+
+  public void displayURI(String uri, String clientId) {
+    Logger.info(LOG_TAG, "Received a URI for display: " + uri + " from " + clientId);
+    // TODO: Bug 732147 - Send tab to device: receiving pushed tabs
   }
 }

--- a/src/test/java/org/mozilla/android/sync/test/TestCommandProcessor.java
+++ b/src/test/java/org/mozilla/android/sync/test/TestCommandProcessor.java
@@ -1,0 +1,89 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+package org.mozilla.android.sync.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.json.simple.parser.ParseException;
+import org.junit.Test;
+import org.mozilla.gecko.sync.CommandProcessor;
+import org.mozilla.gecko.sync.CommandRunner;
+import org.mozilla.gecko.sync.ExtendedJSONObject;
+import org.mozilla.gecko.sync.NonObjectJSONException;
+
+public class TestCommandProcessor extends CommandProcessor {
+
+  public static final String commandType = "displayURI";
+  public static final String commandWithNoArgs = "{\"command\":\"displayURI\"}";
+  public static final String commandWithNoType = "{\"args\":[\"https://bugzilla.mozilla.org/show_bug.cgi?id=731341\",\"PKsljsuqYbGg\"]}";
+  public static final String wellFormedCommand = "{\"args\":[\"https://bugzilla.mozilla.org/show_bug.cgi?id=731341\",\"PKsljsuqYbGg\"],\"command\":\"displayURI\"}";
+
+  private boolean commandExecuted;
+  public class MockCommandRunner implements CommandRunner {
+    @Override
+    public void executeCommand(List<String> args) {
+      commandExecuted = true;
+    }
+  }
+
+  @Test
+  public void testRegisterCommand() throws NonObjectJSONException, IOException, ParseException {
+    assertNull(commands.get(commandType));
+    this.registerCommand(commandType, new MockCommandRunner());
+    assertNotNull(commands.get(commandType));
+  }
+
+  @Test
+  public void testProcessRegisteredCommand() throws NonObjectJSONException, IOException, ParseException {
+    commandExecuted = false;
+    ExtendedJSONObject unparsedCommand = new ExtendedJSONObject(wellFormedCommand);
+    this.registerCommand(commandType, new MockCommandRunner());
+    this.processCommand(unparsedCommand);
+    assertTrue(commandExecuted);
+  }
+
+  @Test
+  public void testProcessUnregisteredCommand() throws NonObjectJSONException, IOException, ParseException {
+    commandExecuted = false;
+    ExtendedJSONObject unparsedCommand = new ExtendedJSONObject(wellFormedCommand);
+    this.processCommand(unparsedCommand);
+    assertFalse(commandExecuted);
+  }
+
+  @Test
+  public void testProcessInvalidCommand() throws NonObjectJSONException, IOException, ParseException {
+    ExtendedJSONObject unparsedCommand = new ExtendedJSONObject(commandWithNoType);
+    this.registerCommand(commandType, new MockCommandRunner());
+    this.processCommand(unparsedCommand);
+    assertFalse(commandExecuted);
+  }
+
+  @Test
+  public void testParseCommandNoType() throws NonObjectJSONException, IOException, ParseException {
+    ExtendedJSONObject unparsedCommand = new ExtendedJSONObject(commandWithNoType);
+    assertNull(this.parseCommand(unparsedCommand));
+  }
+
+  @Test
+  public void testParseCommandNoArgs() throws NonObjectJSONException, IOException, ParseException {
+    ExtendedJSONObject unparsedCommand = new ExtendedJSONObject(commandWithNoArgs);
+    assertNull(this.parseCommand(unparsedCommand));
+  }
+
+  @Test
+  public void testParseWellFormedCommand() throws NonObjectJSONException, IOException, ParseException {
+    ExtendedJSONObject unparsedCommand = new ExtendedJSONObject(wellFormedCommand);
+    Command parsedCommand = this.parseCommand(unparsedCommand);
+    assertNotNull(parsedCommand);
+    assertEquals(2, parsedCommand.args.size());
+    assertEquals(commandType, parsedCommand.commandType);
+  }
+}


### PR DESCRIPTION
This is pretty rough & still doesn't have tests but I wanted some input. @rnewman I used the "register your command" idea we talked about a couple of days ago, but not sure if I fully captured it correctly.

This approach limits a single command per class. So `GlobalSession` cannot have more than one command, for example, unless we have a nested class for each method.

Thoughts, ideas, suggestions?
