### PR TITLE
Bug 736352 - Aborting… doesn't.

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/repositories/RepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/RepositorySession.java
@@ -215,7 +215,7 @@ public abstract class RepositorySession {
     // TODO: do something here.
     this.setStatus(SessionStatus.ABORTED);
     try {
-      storeWorkQueue.shutdown();
+      storeWorkQueue.shutdownNow();
     } catch (Exception e) {
       Logger.error(LOG_TAG, "Caught exception shutting down store work queue.", e);
     }

--- a/src/main/java/org/mozilla/gecko/sync/synchronizer/RecordConsumer.java
+++ b/src/main/java/org/mozilla/gecko/sync/synchronizer/RecordConsumer.java
@@ -1,39 +1,6 @@
-/* ***** BEGIN LICENSE BLOCK *****
- * Version: MPL 1.1/GPL 2.0/LGPL 2.1
- *
- * The contents of this file are subject to the Mozilla Public License Version
- * 1.1 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- * http://www.mozilla.org/MPL/
- *
- * Software distributed under the License is distributed on an "AS IS" basis,
- * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
- * for the specific language governing rights and limitations under the
- * License.
- *
- * The Original Code is Android Sync Client.
- *
- * The Initial Developer of the Original Code is
- * the Mozilla Foundation.
- * Portions created by the Initial Developer are Copyright (C) 2011
- * the Initial Developer. All Rights Reserved.
- *
- * Contributor(s):
- *   Richard Newman <rnewman@mozilla.com>
- *
- * Alternatively, the contents of this file may be used under the terms of
- * either the GNU General Public License Version 2 or later (the "GPL"), or
- * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
- * in which case the provisions of the GPL or the LGPL are applicable instead
- * of those above. If you wish to allow use of your version of this file only
- * under the terms of either the GPL or the LGPL, and not to allow others to
- * use your version of this file under the terms of the MPL, indicate your
- * decision by deleting the provisions above and replace them with the notice
- * and other provisions required by the GPL or the LGPL. If you do not delete
- * the provisions above, a recipient may use your version of this file under
- * the terms of any one of the MPL, the GPL or the LGPL.
- *
- * ***** END LICENSE BLOCK ***** */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.gecko.sync.synchronizer;
 
@@ -56,5 +23,4 @@ public abstract class RecordConsumer implements Runnable {
   public RecordConsumer() {
     super();
   }
-
 }

--- a/src/main/java/org/mozilla/gecko/sync/synchronizer/RecordsChannel.java
+++ b/src/main/java/org/mozilla/gecko/sync/synchronizer/RecordsChannel.java
@@ -102,7 +102,8 @@ class RecordsChannel implements
   }
 
   /**
-   * Attempt to abort an outstanding fetch. Finish both sessions.
+   * Attempt to abort an outstanding fetch. Finish both sessions, and
+   * halt the consumer if it exists.
    */
   public void abort() {
     if (source.isActive()) {
@@ -111,7 +112,12 @@ class RecordsChannel implements
     if (sink.isActive()) {
       sink.abort();
     }
-    this.consumer.halt();
+
+    toProcess.clear();
+    if (consumer == null) {
+      return;
+    }
+    consumer.halt();
   }
 
   /**

--- a/src/main/java/org/mozilla/gecko/sync/synchronizer/RecordsChannel.java
+++ b/src/main/java/org/mozilla/gecko/sync/synchronizer/RecordsChannel.java
@@ -111,6 +111,7 @@ class RecordsChannel implements
     if (sink.isActive()) {
       sink.abort();
     }
+    this.consumer.halt();
   }
 
   /**


### PR DESCRIPTION
With these changes we now terminate outstanding HTTP connections, don't continue processing line-by-line content, don't continue attempting to store, and so on, as soon as we abort the sync.

Before:

https://bugzilla.mozilla.org/attachment.cgi?id=606435

After:

https://bugzilla.mozilla.org/attachment.cgi?id=606482

The only reason I observed this is because we now terminate the HTTP channels when the session is aborted after a single store failure! Previously we were aborting the sync, but it would continue and finish!

Pretty important.
