### PR TITLE
Bugs 709234 and 730643: persist crypto/keys and meta/global.

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/CollectionKeys.java
+++ b/src/main/java/org/mozilla/gecko/sync/CollectionKeys.java
@@ -1,39 +1,6 @@
-/* ***** BEGIN LICENSE BLOCK *****
- * Version: MPL 1.1/GPL 2.0/LGPL 2.1
- *
- * The contents of this file are subject to the Mozilla Public License Version
- * 1.1 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- * http://www.mozilla.org/MPL/
- *
- * Software distributed under the License is distributed on an "AS IS" basis,
- * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
- * for the specific language governing rights and limitations under the
- * License.
- *
- * The Original Code is Android Sync Client.
- *
- * The Initial Developer of the Original Code is
- * the Mozilla Foundation.
- * Portions created by the Initial Developer are Copyright (C) 2011
- * the Initial Developer. All Rights Reserved.
- *
- * Contributor(s):
- *   Richard Newman <rnewman@mozilla.com>
- *
- * Alternatively, the contents of this file may be used under the terms of
- * either the GNU General Public License Version 2 or later (the "GPL"), or
- * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
- * in which case the provisions of the GPL or the LGPL are applicable instead
- * of those above. If you wish to allow use of your version of this file only
- * under the terms of either the GPL or the LGPL, and not to allow others to
- * use your version of this file under the terms of the MPL, indicate your
- * decision by deleting the provisions above and replace them with the notice
- * and other provisions required by the GPL or the LGPL. If you do not delete
- * the provisions above, a recipient may use your version of this file under
- * the terms of any one of the MPL, the GPL or the LGPL.
- *
- * ***** END LICENSE BLOCK ***** */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.gecko.sync;
 
@@ -48,8 +15,6 @@ import org.mozilla.apache.commons.codec.binary.Base64;
 import org.mozilla.gecko.sync.crypto.CryptoException;
 import org.mozilla.gecko.sync.crypto.KeyBundle;
 
-import android.util.Log;
-
 public class CollectionKeys {
   private static final String LOG_TAG = "CollectionKeys";
   private KeyBundle                  defaultKeyBundle     = null;
@@ -61,7 +26,7 @@ public class CollectionKeys {
       return ck.asCryptoRecord();
     } catch (NoCollectionKeysSetException e) {
       // Cannot occur.
-      Log.e(LOG_TAG, "generateCollectionKeys returned a value with no default key. Unpossible.", e);
+      Logger.error(LOG_TAG, "generateCollectionKeys returned a value with no default key.", e);
       throw new IllegalStateException("CollectionKeys should not have null default key.");
     }
   }
@@ -138,38 +103,40 @@ public class CollectionKeys {
     return record;
   }
 
+  /**
+   * Return a <code>CollectionKeys</code> with the given key bundle and data
+   * (possibly decrypted) from the given record.
+   *
+   * @param keys
+   *          A "crypto/keys" <code>CryptoRecord</code>, encrypted with
+   *          <code>syncKeyBundle</code> if <code>syncKeyBundle</code> is non-null.
+   * @param syncKeyBundle
+   *          If non-null, the sync key bundle to decrypt <code>keys</code> with.
+   * @return
+   *          The <code>CollectionKeys</code> object corresponding to <code>keys</code>.
+   */
   public static CollectionKeys fromCryptoRecord(CryptoRecord keys, KeyBundle syncKeyBundle) throws CryptoException, IOException, ParseException, NonObjectJSONException {
-    if (syncKeyBundle != null) {
-      keys.keyBundle = syncKeyBundle;
-      keys.decrypt();
-    }
-    ExtendedJSONObject cleartext = keys.payload;
-    KeyBundle defaultKey = arrayToKeyBundle((JSONArray) cleartext.get("default"));
-
-    ExtendedJSONObject collections = cleartext.getObject("collections");
-    HashMap<String, KeyBundle> collectionKeys = new HashMap<String, KeyBundle>();
-    for (Entry<String, Object> pair : collections.entryIterable()) {
-      KeyBundle bundle = arrayToKeyBundle((JSONArray) pair.getValue());
-      collectionKeys.put(pair.getKey(), bundle);
-    }
-
     CollectionKeys ck = new CollectionKeys();
-    ck.collectionKeyBundles = collectionKeys;
-    ck.defaultKeyBundle     = defaultKey;
+    ck.setKeyPairsFromWBO(keys, syncKeyBundle);
     return ck;
   }
 
   /**
-   * Take a downloaded record, and the Sync Key, decrypting the record and
-   * setting our own keys accordingly.
+   * Set my key bundle and collection keys with the given key bundle and data
+   * (possibly decrypted) from the given record.
+   *
+   * @param keys
+   *          A "crypto/keys" <code>CryptoRecord</code>, encrypted with
+   *          <code>syncKeyBundle</code> if <code>syncKeyBundle</code> is non-null.
+   * @param syncKeyBundle
+   *          If non-null, the sync key bundle to decrypt <code>keys</code> with.
    */
   public void setKeyPairsFromWBO(CryptoRecord keys, KeyBundle syncKeyBundle)
-                                                                            throws CryptoException,
-                                                                            IOException,
-                                                                            ParseException,
-                                                                            NonObjectJSONException {
-    keys.keyBundle = syncKeyBundle;
-    keys.decrypt();
+      throws CryptoException, IOException, ParseException, NonObjectJSONException {
+    if (syncKeyBundle != null) {
+      keys.keyBundle = syncKeyBundle;
+      keys.decrypt();
+    }
     ExtendedJSONObject cleartext = keys.payload;
     KeyBundle defaultKey = arrayToKeyBundle((JSONArray) cleartext.get("default"));
 

--- a/src/main/java/org/mozilla/gecko/sync/CollectionKeys.java
+++ b/src/main/java/org/mozilla/gecko/sync/CollectionKeys.java
@@ -104,24 +104,6 @@ public class CollectionKeys {
   }
 
   /**
-   * Return a <code>CollectionKeys</code> with the given key bundle and data
-   * (possibly decrypted) from the given record.
-   *
-   * @param keys
-   *          A "crypto/keys" <code>CryptoRecord</code>, encrypted with
-   *          <code>syncKeyBundle</code> if <code>syncKeyBundle</code> is non-null.
-   * @param syncKeyBundle
-   *          If non-null, the sync key bundle to decrypt <code>keys</code> with.
-   * @return
-   *          The <code>CollectionKeys</code> object corresponding to <code>keys</code>.
-   */
-  public static CollectionKeys fromCryptoRecord(CryptoRecord keys, KeyBundle syncKeyBundle) throws CryptoException, IOException, ParseException, NonObjectJSONException {
-    CollectionKeys ck = new CollectionKeys();
-    ck.setKeyPairsFromWBO(keys, syncKeyBundle);
-    return ck;
-  }
-
-  /**
    * Set my key bundle and collection keys with the given key bundle and data
    * (possibly decrypted) from the given record.
    *

--- a/src/main/java/org/mozilla/gecko/sync/CredentialsSource.java
+++ b/src/main/java/org/mozilla/gecko/sync/CredentialsSource.java
@@ -1,47 +1,9 @@
-/* ***** BEGIN LICENSE BLOCK *****
- * Version: MPL 1.1/GPL 2.0/LGPL 2.1
- *
- * The contents of this file are subject to the Mozilla Public License Version
- * 1.1 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- * http://www.mozilla.org/MPL/
- *
- * Software distributed under the License is distributed on an "AS IS" basis,
- * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
- * for the specific language governing rights and limitations under the
- * License.
- *
- * The Original Code is Android Sync Client.
- *
- * The Initial Developer of the Original Code is
- * the Mozilla Foundation.
- * Portions created by the Initial Developer are Copyright (C) 2011
- * the Initial Developer. All Rights Reserved.
- *
- * Contributor(s):
- *   Richard Newman <rnewman@mozilla.com>
- *
- * Alternatively, the contents of this file may be used under the terms of
- * either the GNU General Public License Version 2 or later (the "GPL"), or
- * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
- * in which case the provisions of the GPL or the LGPL are applicable instead
- * of those above. If you wish to allow use of your version of this file only
- * under the terms of either the GPL or the LGPL, and not to allow others to
- * use your version of this file under the terms of the MPL, indicate your
- * decision by deleting the provisions above and replace them with the notice
- * and other provisions required by the GPL or the LGPL. If you do not delete
- * the provisions above, a recipient may use your version of this file under
- * the terms of any one of the MPL, the GPL or the LGPL.
- *
- * ***** END LICENSE BLOCK ***** */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.gecko.sync;
 
-import org.mozilla.gecko.sync.crypto.KeyBundle;
-
 public interface CredentialsSource {
-
   public abstract String credentials();
-  public abstract CollectionKeys getCollectionKeys();
-  public abstract KeyBundle keyForCollection(String collection) throws NoCollectionKeysSetException;
 }

--- a/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
+++ b/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
@@ -344,13 +344,6 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
     }
   }
 
