### PR TITLE
Bug 740247 - Follow up: HTTP 412 Error due to inconsistent server & local timestamps

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/CryptoRecord.java
+++ b/src/main/java/org/mozilla/gecko/sync/CryptoRecord.java
@@ -227,8 +227,10 @@ public class CryptoRecord extends Record {
   // TODO: this only works with encrypted object, and has other limitations.
   public JSONObject toJSONObject() {
     ExtendedJSONObject o = new ExtendedJSONObject();
-    o.put(KEY_PAYLOAD, payload.toJSONString());
-    o.put(KEY_ID,      this.guid);
+    o.put(KEY_PAYLOAD,    payload.toJSONString());
+    o.put(KEY_ID,         this.guid);
+    o.put(KEY_MODIFIED,   this.lastModified);
+    o.put(KEY_COLLECTION, this.collection);
     return o.object;
   }
 

--- a/src/main/java/org/mozilla/gecko/sync/CryptoRecord.java
+++ b/src/main/java/org/mozilla/gecko/sync/CryptoRecord.java
@@ -229,8 +229,6 @@ public class CryptoRecord extends Record {
     ExtendedJSONObject o = new ExtendedJSONObject();
     o.put(KEY_PAYLOAD,    payload.toJSONString());
     o.put(KEY_ID,         this.guid);
-    o.put(KEY_MODIFIED,   this.lastModified);
-    o.put(KEY_COLLECTION, this.collection);
     return o.object;
   }
 

--- a/src/main/java/org/mozilla/gecko/sync/stage/SyncClientsEngineStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/SyncClientsEngineStage.java
@@ -18,6 +18,7 @@ import org.mozilla.gecko.sync.GlobalSession;
 import org.mozilla.gecko.sync.HTTPFailureException;
 import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.NoCollectionKeysSetException;
+import org.mozilla.gecko.sync.Utils;
 import org.mozilla.gecko.sync.crypto.CryptoException;
 import org.mozilla.gecko.sync.crypto.KeyBundle;
 import org.mozilla.gecko.sync.delegates.ClientsDataDelegate;
@@ -164,8 +165,14 @@ public class SyncClientsEngineStage implements GlobalSyncStage {
 
     @Override
     public String ifUnmodifiedSince() {
-      // Temporary fix for bug 739519.
-      return null;
+      Long timestampInMilliseconds = session.config.getPersistedServerClientRecordTimestamp();
+
+      // It's the first upload so we don't care about X-If-Unmodified-Since.
+      if (timestampInMilliseconds == 0) {
+        return null;
+      }
+
+      return Utils.millisecondsToDecimalSecondsString(timestampInMilliseconds);
     }
 
     @Override

--- a/src/main/java/org/mozilla/gecko/sync/stage/SyncClientsEngineStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/SyncClientsEngineStage.java
@@ -86,6 +86,7 @@ public class SyncClientsEngineStage implements GlobalSyncStage {
       // If we successfully downloaded all records but ours was not one of them
       // then reset the timestamp.
       if (!localAccountGUIDDownloaded) {
+        Logger.info(LOG_TAG, "Local client GUID does not exist on the server. Upload timestamp will be reset.");
         session.config.persistServerClientRecordTimestamp(0);
       }
       localAccountGUIDDownloaded = false;
@@ -140,6 +141,7 @@ public class SyncClientsEngineStage implements GlobalSyncStage {
       try {
         r = (ClientRecord) factory.createRecord(record.decrypt());
         if (clientsDelegate.isLocalGUID(r.guid)) {
+          Logger.info(LOG_TAG, "Local client GUID exists on server and was downloaded");
           localAccountGUIDDownloaded = true;
           // Oh hey! Our record is on the server. This is the authoritative
           // server timestamp, so let's hang on to it to decide whether we
@@ -198,6 +200,9 @@ public class SyncClientsEngineStage implements GlobalSyncStage {
         long timestamp = Utils.decimalSecondsToMilliseconds(response.body().toString());
         session.config.persistServerClientRecordTimestamp(timestamp);
         BaseResource.consumeEntity(response);
+
+        Logger.info(LOG_TAG, "Timestamp from body is: " + timestamp);
+        Logger.info(LOG_TAG, "Timestamp from header is: " + response.normalizedWeaveTimestamp());
       } catch (Exception e) {
         e.printStackTrace();
         session.abort(e, "Unable to fetch timestamp.");

--- a/src/main/java/org/mozilla/gecko/sync/stage/SyncClientsEngineStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/SyncClientsEngineStage.java
@@ -197,14 +197,13 @@ public class SyncClientsEngineStage implements GlobalSyncStage {
         commandsProcessedShouldUpload = false;
         uploadAttemptsCount.set(0);
 
-        long timestamp = Utils.decimalSecondsToMilliseconds(response.body().toString());
+        long timestamp = Utils.decimalSecondsToMilliseconds(response.body());
         session.config.persistServerClientRecordTimestamp(timestamp);
         BaseResource.consumeEntity(response);
 
-        Logger.info(LOG_TAG, "Timestamp from body is: " + timestamp);
-        Logger.info(LOG_TAG, "Timestamp from header is: " + response.normalizedWeaveTimestamp());
+        Logger.debug(LOG_TAG, "Timestamp from body is: " + timestamp);
+        Logger.debug(LOG_TAG, "Timestamp from header is: " + response.normalizedWeaveTimestamp());
       } catch (Exception e) {
-        e.printStackTrace();
         session.abort(e, "Unable to fetch timestamp.");
         return;
       }

--- a/src/main/java/org/mozilla/gecko/sync/stage/SyncClientsEngineStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/SyncClientsEngineStage.java
@@ -66,6 +66,7 @@ public class SyncClientsEngineStage implements GlobalSyncStage {
 
     // We use this on each WBO, so lift it out.
     final ClientsDataDelegate clientsDelegate = session.getClientsDelegate();
+    boolean localAccountGUIDDownloaded = false;
 
     @Override
     public String credentials() {
@@ -81,6 +82,14 @@ public class SyncClientsEngineStage implements GlobalSyncStage {
     @Override
     public void handleRequestSuccess(SyncStorageResponse response) {
       BaseResource.consumeEntity(response); // We don't need the response at all.
+
+      // If we successfully downloaded all records but ours was not one of them
+      // then reset the timestamp.
+      if (!localAccountGUIDDownloaded) {
+        session.config.persistServerClientRecordTimestamp(0);
+      }
+      localAccountGUIDDownloaded = false;
+
       final int clientsCount;
       try {
         clientsCount = db.clientsCount();
@@ -102,6 +111,8 @@ public class SyncClientsEngineStage implements GlobalSyncStage {
     @Override
     public void handleRequestFailure(SyncStorageResponse response) {
       BaseResource.consumeEntity(response); // We don't need the response at all, and any exception handling shouldn't need the response body.
+      localAccountGUIDDownloaded = false;
+
       try {
         Logger.info(LOG_TAG, "Client upload failed. Aborting sync.");
         session.abort(new HTTPFailureException(response), "Client download failed.");
@@ -113,6 +124,7 @@ public class SyncClientsEngineStage implements GlobalSyncStage {
 
     @Override
     public void handleRequestError(Exception ex) {
+      localAccountGUIDDownloaded = false;
       try {
         Logger.info(LOG_TAG, "Client upload error. Aborting sync.");
         session.abort(ex, "Failure fetching client record.");
@@ -128,6 +140,7 @@ public class SyncClientsEngineStage implements GlobalSyncStage {
       try {
         r = (ClientRecord) factory.createRecord(record.decrypt());
         if (clientsDelegate.isLocalGUID(r.guid)) {
+          localAccountGUIDDownloaded = true;
           // Oh hey! Our record is on the server. This is the authoritative
           // server timestamp, so let's hang on to it to decide whether we
           // need to upload.

--- a/src/main/java/org/mozilla/gecko/sync/stage/SyncClientsEngineStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/SyncClientsEngineStage.java
@@ -191,11 +191,18 @@ public class SyncClientsEngineStage implements GlobalSyncStage {
     @Override
     public void handleRequestSuccess(SyncStorageResponse response) {
       Logger.debug(LOG_TAG, "Upload succeeded.");
-      commandsProcessedShouldUpload = false;
-      uploadAttemptsCount.set(0);
-      session.config.persistServerClientRecordTimestamp(response.normalizedWeaveTimestamp());
+      try {
+        commandsProcessedShouldUpload = false;
+        uploadAttemptsCount.set(0);
 
-      BaseResource.consumeEntity(response);
+        long timestamp = Utils.decimalSecondsToMilliseconds(response.body().toString());
+        session.config.persistServerClientRecordTimestamp(timestamp);
+        BaseResource.consumeEntity(response);
+      } catch (Exception e) {
+        e.printStackTrace();
+        session.abort(e, "Unable to fetch timestamp.");
+        return;
+      }
       session.advance();
     }
 

--- a/src/main/java/org/mozilla/gecko/sync/syncadapter/SyncAdapter.java
+++ b/src/main/java/org/mozilla/gecko/sync/syncadapter/SyncAdapter.java
@@ -12,6 +12,7 @@ import org.json.simple.parser.ParseException;
 import org.mozilla.gecko.sync.AlreadySyncingException;
 import org.mozilla.gecko.sync.GlobalConstants;
 import org.mozilla.gecko.sync.GlobalSession;
+import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.NonObjectJSONException;
 import org.mozilla.gecko.sync.SyncConfiguration;
 import org.mozilla.gecko.sync.SyncConfigurationException;
@@ -408,6 +409,7 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements GlobalSe
   public synchronized String getAccountGUID() {
     String accountGUID = mAccountManager.getUserData(localAccount, Constants.ACCOUNT_GUID);
     if (accountGUID == null) {
+      Logger.info(LOG_TAG, "Account GUID was null. Creating a new one.");
       accountGUID = Utils.generateGuid();
       mAccountManager.setUserData(localAccount, Constants.ACCOUNT_GUID, accountGUID);
     }

--- a/src/test/java/org/mozilla/android/sync/net/test/TestClientsEngineStage.java
+++ b/src/test/java/org/mozilla/android/sync/net/test/TestClientsEngineStage.java
@@ -176,13 +176,14 @@ public class TestClientsEngineStage extends MockSyncClientsEngineStage {
     @Override
     public void handleRequestFailure(SyncStorageResponse response) {
       super.handleRequestFailure(response);
-      fail("Should not error.");
+      fail("Should not fail.");
     }
 
     @Override
     public void handleRequestError(Exception ex) {
       super.handleRequestError(ex);
-      fail("Should not fail.");
+      ex.printStackTrace();
+      fail("Should not error.");
     }
   }
 
@@ -254,7 +255,7 @@ public class TestClientsEngineStage extends MockSyncClientsEngineStage {
   private long setRecentClientRecordTimestamp() {
     long timestamp = System.currentTimeMillis() - (CLIENTS_TTL_REFRESH - 1000);
     session.config.persistServerClientRecordTimestamp(timestamp);
-      return timestamp;
+    return timestamp;
   }
 
   private void performFailingUpload() {

--- a/src/test/java/org/mozilla/android/sync/net/test/TestClientsEngineStage.java
+++ b/src/test/java/org/mozilla/android/sync/net/test/TestClientsEngineStage.java
@@ -98,7 +98,7 @@ public class TestClientsEngineStage extends MockSyncClientsEngineStage {
   @After
   public void teardown() {
     stubUpload = false;
-    ((MockClientsDatabaseAccessor)db).resetVars();
+    ((MockClientsDatabaseAccessor) db).resetVars();
   }
 
   @Before
@@ -160,14 +160,14 @@ public class TestClientsEngineStage extends MockSyncClientsEngineStage {
     @Override
     public void handleRequestFailure(SyncStorageResponse response) {
       super.handleRequestFailure(response);
-      assertTrue(((MockClientsDatabaseAccessor)db).closed);
+      assertTrue(((MockClientsDatabaseAccessor) db).closed);
       fail("Should not error.");
     }
 
     @Override
     public void handleRequestError(Exception ex) {
       super.handleRequestError(ex);
-      assertTrue(((MockClientsDatabaseAccessor)db).closed);
+      assertTrue(((MockClientsDatabaseAccessor) db).closed);
       fail("Should not fail.");
     }
 
@@ -192,14 +192,14 @@ public class TestClientsEngineStage extends MockSyncClientsEngineStage {
     @Override
     public void handleRequestFailure(SyncStorageResponse response) {
       super.handleRequestFailure(response);
-      assertTrue(((MockClientsDatabaseAccessor)db).closed);
+      assertTrue(((MockClientsDatabaseAccessor) db).closed);
       fail("Should not error.");
     }
 
     @Override
     public void handleRequestError(Exception ex) {
       super.handleRequestError(ex);
-      assertTrue(((MockClientsDatabaseAccessor)db).closed);
+      assertTrue(((MockClientsDatabaseAccessor) db).closed);
       ex.printStackTrace();
       fail("Should not fail.");
     }
@@ -374,8 +374,8 @@ public class TestClientsEngineStage extends MockSyncClientsEngineStage {
     assertFalse(shouldWipe);
     wipeAndStore(new ClientRecord());
     assertFalse(shouldWipe);
-    assertFalse(((MockClientsDatabaseAccessor)db).wiped);
-    assertTrue(((MockClientsDatabaseAccessor)db).storedRecord);
+    assertFalse(((MockClientsDatabaseAccessor) db).wiped);
+    assertTrue(((MockClientsDatabaseAccessor) db).storedRecord);
   }
 
   @Test
@@ -384,8 +384,8 @@ public class TestClientsEngineStage extends MockSyncClientsEngineStage {
     shouldWipe = true;
     wipeAndStore(new ClientRecord());
     assertFalse(shouldWipe);
-    assertTrue(((MockClientsDatabaseAccessor)db).wiped);
-    assertTrue(((MockClientsDatabaseAccessor)db).storedRecord);
+    assertTrue(((MockClientsDatabaseAccessor) db).wiped);
+    assertTrue(((MockClientsDatabaseAccessor) db).storedRecord);
   }
 
   @Test
@@ -408,7 +408,7 @@ public class TestClientsEngineStage extends MockSyncClientsEngineStage {
     for (int i = 0; i < downloadedClients.size(); i++) {
       assertTrue(expectedClients.get(i).guid.equals(downloadedClients.get(i).guid));
     }
-    assertTrue(((MockClientsDatabaseAccessor)db).closed);
+    assertTrue(((MockClientsDatabaseAccessor) db).closed);
   }
 
   @Test
@@ -459,7 +459,7 @@ public class TestClientsEngineStage extends MockSyncClientsEngineStage {
     // Timestamp got updated (but not reset) since we downloaded our record
     assertFalse(0 == session.config.getPersistedServerClientRecordTimestamp());
     assertTrue(initialTimestamp < session.config.getPersistedServerClientRecordTimestamp());
-    assertTrue(((MockClientsDatabaseAccessor)db).closed);
+    assertTrue(((MockClientsDatabaseAccessor) db).closed);
   }
 
   @Test
@@ -480,7 +480,7 @@ public class TestClientsEngineStage extends MockSyncClientsEngineStage {
 
     // Timestamp got reset since our record wasn't downloaded.
     assertEquals(0, session.config.getPersistedServerClientRecordTimestamp());
-    assertTrue(((MockClientsDatabaseAccessor)db).closed);
+    assertTrue(((MockClientsDatabaseAccessor) db).closed);
   }
 
   /**

--- a/src/test/java/org/mozilla/android/sync/test/helpers/MockSyncClientsEngineStage.java
+++ b/src/test/java/org/mozilla/android/sync/test/helpers/MockSyncClientsEngineStage.java
@@ -20,8 +20,6 @@ public class MockSyncClientsEngineStage extends SyncClientsEngineStage {
     @Override
     public void handleRequestSuccess(SyncStorageResponse response) {
       assertTrue(response.wasSuccessful());
-      // Make sure we consume the entity, so we can reuse the connection.
-      BaseResource.consumeEntity(response);
       data.stopHTTPServer();
       super.handleRequestSuccess(response);
     }


### PR DESCRIPTION
Still needs to be tested on device + need to make sure upgrading fennec doesn't also trigger this bug, otherwise accountGUID would need to be saved in prefs rather than Account object
