### PR TITLE
Bug 742111 - Focus text entry boxes in Pair a Device.

### DIFF
--- a/res/layout/sync_setup_pair.xml
+++ b/res/layout/sync_setup_pair.xml
@@ -42,7 +42,8 @@
 
         <EditText
           android:id="@+id/pair_row1"
-          style="@style/SyncEditPin" />
+          style="@style/SyncEditPin"
+          android:state_focused="true" />
         <EditText
           android:id="@+id/pair_row2"
           style="@style/SyncEditPin" />


### PR DESCRIPTION
Text entry now focused (with flashing cursor) on launch of pair-device screen.
