### PR TITLE
Bug 739515 - Defensive coding for Fennec history entries.

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserHistoryDataExtender.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserHistoryDataExtender.java
@@ -138,6 +138,11 @@ public class AndroidBrowserHistoryDataExtender extends CachedSQLiteOpenHelper {
   }
 
   public JSONArray visitsForGUID(String guid) throws NullCursorException {
+    if (guid == null) {
+      Logger.warn(LOG_TAG, "Asked for visits for null GUID.");
+      return new JSONArray();
+    }
+
     Logger.debug(LOG_TAG, "Fetching visits for GUID " + guid);
     Cursor visits = fetch(guid);
     try {

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserRepositoryDataAccessor.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserRepositoryDataAccessor.java
@@ -92,10 +92,14 @@ public abstract class AndroidBrowserRepositoryDataAccessor {
     return BrowserContract.SyncColumns.DATE_MODIFIED + " >= " + Long.toString(timestamp);
   }
 
-  public void wipe() {
+  public void delete(String where, String[] args) {
     Uri uri = getUri();
-    Logger.debug(LOG_TAG, "Wiping: " + uri);
-    context.getContentResolver().delete(uri, null, null);
+    context.getContentResolver().delete(uri, where, args);
+  }
+
+  public void wipe() {
+    Logger.debug(LOG_TAG, "Wiping.");
+    delete(null, null);
   }
 
   public void purgeDeleted() throws NullCursorException {


### PR DESCRIPTION
Not entirely tested yet, but should be fine.
