### PR TITLE
Add check_head_headers.sh to verify that all files modified between

### DIFF
--- a/check_head_headers.sh
+++ b/check_head_headers.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Verify that HEAD headers are up to date.
+
+python "tools/check_headers.py" -l "package" -f "tools/COPYRIGHT_MPL" -x "test" "$@" `git diff --name-only develop HEAD | grep ^src/main/java/org/mozilla/`
+python "tools/check_headers.py" -l "package" -f "tools/COPYRIGHT_PD" "$@" `git diff --name-only develop HEAD | grep ^src/test/java/org/mozilla`
+python "tools/check_headers.py" -l "package" -f "tools/COPYRIGHT_PD" "$@" `git diff --name-only develop HEAD | grep ^test/src/org/mozilla`

--- a/tools/check_headers.py
+++ b/tools/check_headers.py
@@ -17,7 +17,7 @@ parser.add_argument('-x', dest='exclude_pat', default='', help='ignore source fi
 parser.add_argument('-d', dest='dry_run', action='store_true', default=False, help='do not write updated source files')
 parser.add_argument('-v', dest='verbose', action='store_true', default=False, help='verbose output')
 parser.add_argument('-s', dest='print_summary', default=True, help='print summary')
-parser.add_argument('files', nargs='+', help='files and directories to update')
+parser.add_argument('files', nargs='*', help='files and directories to update')
 
 args = parser.parse_args(sys.argv[1:])
 


### PR DESCRIPTION
develop and HEAD have up to date licenses.

Just a little guy to ease the last step before push.
