### PR TITLE
Bug 742700 - Null URI crash in canceling J-PAKE.

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/jpake/stage/DeleteChannel.java
+++ b/src/main/java/org/mozilla/gecko/sync/jpake/stage/DeleteChannel.java
@@ -85,7 +85,7 @@ public class DeleteChannel {
       }
     };
 
-    jClient.runOnThread(new Runnable() {
+    JPakeClient.runOnThread(new Runnable() {
       @Override
       public void run() {
         httpResource.delete();


### PR DESCRIPTION
Do not try to delete channel if user quits in GetChannelStage. Also added a safeguard check in DeleteChannel for null Uri, even though we shouldn't reach this part of the code anymore, if we have a null Uri.