-  public void fetchMetaGlobal(MetaGlobalDelegate callback) throws URISyntaxException {
-    if (this.config.metaGlobal == null) {
-      this.config.metaGlobal = new MetaGlobal(config.metaURL(), credentials());
-    }
-    this.config.metaGlobal.fetch(callback);
-  }
-
   public void fetchInfoCollections(InfoCollectionsDelegate callback) throws URISyntaxException {
     if (this.config.infoCollections == null) {
       this.config.infoCollections = new InfoCollections(config.infoURL(), credentials());
@@ -418,6 +411,8 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
    * meta/global callbacks.
    */
   public void processMetaGlobal(MetaGlobal global) {
+    config.metaGlobal = global;
+
     Long storageVersion = global.getStorageVersion();
     if (storageVersion < STORAGE_VERSION) {
       // Outdated server.

--- a/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
+++ b/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
@@ -552,54 +552,6 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
             Logger.warn(LOG_TAG, "Got error uploading new meta/global.", e);
             freshStartDelegate.onFreshStartFailed(e);
           }
-
-          @Override
-          public MetaGlobalDelegate deferred() {
-            final MetaGlobalDelegate self = this;
-            return new MetaGlobalDelegate() {
-
-              @Override
-              public void handleSuccess(final MetaGlobal global, final SyncStorageResponse response) {
-                ThreadPool.run(new Runnable() {
-                  @Override
-                  public void run() {
-                    self.handleSuccess(global, response);
-                  }});
-              }
-
-              @Override
-              public void handleMissing(final MetaGlobal global, final SyncStorageResponse response) {
-                ThreadPool.run(new Runnable() {
-                  @Override
-                  public void run() {
-                    self.handleMissing(global, response);
-                  }});
-              }
-
-              @Override
-              public void handleFailure(final SyncStorageResponse response) {
-                ThreadPool.run(new Runnable() {
-                  @Override
-                  public void run() {
-                    self.handleFailure(response);
-                  }});
-              }
-
-              @Override
-              public void handleError(final Exception e) {
-                ThreadPool.run(new Runnable() {
-                  @Override
-                  public void run() {
-                    self.handleError(e);
-                  }});
-              }
-
-              @Override
-              public MetaGlobalDelegate deferred() {
-                return this;
-              }
-            };
-          }
         });
       }
 

--- a/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
+++ b/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
@@ -36,7 +36,7 @@ import org.mozilla.gecko.sync.stage.AndroidBrowserHistoryServerSyncStage;
 import org.mozilla.gecko.sync.stage.CheckPreconditionsStage;
 import org.mozilla.gecko.sync.stage.CompletedStage;
 import org.mozilla.gecko.sync.stage.EnsureClusterURLStage;
-import org.mozilla.gecko.sync.stage.EnsureKeysStage;
+import org.mozilla.gecko.sync.stage.EnsureCrypto5KeysStage;
 import org.mozilla.gecko.sync.stage.FennecTabsServerSyncStage;
 import org.mozilla.gecko.sync.stage.FetchInfoCollectionsStage;
 import org.mozilla.gecko.sync.stage.FetchMetaGlobalStage;
@@ -184,7 +184,7 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
     stages.put(Stage.ensureClusterURL,        new EnsureClusterURLStage());
     stages.put(Stage.fetchInfoCollections,    new FetchInfoCollectionsStage());
     stages.put(Stage.fetchMetaGlobal,         new FetchMetaGlobalStage());
-    stages.put(Stage.ensureKeysStage,         new EnsureKeysStage());
+    stages.put(Stage.ensureKeysStage,         new EnsureCrypto5KeysStage());
     stages.put(Stage.syncClientsEngine,       new SyncClientsEngineStage());
 
     // TODO: more stages.

--- a/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
+++ b/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
@@ -439,9 +439,7 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
     if (!remoteSyncID.equals(localSyncID)) {
       // Sync ID has changed. Reset timestamps and fetch new keys.
       resetClient(null);
-      if (config.collectionKeys != null) {
-        config.collectionKeys.clear();
-      }
+      config.purgeCryptoKeys();
       config.syncID = remoteSyncID;
       // TODO TODO TODO
     }
