### PR TITLE
Bug 715794 - Adjust syncResult delay to implement client-count-based sync interval.

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/syncadapter/SyncAdapter.java
+++ b/src/main/java/org/mozilla/gecko/sync/syncadapter/SyncAdapter.java
@@ -51,7 +51,8 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements GlobalSe
 
   private static final int     SHARED_PREFERENCES_MODE = 0;
   private static final int     BACKOFF_PAD_SECONDS = 5;
-  private static final int     MINIMUM_SYNC_INTERVAL_MILLISECONDS = 5 * 60 * 1000;   // 5 minutes.
+  public  static final int     MULTI_DEVICE_INTERVAL_MILLISECONDS = 5 * 60 * 1000;         // 5 minutes.
+  public  static final int     SINGLE_DEVICE_INTERVAL_MILLISECONDS = 24 * 60 * 60 * 1000;  // 24 hours.
 
   private final AccountManager mAccountManager;
   private final Context        mContext;
@@ -297,7 +298,7 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements GlobalSe
       Log.i(LOG_TAG, "Waiting on sync monitor.");
       try {
         syncMonitor.wait();
-        long next = System.currentTimeMillis() + MINIMUM_SYNC_INTERVAL_MILLISECONDS;
+        long next = System.currentTimeMillis() + getSyncInterval();
         Log.i(LOG_TAG, "Setting minimum next sync time to " + next);
         extendEarliestNextSync(next);
       } catch (InterruptedException e) {
@@ -308,6 +309,15 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements GlobalSe
       }
     }
  }
+
+  public int getSyncInterval() {
+    int clientsCount = this.getClientsCount();
+    if (clientsCount <= 1) {
+      return SINGLE_DEVICE_INTERVAL_MILLISECONDS;
+    }
+
+    return MULTI_DEVICE_INTERVAL_MILLISECONDS;
+  }
 
 
   /**

--- a/src/main/java/org/mozilla/gecko/sync/syncadapter/SyncAdapter.java
+++ b/src/main/java/org/mozilla/gecko/sync/syncadapter/SyncAdapter.java
@@ -172,7 +172,7 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements GlobalSe
   public Object syncMonitor = new Object();
   private SyncResult syncResult;
 
-  private Account localAccount;
+  public Account localAccount;
 
   /**
    * Return the number of milliseconds until we're allowed to sync again,

--- a/test/src/org/mozilla/android/sync/test/TestClientsDataDelegate.java
+++ b/test/src/org/mozilla/android/sync/test/TestClientsDataDelegate.java
@@ -1,0 +1,72 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+package org.mozilla.android.sync.test;
+
+import org.mozilla.gecko.sync.delegates.ClientsDataDelegate;
+import org.mozilla.gecko.sync.setup.Constants;
+import org.mozilla.gecko.sync.syncadapter.SyncAdapter;
+
+import android.accounts.Account;
+import android.accounts.AccountManager;
+import android.content.Context;
+import android.os.Bundle;
+
+public class TestClientsDataDelegate extends AndroidSyncTestCase {
+  private Context context;
+  private ClientsDataDelegate clientsDelegate;
+  private AccountManager accountManager;
+  private final Account account = new Account("blah@mozilla.com", Constants.ACCOUNTTYPE_SYNC);;
+  private final Bundle userbundle = new Bundle();
+
+  public void setUp() {
+    context = getApplicationContext();
+    accountManager = AccountManager.get(context);
+    clientsDelegate = new SyncAdapter(context, false);
+
+    ((SyncAdapter)clientsDelegate).localAccount = account;
+    accountManager.addAccountExplicitly(account, "", userbundle);
+  }
+
+  public void tearDown() {
+    // Cleanup.
+    clientsDelegate.setClientsCount(0);
+  }
+
+  public void testGetAccountGUID() {
+    // Test getAccountGUID() saved the value it returned the first time.
+    String accountGUID = clientsDelegate.getAccountGUID();
+    assertNotNull(accountGUID);
+    assertEquals(accountGUID, clientsDelegate.getAccountGUID());
+  }
+
+  public void testGetClientName() {
+    // Test getClientName() saved the value it returned the first time.
+    String clientName = clientsDelegate.getClientName();
+    assertNotNull(clientName);
+    assertEquals(clientName, clientsDelegate.getClientName());
+  }
+
+  public void testClientsCount() {
+    final int CLIENTS_COUNT = 15;
+
+    assertEquals(0, clientsDelegate.getClientsCount());
+    clientsDelegate.setClientsCount(CLIENTS_COUNT);
+    assertEquals(CLIENTS_COUNT, clientsDelegate.getClientsCount());
+  }
+
+  public void testIsLocalGUID() {
+    assertTrue(clientsDelegate.isLocalGUID(clientsDelegate.getAccountGUID()));
+  }
+
+  public void testGetSyncInterval() {
+    assertEquals(0, clientsDelegate.getClientsCount());
+    assertEquals(SyncAdapter.SINGLE_DEVICE_INTERVAL_MILLISECONDS, ((SyncAdapter)clientsDelegate).getSyncInterval());
+
+    clientsDelegate.setClientsCount(1);
+    assertEquals(SyncAdapter.SINGLE_DEVICE_INTERVAL_MILLISECONDS, ((SyncAdapter)clientsDelegate).getSyncInterval());
+
+    clientsDelegate.setClientsCount(2);
+    assertEquals(SyncAdapter.MULTI_DEVICE_INTERVAL_MILLISECONDS, ((SyncAdapter)clientsDelegate).getSyncInterval());
+  }
+}


### PR DESCRIPTION
- Includes tests for ClientsDataDelegate functions as well.
- Should we be flagging some test in litmus to test sync intervals?
