### PR TITLE
In testing for expected records, keep track of records after finding them, to fix double-counting.

### DIFF
--- a/test/src/org/mozilla/android/sync/test/helpers/DefaultFetchDelegate.java
+++ b/test/src/org/mozilla/android/sync/test/helpers/DefaultFetchDelegate.java
@@ -45,6 +45,7 @@ public class DefaultFetchDelegate extends DefaultDelegate implements RepositoryS
     Log.i(LOG_TAG, "End timestamp is " + end);
     Log.i(LOG_TAG, "Expected is " + expected);
     Log.i(LOG_TAG, "Records is " + records);
+    Set<String> foundGuids = new HashSet<String>();
     try {
       int expectedCount = 0;
       int expectedFound = 0;
@@ -61,6 +62,9 @@ public class DefaultFetchDelegate extends DefaultDelegate implements RepositoryS
 
         // Ignore special GUIDs (e.g., for bookmarks).
         if (!ignore.contains(record.guid)) {
+          if (foundGuids.contains(record.guid)) {
+            fail("Found duplicate guid " + record.guid);
+          }
           Record expect = expected.get(record.guid);
           if (expect == null) {
             fail("Do not expect to get back a record with guid: " + record.guid); // Caught below
@@ -73,6 +77,8 @@ public class DefaultFetchDelegate extends DefaultDelegate implements RepositoryS
           }
           Log.d(LOG_TAG, "Checked equality.");
           expectedFound += 1;
+          // Track record once we've found it.
+          foundGuids.add(record.guid);
         }
       }
       assertEquals(expectedCount, expectedFound); // Caught below


### PR DESCRIPTION
When testing for expected records, FetchDelegate needs to keep track of records after finding them. Passwords fetchAll was returning the same record guid multiple times, which was incorrect, but did not fail.

Updated to not modify caller args.