@@ -492,7 +490,7 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
       @Override
       public void onWiped(long timestamp) {
         session.resetClient(null);
-        session.config.collectionKeys.clear();      // TODO: make sure we clear our keys timestamp.
+        session.config.purgeCryptoKeys();
         session.config.persistToPrefs();
 
         MetaGlobal mg = new MetaGlobal(metaURL, credentials);

--- a/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
+++ b/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
@@ -69,16 +69,8 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
   /*
    * Key accessors.
    */
-  public void setCollectionKeys(CollectionKeys k) {
-    config.setCollectionKeys(k);
-  }
-  @Override
-  public CollectionKeys getCollectionKeys() {
-    return config.collectionKeys;
-  }
-  @Override
-  public KeyBundle keyForCollection(String collection) throws NoCollectionKeysSetException {
-    return config.keyForCollection(collection);
+  public KeyBundle keyBundleForCollection(String collection) throws NoCollectionKeysSetException {
+    return config.getCollectionKeys().keyBundleForCollection(collection);
   }
 
   /*
@@ -271,7 +263,6 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
     return this.getContext().getSharedPreferences(name, mode);
   }
 
-  @Override
   public Context getContext() {
     return this.context;
   }

--- a/src/main/java/org/mozilla/gecko/sync/InfoCollections.java
+++ b/src/main/java/org/mozilla/gecko/sync/InfoCollections.java
@@ -1,39 +1,6 @@
-/* ***** BEGIN LICENSE BLOCK *****
- * Version: MPL 1.1/GPL 2.0/LGPL 2.1
- *
- * The contents of this file are subject to the Mozilla Public License Version
- * 1.1 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- * http://www.mozilla.org/MPL/
- *
- * Software distributed under the License is distributed on an "AS IS" basis,
- * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
- * for the specific language governing rights and limitations under the
- * License.
- *
- * The Original Code is Android Sync Client.
- *
- * The Initial Developer of the Original Code is
- * the Mozilla Foundation.
- * Portions created by the Initial Developer are Copyright (C) 2011
- * the Initial Developer. All Rights Reserved.
- *
- * Contributor(s):
- * Richard Newman <rnewman@mozilla.com>
- *
- * Alternatively, the contents of this file may be used under the terms of
- * either the GNU General Public License Version 2 or later (the "GPL"), or
- * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
- * in which case the provisions of the GPL or the LGPL are applicable instead
- * of those above. If you wish to allow use of your version of this file only
- * under the terms of either the GPL or the LGPL, and not to allow others to
- * use your version of this file under the terms of the MPL, indicate your
- * decision by deleting the provisions above and replace them with the notice
- * and other provisions required by the GPL or the LGPL. If you do not delete
- * the provisions above, a recipient may use your version of this file under
- * the terms of any one of the MPL, the GPL or the LGPL.
- *
- * ***** END LICENSE BLOCK ***** */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.gecko.sync;
 
@@ -56,17 +23,13 @@ public class InfoCollections implements SyncStorageRequestDelegate {
   protected String infoURL;
   protected String credentials;
 
-  // Fetched objects.
-  protected SyncStorageResponse response;
-  private ExtendedJSONObject    record;
-
   // Fields.
   // Rather than storing decimal/double timestamps, as provided by the
   // server, we convert immediately to milliseconds since epoch.
   private HashMap<String, Long> timestamps;
 
   public HashMap<String, Long> getTimestamps() {
-    if (!this.wasSuccessful()) {
+    if (this.timestamps == null) {
       throw new IllegalStateException("No record fetched.");
     }
     return this.timestamps;
@@ -76,9 +39,31 @@ public class InfoCollections implements SyncStorageRequestDelegate {
     return this.getTimestamps().get(collection);
   }
 
-  public boolean wasSuccessful() {
-    return this.response.wasSuccessful() &&
-           this.timestamps != null;
+  /**
+   * Test if a given collection needs to be updated.
+   *
+   * @param collection
+   *          The collection to test.
+   * @param lastModified
+   *          Timestamp when local record was last modified.
+   */
+  public boolean updateNeeded(String collection, long lastModified) {
+    Logger.trace(LOG_TAG, "Testing " + collection + " for updateNeeded. Local last modified is " + lastModified + ".");
+
+    // No local record of modification time? Need an update.
+    if (lastModified <= 0) {
+      return true;
+    }
+
+    // No meta/global on the server? We need an update. The server fetch will fail and
+    // then we will upload a fresh meta/global.
+    Long serverLastModified = getTimestamp(collection);
+    if (serverLastModified == null) {
+      return true;
+    }
+
+    // Otherwise, we need an update if our modification time is stale.
+    return (serverLastModified.longValue() > lastModified);
   }
 
   // Temporary location to store our callback.
@@ -90,7 +75,7 @@ public class InfoCollections implements SyncStorageRequestDelegate {
   }
 
   public void fetch(InfoCollectionsDelegate callback) {
-    if (this.response == null) {
+    if (this.timestamps == null) {
       this.callback = callback;
       this.doFetch();
       return;
@@ -118,29 +103,12 @@ public class InfoCollections implements SyncStorageRequestDelegate {
     }
   }
 
-  public SyncStorageResponse getResponse() {
-    return this.response;
-  }
-
-  protected ExtendedJSONObject ensureRecord() {
-    if (record == null) {
-      record = new ExtendedJSONObject();
-    }
-    return record;
-  }
-
-  protected void setRecord(ExtendedJSONObject record) {
-    this.record = record;
-  }
-
   @SuppressWarnings("unchecked")
-  private void unpack(SyncStorageResponse response) throws IllegalStateException, IOException, ParseException, NonObjectJSONException {
-    this.response = response;
-    this.setRecord(response.jsonObjectBody());
-    Log.i(LOG_TAG, "info/collections is " + this.record.toJSONString());
+  public void setFromRecord(ExtendedJSONObject record) throws IllegalStateException, IOException, ParseException, NonObjectJSONException {
+    Log.i(LOG_TAG, "info/collections is " + record.toJSONString());
     HashMap<String, Long> map = new HashMap<String, Long>();
 
-    Set<Entry<String, Object>> entrySet = this.record.object.entrySet();
+    Set<Entry<String, Object>> entrySet = record.object.entrySet();
     for (Entry<String, Object> entry : entrySet) {
       // These objects are most likely going to be Doubles. Regardless, we
       // want to get them in a more sane time format.
@@ -175,7 +143,7 @@ public class InfoCollections implements SyncStorageRequestDelegate {
   public void handleRequestSuccess(SyncStorageResponse response) {
     if (response.wasSuccessful()) {
       try {
-        this.unpack(response);
+        this.setFromRecord(response.jsonObjectBody());
         this.callback.handleSuccess(this);
         this.callback = null;
       } catch (Exception e) {

--- a/src/main/java/org/mozilla/gecko/sync/MetaGlobal.java
+++ b/src/main/java/org/mozilla/gecko/sync/MetaGlobal.java
@@ -1,39 +1,6 @@
-/* ***** BEGIN LICENSE BLOCK *****
- * Version: MPL 1.1/GPL 2.0/LGPL 2.1
- *
- * The contents of this file are subject to the Mozilla Public License Version
- * 1.1 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- * http://www.mozilla.org/MPL/
- *
- * Software distributed under the License is distributed on an "AS IS" basis,
- * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
- * for the specific language governing rights and limitations under the
- * License.
- *
- * The Original Code is Android Sync Client.
- *
- * The Initial Developer of the Original Code is
- * the Mozilla Foundation.
- * Portions created by the Initial Developer are Copyright (C) 2011
- * the Initial Developer. All Rights Reserved.
- *
- * Contributor(s):
- * Richard Newman <rnewman@mozilla.com>
- *
- * Alternatively, the contents of this file may be used under the terms of
- * either the GNU General Public License Version 2 or later (the "GPL"), or
- * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
- * in which case the provisions of the GPL or the LGPL are applicable instead
- * of those above. If you wish to allow use of your version of this file only
- * under the terms of either the GPL or the LGPL, and not to allow others to
- * use your version of this file under the terms of the MPL, indicate your
- * decision by deleting the provisions above and replace them with the notice
- * and other provisions required by the GPL or the LGPL. If you do not delete
- * the provisions above, a recipient may use your version of this file under
- * the terms of any one of the MPL, the GPL or the LGPL.
- *
- * ***** END LICENSE BLOCK ***** */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.gecko.sync;
 

--- a/src/main/java/org/mozilla/gecko/sync/PersistedMetaGlobal.java
+++ b/src/main/java/org/mozilla/gecko/sync/PersistedMetaGlobal.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.gecko.sync;
 
 import org.mozilla.gecko.sync.CryptoRecord;

--- a/src/main/java/org/mozilla/gecko/sync/PersistedMetaGlobal.java
+++ b/src/main/java/org/mozilla/gecko/sync/PersistedMetaGlobal.java
@@ -1,0 +1,71 @@
+package org.mozilla.gecko.sync;
+
+import org.mozilla.gecko.sync.CryptoRecord;
+import org.mozilla.gecko.sync.Logger;
+
+import android.content.SharedPreferences;
+
+public class PersistedMetaGlobal {
+  public static final String LOG_TAG = "PersistedMetaGlobal";
+
+  public static final String META_GLOBAL_SERVER_RESPONSE_BODY = "metaGlobalServerResponseBody";
+  public static final String META_GLOBAL_LAST_MODIFIED        = "metaGlobalLastModified";
+
+  protected SharedPreferences prefs;
+
+  public PersistedMetaGlobal(SharedPreferences prefs) {
+    this.prefs = prefs;
+  }
+
+  public MetaGlobal metaGlobal() {
+    String json = prefs.getString(META_GLOBAL_SERVER_RESPONSE_BODY, null);
+    if (json == null) {
+      return null;
+    }
+    MetaGlobal metaGlobal = null;
+    try {
+      CryptoRecord cryptoRecord = CryptoRecord.fromJSONRecord(json);
+      MetaGlobal mg = new MetaGlobal(null, null);
+      mg.setFromRecord(cryptoRecord);
+      metaGlobal = mg;
+    } catch (Exception e) {
+      Logger.warn(LOG_TAG, "Got exception decrypting persisted meta/global.", e);
+    }
+    return metaGlobal;
+  }
+
+  public void persistMetaGlobal(MetaGlobal metaGlobal) {
+    if (metaGlobal == null) {
+      Logger.debug(LOG_TAG, "Clearing persisted meta/global.");
+      prefs.edit().remove(META_GLOBAL_SERVER_RESPONSE_BODY).commit();
+      return;
+    }
+    try {
+      CryptoRecord cryptoRecord = metaGlobal.asCryptoRecord();
+      String json = cryptoRecord.toJSONString();
+      Logger.debug(LOG_TAG, "Persisting meta/global.");
+      prefs.edit().putString(META_GLOBAL_SERVER_RESPONSE_BODY, json).commit();
+    } catch (Exception e) {
+      Logger.warn(LOG_TAG, "Got exception encrypting while persisting meta/global.", e);
+    }
+  }
+
+  public long lastModified() {
+    return prefs.getLong(META_GLOBAL_LAST_MODIFIED, -1);
+  }
+
+  public void persistLastModified(long lastModified) {
+    if (lastModified <= 0) {
+      Logger.debug(LOG_TAG, "Clearing persisted meta/global last modified timestamp.");
+      prefs.edit().remove(META_GLOBAL_LAST_MODIFIED).commit();
+      return;
+    }
+    Logger.debug(LOG_TAG, "Persisting meta/global last modified timestamp " + lastModified + ".");
+    prefs.edit().putLong(META_GLOBAL_LAST_MODIFIED, lastModified).commit();
+  }
+
+  public void purge() {
+    persistLastModified(-1);
+    persistMetaGlobal(null);
+  }
+}

--- a/src/main/java/org/mozilla/gecko/sync/PrefsSource.java
+++ b/src/main/java/org/mozilla/gecko/sync/PrefsSource.java
@@ -1,43 +1,9 @@
-/* ***** BEGIN LICENSE BLOCK *****
- * Version: MPL 1.1/GPL 2.0/LGPL 2.1
- *
- * The contents of this file are subject to the Mozilla Public License Version
- * 1.1 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- * http://www.mozilla.org/MPL/
- *
- * Software distributed under the License is distributed on an "AS IS" basis,
- * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
- * for the specific language governing rights and limitations under the
- * License.
- *
- * The Original Code is Android Sync Client.
- *
- * The Initial Developer of the Original Code is
- * the Mozilla Foundation.
- * Portions created by the Initial Developer are Copyright (C) 2011
- * the Initial Developer. All Rights Reserved.
- *
- * Contributor(s):
- *   Richard Newman <rnewman@mozilla.com>
- *
- * Alternatively, the contents of this file may be used under the terms of
- * either the GNU General Public License Version 2 or later (the "GPL"), or
- * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
- * in which case the provisions of the GPL or the LGPL are applicable instead
- * of those above. If you wish to allow use of your version of this file only
- * under the terms of either the GPL or the LGPL, and not to allow others to
- * use your version of this file under the terms of the MPL, indicate your
- * decision by deleting the provisions above and replace them with the notice
- * and other provisions required by the GPL or the LGPL. If you do not delete
- * the provisions above, a recipient may use your version of this file under
- * the terms of any one of the MPL, the GPL or the LGPL.
- *
- * ***** END LICENSE BLOCK ***** */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.gecko.sync;
 
-import android.content.Context;
 import android.content.SharedPreferences;
 
 /**
@@ -51,8 +17,6 @@ import android.content.SharedPreferences;
  *
  */
 public interface PrefsSource {
-  public Context getContext();
-
   /**
    * Return a SharedPreferences instance.
    * @param name

--- a/src/main/java/org/mozilla/gecko/sync/SyncConfiguration.java
+++ b/src/main/java/org/mozilla/gecko/sync/SyncConfiguration.java
@@ -258,14 +258,8 @@ public class SyncConfiguration implements CredentialsSource {
     return username + ":" + password;
   }
 
-  @Override
   public CollectionKeys getCollectionKeys() {
     return collectionKeys;
-  }
-
-  @Override
-  public KeyBundle keyForCollection(String collection) throws NoCollectionKeysSetException {
-    return getCollectionKeys().keyBundleForCollection(collection);
   }
 
   public void setCollectionKeys(CollectionKeys k) {

--- a/src/main/java/org/mozilla/gecko/sync/SyncConfiguration.java
+++ b/src/main/java/org/mozilla/gecko/sync/SyncConfiguration.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.mozilla.gecko.sync.crypto.KeyBundle;
+import org.mozilla.gecko.sync.crypto.PersistedCrypto5Keys;
 
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
@@ -232,7 +233,9 @@ public class SyncConfiguration implements CredentialsSource {
       syncID = prefs.getString("syncID", null);
       Logger.info(LOG_TAG, "Set syncID from bundle: " + syncID);
     }
-    // TODO: MetaGlobal, password, infoCollections, collectionKeys.
+    // We don't set crypto/keys here because we need the syncKeyBundle to decrypt the JSON
+    // and we won't have it on construction.
+    // TODO: MetaGlobal, password, infoCollections.
   }
 
   public void persistToPrefs() {
@@ -372,5 +375,16 @@ public class SyncConfiguration implements CredentialsSource {
 
   public long getPersistedServerClientRecordTimestamp() {
     return getPrefs().getLong(SyncConfiguration.CLIENT_RECORD_TIMESTAMP, 0);
+  }
+
+  public void purgeCryptoKeys() {
+    if (collectionKeys != null) {
+      collectionKeys.clear();
+    }
+    persistedCryptoKeys().purge();
+  }
+
+  public PersistedCrypto5Keys persistedCryptoKeys() {
+    return new PersistedCrypto5Keys(getPrefs(), syncKeyBundle);
   }
 }

--- a/src/main/java/org/mozilla/gecko/sync/SyncConfiguration.java
+++ b/src/main/java/org/mozilla/gecko/sync/SyncConfiguration.java
@@ -387,4 +387,8 @@ public class SyncConfiguration implements CredentialsSource {
   public PersistedCrypto5Keys persistedCryptoKeys() {
     return new PersistedCrypto5Keys(getPrefs(), syncKeyBundle);
   }
+
+  public PersistedMetaGlobal persistedMetaGlobal() {
+    return new PersistedMetaGlobal(getPrefs());
+  }
 }

--- a/src/main/java/org/mozilla/gecko/sync/crypto/PersistedCrypto5Keys.java
+++ b/src/main/java/org/mozilla/gecko/sync/crypto/PersistedCrypto5Keys.java
@@ -1,0 +1,95 @@
+package org.mozilla.gecko.sync.crypto;
+
+import org.mozilla.gecko.sync.CollectionKeys;
+import org.mozilla.gecko.sync.CryptoRecord;
+import org.mozilla.gecko.sync.Logger;
+
+import android.content.SharedPreferences;
+
+public class PersistedCrypto5Keys {
+  public static final String LOG_TAG = "PersistedC5Keys";
+
+  public static final String CRYPTO5_KEYS_SERVER_RESPONSE_BODY = "crypto5KeysServerResponseBody";
+  public static final String CRYPTO5_KEYS_LAST_MODIFIED        = "crypto5KeysLastModified";
+
+  protected SharedPreferences prefs;
+  protected KeyBundle syncKeyBundle;
+
+  public PersistedCrypto5Keys(SharedPreferences prefs, KeyBundle syncKeyBundle) {
+    if (syncKeyBundle == null) {
+      throw new IllegalArgumentException("Null syncKeyBundle passed in to PersistedCrypto5Keys constructor.");
+    }
+    this.prefs = prefs;
+    this.syncKeyBundle = syncKeyBundle;
+  }
+
+  /**
+   * Get persisted crypto/keys.
+   * <p>
+   * crypto/keys is fetched from an encrypted JSON-encoded <code>CryptoRecord</code>.
+   *
+   * @return A <code>CollectionKeys</code> instance or <code>null</code> if none
+   *         is currently persisted.
+   */
+  public CollectionKeys keys() {
+    String keysJSON = prefs.getString(CRYPTO5_KEYS_SERVER_RESPONSE_BODY, null);
+    if (keysJSON == null) {
+      return null;
+    }
+    try {
+      CryptoRecord cryptoRecord = CryptoRecord.fromJSONRecord(keysJSON);
+      CollectionKeys keys = new CollectionKeys();
+      keys.setKeyPairsFromWBO(cryptoRecord, syncKeyBundle);
+      return keys;
+    } catch (Exception e) {
+      Logger.warn(LOG_TAG, "Got exception decrypting persisted crypto/keys.", e);
+      return null;
+    }
+  }
+
+  /**
+   * Persist crypto/keys.
+   * <p>
+   * crypto/keys is stored as an encrypted JSON-encoded <code>CryptoRecord</code>.
+   *
+   * @param keys
+   *          The <code>CollectionKeys</code> object to persist, which should
+   *          have the same default key bundle as the sync key bundle.
+   */
+  public void persistKeys(CollectionKeys keys) {
+    if (keys == null) {
+      Logger.debug(LOG_TAG, "Clearing persisted crypto/keys.");
+      prefs.edit().remove(CRYPTO5_KEYS_SERVER_RESPONSE_BODY).commit();
+      return;
+    }
+    try {
+      CryptoRecord cryptoRecord = keys.asCryptoRecord();
+      cryptoRecord.keyBundle = syncKeyBundle;
+      cryptoRecord.encrypt();
+      String keysJSON = cryptoRecord.toJSONString();
+      Logger.debug(LOG_TAG, "Persisting crypto/keys.");
+      prefs.edit().putString(CRYPTO5_KEYS_SERVER_RESPONSE_BODY, keysJSON).commit();
+    } catch (Exception e) {
+      Logger.warn(LOG_TAG, "Got exception encrypting while persisting crypto/keys.", e);
+    }
+  }
+
+  public long lastModified() {
+    return prefs.getLong(CRYPTO5_KEYS_LAST_MODIFIED, -1);
+  }
+
+  public void persistLastModified(long lastModified) {
+    if (lastModified <= 0) {
+      Logger.debug(LOG_TAG, "Clearing persisted crypto/keys last modified timestamp.");
+      prefs.edit().remove(CRYPTO5_KEYS_LAST_MODIFIED).commit();
+      return;
+    }
+    Logger.debug(LOG_TAG, "Persisting crypto/keys last modified timestamp " + lastModified + ".");
+    prefs.edit().putLong(CRYPTO5_KEYS_LAST_MODIFIED, lastModified).commit();
+  }
+
+  public void purge() {
+    persistLastModified(-1);
+    persistKeys(null);
+  }
+}

--- a/src/main/java/org/mozilla/gecko/sync/crypto/PersistedCrypto5Keys.java
+++ b/src/main/java/org/mozilla/gecko/sync/crypto/PersistedCrypto5Keys.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.gecko.sync.crypto;
 
 import org.mozilla.gecko.sync.CollectionKeys;

--- a/src/main/java/org/mozilla/gecko/sync/delegates/MetaGlobalDelegate.java
+++ b/src/main/java/org/mozilla/gecko/sync/delegates/MetaGlobalDelegate.java
@@ -1,39 +1,6 @@
-/* ***** BEGIN LICENSE BLOCK *****
- * Version: MPL 1.1/GPL 2.0/LGPL 2.1
- *
- * The contents of this file are subject to the Mozilla Public License Version
- * 1.1 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- * http://www.mozilla.org/MPL/
- *
- * Software distributed under the License is distributed on an "AS IS" basis,
- * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
- * for the specific language governing rights and limitations under the
- * License.
- *
- * The Original Code is Android Sync Client.
- *
- * The Initial Developer of the Original Code is
- * the Mozilla Foundation.
- * Portions created by the Initial Developer are Copyright (C) 2011
- * the Initial Developer. All Rights Reserved.
- *
- * Contributor(s):
- * Richard Newman <rnewman@mozilla.com>
- *
- * Alternatively, the contents of this file may be used under the terms of
- * either the GNU General Public License Version 2 or later (the "GPL"), or
- * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
- * in which case the provisions of the GPL or the LGPL are applicable instead
- * of those above. If you wish to allow use of your version of this file only
- * under the terms of either the GPL or the LGPL, and not to allow others to
- * use your version of this file under the terms of the MPL, indicate your
- * decision by deleting the provisions above and replace them with the notice
- * and other provisions required by the GPL or the LGPL. If you do not delete
- * the provisions above, a recipient may use your version of this file under
- * the terms of any one of the MPL, the GPL or the LGPL.
- *
- * ***** END LICENSE BLOCK ***** */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.gecko.sync.delegates;
 

--- a/src/main/java/org/mozilla/gecko/sync/delegates/MetaGlobalDelegate.java
+++ b/src/main/java/org/mozilla/gecko/sync/delegates/MetaGlobalDelegate.java
@@ -45,5 +45,4 @@ public interface MetaGlobalDelegate {
   public void handleMissing(MetaGlobal global, SyncStorageResponse response);
   public void handleFailure(SyncStorageResponse response);
   public void handleError(Exception e);
-  public MetaGlobalDelegate deferred();
 }

--- a/src/main/java/org/mozilla/gecko/sync/stage/EnsureCrypto5KeysStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/EnsureCrypto5KeysStage.java
@@ -21,8 +21,8 @@ import org.mozilla.gecko.sync.net.SyncStorageRecordRequest;
 import org.mozilla.gecko.sync.net.SyncStorageRequestDelegate;
 import org.mozilla.gecko.sync.net.SyncStorageResponse;
 
-public class EnsureKeysStage implements GlobalSyncStage, SyncStorageRequestDelegate, KeyUploadDelegate {
-  private static final String LOG_TAG = "EnsureKeysStage";
+public class EnsureCrypto5KeysStage implements GlobalSyncStage, SyncStorageRequestDelegate, KeyUploadDelegate {
+  private static final String LOG_TAG = "EnsureC5KeysStage";
   private GlobalSession session;
   private boolean retrying = false;
 

--- a/src/main/java/org/mozilla/gecko/sync/stage/EnsureCrypto5KeysStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/EnsureCrypto5KeysStage.java
@@ -9,13 +9,15 @@ import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
 
 import org.json.simple.parser.ParseException;
-import org.mozilla.gecko.sync.crypto.CryptoException;
 import org.mozilla.gecko.sync.CollectionKeys;
 import org.mozilla.gecko.sync.CryptoRecord;
 import org.mozilla.gecko.sync.ExtendedJSONObject;
 import org.mozilla.gecko.sync.GlobalSession;
+import org.mozilla.gecko.sync.InfoCollections;
 import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.NonObjectJSONException;
+import org.mozilla.gecko.sync.crypto.CryptoException;
+import org.mozilla.gecko.sync.crypto.PersistedCrypto5Keys;
 import org.mozilla.gecko.sync.delegates.KeyUploadDelegate;
 import org.mozilla.gecko.sync.net.SyncStorageRecordRequest;
 import org.mozilla.gecko.sync.net.SyncStorageRequestDelegate;
@@ -23,16 +25,39 @@ import org.mozilla.gecko.sync.net.SyncStorageResponse;
 
 public class EnsureCrypto5KeysStage implements GlobalSyncStage, SyncStorageRequestDelegate, KeyUploadDelegate {
   private static final String LOG_TAG = "EnsureC5KeysStage";
-  private GlobalSession session;
-  private boolean retrying = false;
+  private static final String CRYPTO_COLLECTION = "crypto";
+  protected GlobalSession session;
+  protected boolean retrying = false;
 
   @Override
   public void execute(GlobalSession session) throws NoSuchStageException {
     this.session = session;
 
-    // TODO: decide whether we need to do this work.
+    InfoCollections infoCollections = session.config.infoCollections;
+    if (infoCollections == null) {
+      session.abort(null, "No info/collections set in EnsureCrypto5KeysStage.");
+      return;
+    }
+
+    PersistedCrypto5Keys pck = session.config.persistedCryptoKeys();
+    long lastModified = pck.lastModified();
+    if (!infoCollections.updateNeeded(CRYPTO_COLLECTION, lastModified)) {
+      // Try to use our local collection keys for this session.
+      Logger.info(LOG_TAG, "Trying to use persisted collection keys for this session.");
+      CollectionKeys keys = pck.keys();
+      if (keys != null) {
+        Logger.info(LOG_TAG, "Using persisted collection keys for this session.");
+        session.config.setCollectionKeys(keys);
+        session.advance();
+        return;
+      }
+      Logger.info(LOG_TAG, "Failed to use persisted collection keys for this session.");
+    }
+
+    // We need an update: fetch or upload keys as necessary.
+    Logger.info(LOG_TAG, "Fetching fresh collection keys for this session.");
     try {
-      SyncStorageRecordRequest request = new SyncStorageRecordRequest(session.wboURI("crypto", "keys"));
+      SyncStorageRecordRequest request = new SyncStorageRecordRequest(session.wboURI(CRYPTO_COLLECTION, "keys"));
       request.delegate = this;
       request.get();
     } catch (URISyntaxException e) {
@@ -79,8 +104,15 @@ public class EnsureCrypto5KeysStage implements GlobalSyncStage, SyncStorageReque
       return;
     }
 
-    Logger.trace(LOG_TAG, "Setting keys.");
+    // New keys! Persist keys and server timestamp.
+    Logger.info(LOG_TAG, "Setting fetched keys for this session.");
     session.config.setCollectionKeys(k);
+    Logger.trace(LOG_TAG, "Persisting fetched keys and last modified.");
+    PersistedCrypto5Keys pck = session.config.persistedCryptoKeys();
+    pck.persistKeys(k);
+    // Take the timestamp from the response since it is later than the timestamp from info/collections.
+    pck.persistLastModified(response.normalizedWeaveTimestamp());
+
     session.advance();
   }
 
@@ -128,6 +160,7 @@ public class EnsureCrypto5KeysStage implements GlobalSyncStage, SyncStorageReque
   public void onKeysUploaded() {
     Logger.debug(LOG_TAG, "New keys uploaded. Starting stage again to fetch them.");
     try {
+      retrying = true;
       this.execute(this.session);
     } catch (NoSuchStageException e) {
       session.abort(e, "No such stage.");

--- a/src/main/java/org/mozilla/gecko/sync/stage/EnsureKeysStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/EnsureKeysStage.java
@@ -80,7 +80,7 @@ public class EnsureKeysStage implements GlobalSyncStage, SyncStorageRequestDeleg
     }
 
     Logger.trace(LOG_TAG, "Setting keys.");
-    session.setCollectionKeys(k);
+    session.config.setCollectionKeys(k);
     session.advance();
   }
 

--- a/src/main/java/org/mozilla/gecko/sync/stage/FetchMetaGlobalStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/FetchMetaGlobalStage.java
@@ -72,12 +72,6 @@ public class FetchMetaGlobalStage implements GlobalSyncStage {
     public void handleMissing(MetaGlobal global, SyncStorageResponse response) {
       session.processMissingMetaGlobal(global);
     }
-
-    @Override
-    public MetaGlobalDelegate deferred() {
-      // TODO: defer!
-      return this;
-    }
   }
 
   @Override

--- a/src/main/java/org/mozilla/gecko/sync/stage/FetchMetaGlobalStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/FetchMetaGlobalStage.java
@@ -1,50 +1,20 @@
-/* ***** BEGIN LICENSE BLOCK *****
- * Version: MPL 1.1/GPL 2.0/LGPL 2.1
- *
- * The contents of this file are subject to the Mozilla Public License Version
- * 1.1 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- * http://www.mozilla.org/MPL/
- *
- * Software distributed under the License is distributed on an "AS IS" basis,
- * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
- * for the specific language governing rights and limitations under the
- * License.
- *
- * The Original Code is Android Sync Client.
- *
- * The Initial Developer of the Original Code is
- * the Mozilla Foundation.
- * Portions created by the Initial Developer are Copyright (C) 2011
- * the Initial Developer. All Rights Reserved.
- *
- * Contributor(s):
- *  Richard Newman <rnewman@mozilla.com>
- *
- * Alternatively, the contents of this file may be used under the terms of
- * either the GNU General Public License Version 2 or later (the "GPL"), or
- * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
- * in which case the provisions of the GPL or the LGPL are applicable instead
- * of those above. If you wish to allow use of your version of this file only
- * under the terms of either the GPL or the LGPL, and not to allow others to
- * use your version of this file under the terms of the MPL, indicate your
- * decision by deleting the provisions above and replace them with the notice
- * and other provisions required by the GPL or the LGPL. If you do not delete
- * the provisions above, a recipient may use your version of this file under
- * the terms of any one of the MPL, the GPL or the LGPL.
- *
- * ***** END LICENSE BLOCK ***** */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.gecko.sync.stage;
 
-import java.net.URISyntaxException;
-
 import org.mozilla.gecko.sync.GlobalSession;
+import org.mozilla.gecko.sync.InfoCollections;
+import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.MetaGlobal;
+import org.mozilla.gecko.sync.PersistedMetaGlobal;
 import org.mozilla.gecko.sync.delegates.MetaGlobalDelegate;
 import org.mozilla.gecko.sync.net.SyncStorageResponse;
 
 public class FetchMetaGlobalStage implements GlobalSyncStage {
+  private static final String LOG_TAG = "FetchMetaGlobalStage";
+  private static final String META_COLLECTION = "meta";
 
   public class StageMetaGlobalDelegate implements MetaGlobalDelegate {
 
@@ -55,6 +25,12 @@ public class FetchMetaGlobalStage implements GlobalSyncStage {
 
     @Override
     public void handleSuccess(MetaGlobal global, SyncStorageResponse response) {
+      Logger.trace(LOG_TAG, "Persisting fetched meta/global and last modified.");
+      PersistedMetaGlobal pmg = session.config.persistedMetaGlobal();
+      pmg.persistMetaGlobal(global);
+      // Take the timestamp from the response since it is later than the timestamp from info/collections.
+      pmg.persistLastModified(response.normalizedWeaveTimestamp());
+
       session.processMetaGlobal(global);
     }
 
@@ -76,11 +52,28 @@ public class FetchMetaGlobalStage implements GlobalSyncStage {
 
   @Override
   public void execute(GlobalSession session) throws NoSuchStageException {
-    try {
-      session.fetchMetaGlobal(new StageMetaGlobalDelegate(session));
-    } catch (URISyntaxException e) {
-      session.abort(e, "Invalid URI.");
+    InfoCollections infoCollections = session.config.infoCollections;
+    if (infoCollections == null) {
+      session.abort(null, "No info/collections set in FetchMetaGlobalStage.");
+      return;
     }
-  }
 
+    long lastModified = session.config.persistedMetaGlobal().lastModified();
+    if (!infoCollections.updateNeeded(META_COLLECTION, lastModified)) {
+      // Try to use our local collection keys for this session.
+      Logger.info(LOG_TAG, "Trying to use persisted meta/global for this session.");
+      MetaGlobal global = session.config.persistedMetaGlobal().metaGlobal();
+      if (global != null) {
+        Logger.info(LOG_TAG, "Using persisted meta/global for this session.");
+        session.processMetaGlobal(global); // Calls session.advance().
+        return;
+      }
+      Logger.info(LOG_TAG, "Failed to use persisted meta/global for this session.");
+    }
+
+    // We need an update: fetch or upload meta/global as necessary.
+    Logger.info(LOG_TAG, "Fetching fresh meta/global for this session.");
+    MetaGlobal global = new MetaGlobal(session.config.metaURL(), session.credentials());
+    global.fetch(new StageMetaGlobalDelegate(session));
+  }
 }

--- a/src/main/java/org/mozilla/gecko/sync/stage/ServerSyncStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/ServerSyncStage.java
@@ -67,7 +67,7 @@ public abstract class ServerSyncStage implements
    */
   protected Repository wrappedServerRepo() throws NoCollectionKeysSetException, URISyntaxException {
     String collection = this.getCollection();
-    KeyBundle collectionKey = session.keyForCollection(collection);
+    KeyBundle collectionKey = session.keyBundleForCollection(collection);
     Crypto5MiddlewareRepository cryptoRepo = new Crypto5MiddlewareRepository(getRemoteRepository(), collectionKey);
     cryptoRepo.recordFactory = getRecordFactory();
     return cryptoRepo;

--- a/src/main/java/org/mozilla/gecko/sync/stage/SyncClientsEngineStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/SyncClientsEngineStage.java
@@ -162,7 +162,7 @@ public class SyncClientsEngineStage implements GlobalSyncStage {
     @Override
     public KeyBundle keyBundle() {
       try {
-        return session.keyForCollection(COLLECTION_NAME);
+        return session.keyBundleForCollection(COLLECTION_NAME);
       } catch (NoCollectionKeysSetException e) {
         session.abort(e, "No collection keys set.");
         return null;
@@ -241,7 +241,7 @@ public class SyncClientsEngineStage implements GlobalSyncStage {
     @Override
     public KeyBundle keyBundle() {
       try {
-        return session.keyForCollection(COLLECTION_NAME);
+        return session.keyBundleForCollection(COLLECTION_NAME);
       } catch (NoCollectionKeysSetException e) {
         session.abort(e, "No collection keys set.");
         return null;

--- a/src/test/java/org/mozilla/android/sync/net/test/TestClientsEngineStage.java
+++ b/src/test/java/org/mozilla/android/sync/net/test/TestClientsEngineStage.java
@@ -88,7 +88,7 @@ public class TestClientsEngineStage extends MockSyncClientsEngineStage {
       final KeyBundle bundle = new KeyBundle(USERNAME, SYNC_KEY);
       session = new MockClientsGlobalSession(TEST_SERVER, USERNAME, PASSWORD, bundle, callback);
       session.config.setClusterURL(new URI(TEST_SERVER));
-      session.setCollectionKeys(CollectionKeys.generateCollectionKeys());
+      session.config.setCollectionKeys(CollectionKeys.generateCollectionKeys());
     } catch (Exception e) {
       e.printStackTrace();
       fail("Unexpected failure in session.");
@@ -254,7 +254,7 @@ public class TestClientsEngineStage extends MockSyncClientsEngineStage {
       try {
         // Save uploadedRecord to test against.
         CryptoRecord cryptoRecord = CryptoRecord.fromJSONRecord(request.getContent());
-        cryptoRecord.keyBundle = session.keyForCollection(COLLECTION_NAME);
+        cryptoRecord.keyBundle = session.keyBundleForCollection(COLLECTION_NAME);
         uploadedRecord = (ClientRecord) factory.createRecord(cryptoRecord.decrypt());
 
         // Note: collection is not saved in CryptoRecord.toJSONObject() upon upload.

--- a/src/test/java/org/mozilla/android/sync/test/TestCollectionKeys.java
+++ b/src/test/java/org/mozilla/android/sync/test/TestCollectionKeys.java
@@ -92,7 +92,8 @@ public class TestCollectionKeys {
     JSONArray defaultKey = (JSONArray) rec.payload.get("default");
 
     assertSame(Base64.decodeBase64((String) (defaultKey.get(0))), ck1.defaultKeyBundle().getEncryptionKey());
-    CollectionKeys ck2 = CollectionKeys.fromCryptoRecord(rec, null);
+    CollectionKeys ck2 = new CollectionKeys();
+    ck2.setKeyPairsFromWBO(rec, null);
     assertSame(ck1.defaultKeyBundle().getEncryptionKey(), ck2.defaultKeyBundle().getEncryptionKey());
   }
 
@@ -108,7 +109,8 @@ public class TestCollectionKeys {
     unencrypted.keyBundle = syncKeyBundle;
     CryptoRecord encrypted = unencrypted.encrypt();
 
-    CollectionKeys ckDecrypted = CollectionKeys.fromCryptoRecord(encrypted, syncKeyBundle);
+    CollectionKeys ckDecrypted = new CollectionKeys();
+    ckDecrypted.setKeyPairsFromWBO(encrypted, syncKeyBundle);
 
     // Compare decrypted keys to the keys that were set upon creation
     assertArrayEquals(ck.defaultKeyBundle().getEncryptionKey(), ckDecrypted.defaultKeyBundle().getEncryptionKey());

--- a/src/test/java/org/mozilla/gecko/sync/crypto/test/TestPersistedCrypto5Keys.java
+++ b/src/test/java/org/mozilla/gecko/sync/crypto/test/TestPersistedCrypto5Keys.java
@@ -1,3 +1,6 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
 package org.mozilla.gecko.sync.crypto.test;
 
 import static org.junit.Assert.assertArrayEquals;

--- a/src/test/java/org/mozilla/gecko/sync/crypto/test/TestPersistedCrypto5Keys.java
+++ b/src/test/java/org/mozilla/gecko/sync/crypto/test/TestPersistedCrypto5Keys.java
@@ -1,0 +1,79 @@
+package org.mozilla.gecko.sync.crypto.test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mozilla.android.sync.test.helpers.MockSharedPreferences;
+import org.mozilla.gecko.sync.CollectionKeys;
+import org.mozilla.gecko.sync.Logger;
+import org.mozilla.gecko.sync.NoCollectionKeysSetException;
+import org.mozilla.gecko.sync.crypto.CryptoException;
+import org.mozilla.gecko.sync.crypto.KeyBundle;
+import org.mozilla.gecko.sync.crypto.PersistedCrypto5Keys;
+
+public class TestPersistedCrypto5Keys {
+  MockSharedPreferences prefs = null;
+
+  @Before
+  public void setUp() {
+    Logger.LOG_TO_STDOUT = true;
+    prefs = new MockSharedPreferences();
+  }
+
+  @Test
+  public void testPersistLastModified() throws CryptoException, NoCollectionKeysSetException {
+    long LAST_MODIFIED = System.currentTimeMillis();
+    KeyBundle syncKeyBundle = KeyBundle.withRandomKeys();
+    PersistedCrypto5Keys persisted = new PersistedCrypto5Keys(prefs, syncKeyBundle);
+
+    // Test fresh start.
+    assertEquals(-1, persisted.lastModified());
+
+    // Test persisting.
+    persisted.persistLastModified(LAST_MODIFIED);
+    assertEquals(LAST_MODIFIED, persisted.lastModified());
+
+    // Test clearing.
+    persisted.persistLastModified(0);
+    assertEquals(-1, persisted.lastModified());
+  }
+
+  @Test
+  public void testPersistKeys() throws CryptoException, NoCollectionKeysSetException {
+    KeyBundle syncKeyBundle = KeyBundle.withRandomKeys();
+    KeyBundle testKeyBundle = KeyBundle.withRandomKeys();
+
+    PersistedCrypto5Keys persisted = new PersistedCrypto5Keys(prefs, syncKeyBundle);
+
+    // Test fresh start.
+    assertNull(persisted.keys());
+
+    // Test persisting.
+    CollectionKeys keys = new CollectionKeys();
+    keys.setDefaultKeyBundle(syncKeyBundle);
+    keys.setKeyBundleForCollection("test", testKeyBundle);
+    persisted.persistKeys(keys);
+
+    CollectionKeys persistedKeys = persisted.keys();
+    assertNotNull(persistedKeys);
+    assertArrayEquals(syncKeyBundle.getEncryptionKey(), persistedKeys.defaultKeyBundle().getEncryptionKey());
+    assertArrayEquals(syncKeyBundle.getHMACKey(), persistedKeys.defaultKeyBundle().getHMACKey());
+    assertArrayEquals(testKeyBundle.getEncryptionKey(), persistedKeys.keyBundleForCollection("test").getEncryptionKey());
+    assertArrayEquals(testKeyBundle.getHMACKey(), persistedKeys.keyBundleForCollection("test").getHMACKey());
+
+    // Test clearing.
+    persisted.persistKeys(null);
+    assertNull(persisted.keys());
+
+    // Test loading a persisted bundle with wrong syncKeyBundle.
+    persisted.persistKeys(keys);
+    assertNotNull(persisted.keys());
+
+    persisted = new PersistedCrypto5Keys(prefs, testKeyBundle);
+    assertNull(persisted.keys());
+  }
+}

--- a/src/test/java/org/mozilla/gecko/sync/test/TestInfoCollections.java
+++ b/src/test/java/org/mozilla/gecko/sync/test/TestInfoCollections.java
@@ -1,3 +1,6 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
 package org.mozilla.gecko.sync.test;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/gecko/sync/test/TestInfoCollections.java
+++ b/src/test/java/org/mozilla/gecko/sync/test/TestInfoCollections.java
@@ -1,0 +1,69 @@
+package org.mozilla.gecko.sync.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.json.simple.parser.ParseException;
+import org.junit.Test;
+import org.mozilla.gecko.sync.ExtendedJSONObject;
+import org.mozilla.gecko.sync.InfoCollections;
+import org.mozilla.gecko.sync.NonObjectJSONException;
+import org.mozilla.gecko.sync.SyncConfigurationException;
+import org.mozilla.gecko.sync.Utils;
+import org.mozilla.gecko.sync.crypto.CryptoException;
+
+public class TestInfoCollections {
+  public static final String TEST_JSON =
+      "{\"history\":1.3319567131E9,\"bookmarks\":1.33195669592E9," +
+      "\"prefs\":1.33115408641E9,\"crypto\":1.32046063664E9,\"meta\":1.321E9," +
+      "\"forms\":1.33136685374E9,\"clients\":1.3313667619E9,\"tabs\":1.35E9}";
+
+  @Test
+  public void testSetFromRecord() throws NonObjectJSONException, IOException, ParseException, CryptoException, SyncConfigurationException, IllegalArgumentException {
+    InfoCollections infoCollections = new InfoCollections(null, null);
+    ExtendedJSONObject record = ExtendedJSONObject.parseJSONObject(TEST_JSON);
+    infoCollections.setFromRecord(record);
+
+    assertNotNull(infoCollections.getTimestamps());
+    assertEquals(Utils.decimalSecondsToMilliseconds(1.3319567131E9), infoCollections.getTimestamp("history").longValue());
+    assertEquals(Utils.decimalSecondsToMilliseconds(1.321E9), infoCollections.getTimestamp("meta").longValue());
+    assertEquals(Utils.decimalSecondsToMilliseconds(1.35E9), infoCollections.getTimestamp("tabs").longValue());
+    assertNull(infoCollections.getTimestamp("missing"));
+  }
+
+  @Test
+  public void testUpdateNeeded() throws NonObjectJSONException, IOException, ParseException, CryptoException, SyncConfigurationException, IllegalArgumentException {
+    InfoCollections infoCollections = new InfoCollections(null, null);
+    ExtendedJSONObject record = ExtendedJSONObject.parseJSONObject(TEST_JSON);
+    infoCollections.setFromRecord(record);
+
+    long none = -1;
+    long past = Utils.decimalSecondsToMilliseconds(1.3E9);
+    long same = Utils.decimalSecondsToMilliseconds(1.35E9);
+    long future = Utils.decimalSecondsToMilliseconds(1.4E9);
+
+
+    // Test with no local timestamp set.
+    assertTrue(infoCollections.updateNeeded("tabs", none));
+
+    // Test with local timestamp set in the past.
+    assertTrue(infoCollections.updateNeeded("tabs", past));
+
+    // Test with same timestamp.
+    assertFalse(infoCollections.updateNeeded("tabs", same));
+
+    // Test with local timestamp set in the future.
+    assertFalse(infoCollections.updateNeeded("tabs", future));
+
+    // Test with no collection.
+    assertTrue(infoCollections.updateNeeded("missing", none));
+    assertTrue(infoCollections.updateNeeded("missing", past));
+    assertTrue(infoCollections.updateNeeded("missing", same));
+    assertTrue(infoCollections.updateNeeded("missing", future));
+  }
+}

--- a/src/test/java/org/mozilla/gecko/sync/test/TestPersistedMetaGlobal.java
+++ b/src/test/java/org/mozilla/gecko/sync/test/TestPersistedMetaGlobal.java
@@ -1,3 +1,6 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
 package org.mozilla.gecko.sync.test;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/gecko/sync/test/TestPersistedMetaGlobal.java
+++ b/src/test/java/org/mozilla/gecko/sync/test/TestPersistedMetaGlobal.java
@@ -1,0 +1,72 @@
+package org.mozilla.gecko.sync.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.json.simple.parser.ParseException;
+import org.junit.Before;
+import org.junit.Test;
+import org.mozilla.android.sync.test.helpers.MockSharedPreferences;
+import org.mozilla.gecko.sync.CryptoRecord;
+import org.mozilla.gecko.sync.ExtendedJSONObject;
+import org.mozilla.gecko.sync.Logger;
+import org.mozilla.gecko.sync.MetaGlobal;
+import org.mozilla.gecko.sync.NoCollectionKeysSetException;
+import org.mozilla.gecko.sync.NonObjectJSONException;
+import org.mozilla.gecko.sync.PersistedMetaGlobal;
+import org.mozilla.gecko.sync.crypto.CryptoException;
+
+public class TestPersistedMetaGlobal {
+  MockSharedPreferences prefs = null;
+
+  @Before
+  public void setUp() {
+    Logger.LOG_TO_STDOUT = true;
+    prefs = new MockSharedPreferences();
+  }
+
+  @Test
+  public void testPersistLastModified() throws CryptoException, NoCollectionKeysSetException {
+    long LAST_MODIFIED = System.currentTimeMillis();
+    PersistedMetaGlobal persisted = new PersistedMetaGlobal(prefs);
+
+    // Test fresh start.
+    assertEquals(-1, persisted.lastModified());
+
+    // Test persisting.
+    persisted.persistLastModified(LAST_MODIFIED);
+    assertEquals(LAST_MODIFIED, persisted.lastModified());
+
+    // Test clearing.
+    persisted.persistLastModified(0);
+    assertEquals(-1, persisted.lastModified());
+  }
+
+  @Test
+  public void testPersistMetaGlobal() throws IllegalStateException, NonObjectJSONException, IOException, ParseException {
+    PersistedMetaGlobal persisted = new PersistedMetaGlobal(prefs);
+
+    // Test fresh start.
+    assertNull(persisted.metaGlobal());
+
+    // Test persisting.
+    String body = "{\"id\":\"global\",\"payload\":\"{\\\"syncID\\\":\\\"zPSQTm7WBVWB\\\",\\\"storageVersion\\\":5,\\\"engines\\\":{\\\"clients\\\":{\\\"version\\\":1,\\\"syncID\\\":\\\"fDg0MS5bDtV7\\\"},\\\"bookmarks\\\":{\\\"version\\\":2,\\\"syncID\\\":\\\"NNaQr6_F-9dm\\\"},\\\"forms\\\":{\\\"version\\\":1,\\\"syncID\\\":\\\"GXF29AFprnvc\\\"},\\\"history\\\":{\\\"version\\\":1,\\\"syncID\\\":\\\"av75g4vm-_rp\\\"},\\\"passwords\\\":{\\\"version\\\":1,\\\"syncID\\\":\\\"LT_ACGpuKZ6a\\\"},\\\"prefs\\\":{\\\"version\\\":2,\\\"syncID\\\":\\\"-3nsksP9wSAs\\\"},\\\"tabs\\\":{\\\"version\\\":1,\\\"syncID\\\":\\\"W4H5lOMChkYA\\\"}}}\",\"username\":\"5817483\",\"modified\":1.32046073744E9}";
+    MetaGlobal mg = new MetaGlobal(null, null);
+    mg.setFromRecord(CryptoRecord.fromJSONRecord(body));
+    persisted.persistMetaGlobal(mg);
+
+    MetaGlobal persistedGlobal = persisted.metaGlobal();
+    assertNotNull(persistedGlobal);
+    assertEquals("zPSQTm7WBVWB", persistedGlobal.getSyncID());
+    assertTrue(persistedGlobal.getEngines() instanceof ExtendedJSONObject);
+    assertEquals(new Long(5), persistedGlobal.getStorageVersion());
+
+    // Test clearing.
+    persisted.persistMetaGlobal(null);
+    assertNull(persisted.metaGlobal());
+  }
+}


### PR DESCRIPTION
Both tested on device.  I bumped crypto/keys and meta/global separately (using JS snippet) and got the expected behavior.
