### PR TITLE
Bug 714657 - purge stored prefs

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
+++ b/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
@@ -676,6 +676,13 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
    * cached records.
    */
   private void resetClient(String[] engines) {
+    try {
+      String serverURL = config.serverURL.toASCIIString();
+      Utils.purgeSharedPreferences(context, config.username, serverURL);
+    } catch (Exception e) {
+      Logger.error(LOG_TAG, "Got exception clearing preferences.", e);
+    }
+
     if (engines == null) {
       // Set `engines` to be *all* the engines.
     }

--- a/src/main/java/org/mozilla/gecko/sync/SyncConfiguration.java
+++ b/src/main/java/org/mozilla/gecko/sync/SyncConfiguration.java
@@ -202,7 +202,7 @@ public class SyncConfiguration implements CredentialsSource {
     this.loadFromPrefs(getPrefs());
   }
 
-  public SharedPreferences getPrefs() {
+  protected SharedPreferences getPrefs() {
     Logger.debug(LOG_TAG, "Returning prefs for " + prefsPath);
     return prefsSource.getPrefs(prefsPath, Utils.SHARED_PREFERENCES_MODE);
   }
@@ -239,7 +239,7 @@ public class SyncConfiguration implements CredentialsSource {
     this.persistToPrefs(this.getPrefs());
   }
 
-  public void persistToPrefs(SharedPreferences prefs) {
+  protected void persistToPrefs(SharedPreferences prefs) {
     Editor edit = prefs.edit();
     if (clusterURL == null) {
       edit.remove("clusterURL");
@@ -368,15 +368,15 @@ public class SyncConfiguration implements CredentialsSource {
   /**
    * Used for direct management of related prefs.
    */
-  public Editor getEditor() {
+  protected Editor getEditor() {
     return this.getPrefs().edit();
   }
 
   public void persistServerClientRecordTimestamp(long timestamp) {
-    getEditor().putLong(SyncConfiguration.CLIENT_RECORD_TIMESTAMP, timestamp).commit();
+    getEditor().putLong(CLIENT_RECORD_TIMESTAMP, timestamp).commit();
   }
 
   public long getPersistedServerClientRecordTimestamp() {
-    return getPrefs().getLong(SyncConfiguration.CLIENT_RECORD_TIMESTAMP, 0);
+    return getPrefs().getLong(CLIENT_RECORD_TIMESTAMP, 0);
   }
 }

--- a/src/main/java/org/mozilla/gecko/sync/setup/SyncAccounts.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/SyncAccounts.java
@@ -104,12 +104,7 @@ public class SyncAccounts {
     Logger.debug(LOG_TAG, "Finished setting syncables.");
 
     // TODO: correctly implement Sync Options.
-    Logger.info(LOG_TAG, "Clearing preferences for this account.");
-    try {
-      Utils.getSharedPreferences(context, username, serverURL).edit().clear().commit();
-    } catch (Exception e) {
-      Logger.error(LOG_TAG, "Could not clear prefs path!", e);
-    }
+    Utils.purgeSharedPreferences(context, username, serverURL);
 
     final Intent intent = new Intent();
     intent.putExtra(AccountManager.KEY_ACCOUNT_NAME, username);


### PR DESCRIPTION
I got rid of "sync.prefs.global" -- don't understand why it was there in the first place, and some decidely not-global state (stale clusterURL flag) was being written there.  Now we just take care to get our prefs in place for the correct account before testing for earliest next sync.

This will probably conflict with https://github.com/mozilla-services/android-sync/pull/138, which is languishing...
