### PR TITLE
Bug 739629 - Expose safe account creation API for profile migration.

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/SyncConfiguration.java
+++ b/src/main/java/org/mozilla/gecko/sync/SyncConfiguration.java
@@ -192,6 +192,8 @@ public class SyncConfiguration implements CredentialsSource {
   public PrefsSource     prefsSource;
 
   public static final String CLIENT_RECORD_TIMESTAMP = "serverClientRecordTimestamp";
+  public static final String PREF_CLUSTER_URL = "clusterURL";
+  public static final String PREF_SYNC_ID = "syncID";
 
   /**
    * Create a new SyncConfiguration instance. Pass in a PrefsSource to
@@ -220,8 +222,8 @@ public class SyncConfiguration implements CredentialsSource {
 
   public void loadFromPrefs(SharedPreferences prefs) {
 
-    if (prefs.contains("clusterURL")) {
-      String u = prefs.getString("clusterURL", null);
+    if (prefs.contains(PREF_CLUSTER_URL)) {
+      String u = prefs.getString(PREF_CLUSTER_URL, null);
       try {
         clusterURL = new URI(u);
         Logger.info(LOG_TAG, "Set clusterURL from bundle: " + u);
@@ -229,8 +231,8 @@ public class SyncConfiguration implements CredentialsSource {
         Logger.warn(LOG_TAG, "Ignoring bundle clusterURL (" + u + "): invalid URI.", e);
       }
     }
-    if (prefs.contains("syncID")) {
-      syncID = prefs.getString("syncID", null);
+    if (prefs.contains(PREF_SYNC_ID)) {
+      syncID = prefs.getString(PREF_SYNC_ID, null);
       Logger.info(LOG_TAG, "Set syncID from bundle: " + syncID);
     }
     // We don't set crypto/keys here because we need the syncKeyBundle to decrypt the JSON
@@ -245,12 +247,12 @@ public class SyncConfiguration implements CredentialsSource {
   public void persistToPrefs(SharedPreferences prefs) {
     Editor edit = prefs.edit();
     if (clusterURL == null) {
-      edit.remove("clusterURL");
+      edit.remove(PREF_CLUSTER_URL);
     } else {
-      edit.putString("clusterURL", clusterURL.toASCIIString());
+      edit.putString(PREF_CLUSTER_URL, clusterURL.toASCIIString());
     }
     if (syncID != null) {
-      edit.putString("syncID", syncID);
+      edit.putString(PREF_SYNC_ID, syncID);
     }
     edit.commit();
     // TODO: keys.
@@ -339,7 +341,7 @@ public class SyncConfiguration implements CredentialsSource {
     clusterURL = u;
     if (shouldPersist) {
       Editor edit = prefs.edit();
-      edit.putString("clusterURL", clusterURL.toASCIIString());
+      edit.putString(PREF_CLUSTER_URL, clusterURL.toASCIIString());
       edit.commit();
     }
   }

--- a/src/main/java/org/mozilla/gecko/sync/setup/SyncAccounts.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/SyncAccounts.java
@@ -12,7 +12,6 @@ import android.accounts.Account;
 import android.accounts.AccountManager;
 import android.content.ContentResolver;
 import android.content.Context;
-import android.content.Intent;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.util.Log;
@@ -20,27 +19,28 @@ import android.util.Log;
 /**
  * This class contains utilities that are of use to Fennec
  * and Sync setup activities.
- *
+ * <p>
  * Do not break these APIs without correcting upstream code!
  */
 public class SyncAccounts {
 
   private final static String DEFAULT_SERVER = "https://auth.services.mozilla.com/";
   private static final String LOG_TAG = "SyncAccounts";
+  private static final String GLOBAL_LOG_TAG = "FxSync";
 
   /**
    * Returns true if a Sync account is set up.
-   *
+   * <p>
    * Do not call this method from the main thread.
    */
   public static boolean syncAccountsExist(Context c) {
-    return AccountManager.get(c).getAccountsByType("org.mozilla.firefox_sync").length > 0;
+    return AccountManager.get(c).getAccountsByType(Constants.ACCOUNTTYPE_SYNC).length > 0;
   }
 
   /**
    * This class provides background-thread abstracted access to whether a
    * Firefox Sync account has been set up on this device.
-   *
+   * <p>
    * Subclass this task and override `onPostExecute` to act on the result.
    */
   public static class AccountsExistTask extends AsyncTask<Context, Void, Boolean> {
@@ -51,12 +51,99 @@ public class SyncAccounts {
     }
   }
 
-  public static Intent createAccount(Context context,
-                                     AccountManager accountManager,
-                                     String username,
-                                     String syncKey,
-                                     String password,
-                                     String serverURL) {
+  /**
+   * This class encapsulates the parameters needed to create a new Firefox Sync
+   * account.
+   */
+  public static class SyncAccountParameters {
+    public final Context context;
+    public final AccountManager accountManager;
+
+    public final String username;
+    public final String syncKey;
+    public final String password;
+    public final String serverURL;
+
+    /**
+     * Encapsulate the parameters needed to create a new Firefox Sync account.
+     *
+     * @param context
+     *          the current <code>Context</code>; cannot be null.
+     * @param accountManager
+     *          an <code>AccountManager</code> instance to use; if null, get it
+     *          from <code>context</code>.
+     * @param username
+     *          the desired username; cannot be null.
+     * @param syncKey
+     *          the desired sync key; cannot be null.
+     * @param password
+     *          the desired password; cannot be null.
+     * @param serverURL
+     *          the server URL to use; if null, use the default.
+     */
+    public SyncAccountParameters(Context context, AccountManager accountManager,
+        String username, String syncKey, String password, String serverURL) {
+      if (context == null) {
+        throw new IllegalArgumentException("Null context passed to SyncAccountParameters constructor.");
+      }
+      if (username == null) {
+        throw new IllegalArgumentException("Null username passed to SyncAccountParameters constructor.");
+      }
+      if (syncKey == null) {
+        throw new IllegalArgumentException("Null syncKey passed to SyncAccountParameters constructor.");
+      }
+      if (password == null) {
+        throw new IllegalArgumentException("Null password passed to SyncAccountParameters constructor.");
+      }
+      this.context = context;
+      this.accountManager = accountManager;
+      this.username = username;
+      this.syncKey = syncKey;
+      this.password = password;
+      this.serverURL = serverURL;
+    }
+  }
+
+  /**
+   * This class provides background-thread abstracted access to creating a
+   * Firefox Sync account.
+   * <p>
+   * Subclass this task and override `onPostExecute` to act on the result. The
+   * <code>Result</code> (of type <code>Account</code>) is null if an error
+   * occurred and the account could not be added.
+   */
+  public static class CreateSyncAccountTask extends AsyncTask<SyncAccountParameters, Void, Account> {
+    @Override
+    protected Account doInBackground(SyncAccountParameters... params) {
+      SyncAccountParameters syncAccount = params[0];
+      try {
+        return createSyncAccount(syncAccount);
+      } catch (Exception e) {
+        Log.e(GLOBAL_LOG_TAG, "Unable to create account.", e);
+        return null;
+      }
+    }
+  }
+
+  /**
+   * Create a sync account.
+   * <p>
+   * Do not call this method from the main thread.
+   *
+   * @param syncAccount
+   *        The parameters of the account to be created.
+   * @return The created <code>Account</code>, or null if an error occurred and
+   *         the account could not be added.
+   */
+  public static Account createSyncAccount(SyncAccountParameters syncAccount) {
+    final Context context = syncAccount.context;
+    final AccountManager accountManager = (syncAccount.accountManager == null) ?
+          AccountManager.get(syncAccount.context) : syncAccount.accountManager;
+    final String username  = syncAccount.username;
+    final String syncKey   = syncAccount.syncKey;
+    final String password  = syncAccount.password;
+    final String serverURL = syncAccount.serverURL;
+    Logger.debug(LOG_TAG, "Using account manager " + accountManager);
 
     final Account account = new Account(username, Constants.ACCOUNTTYPE_SYNC);
     final Bundle userbundle = new Bundle();
@@ -74,21 +161,23 @@ public class SyncAccounts {
     try {
       result = accountManager.addAccountExplicitly(account, password, userbundle);
     } catch (SecurityException e) {
+      // We use Log rather than Logger here to avoid possibly hiding these errors.
       final String message = e.getMessage();
       if (message != null && (message.indexOf("is different than the authenticator's uid") > 0)) {
-        Log.wtf("FirefoxSync",
+        Log.wtf(GLOBAL_LOG_TAG,
                 "Unable to create account. " +
                 "If you have more than one version of " +
                 "Firefox/Beta/Aurora/Nightly/Fennec installed, that's why.",
                 e);
       } else {
-        Log.e("FirefoxSync", "Unable to create account.", e);
+        Log.e(GLOBAL_LOG_TAG, "Unable to create account.", e);
       }
     }
 
     Logger.debug(LOG_TAG, "Account: " + account + " added successfully? " + result);
     if (!result) {
       Logger.error(LOG_TAG, "Failed to add account!");
+      return null;
     }
 
     // Set components to sync (default: all).
@@ -110,11 +199,25 @@ public class SyncAccounts {
     } catch (Exception e) {
       Logger.error(LOG_TAG, "Could not clear prefs path!", e);
     }
+    return account;
+  }
 
-    final Intent intent = new Intent();
-    intent.putExtra(AccountManager.KEY_ACCOUNT_NAME, username);
-    intent.putExtra(AccountManager.KEY_ACCOUNT_TYPE, Constants.ACCOUNTTYPE_SYNC);
-    intent.putExtra(AccountManager.KEY_AUTHTOKEN, Constants.ACCOUNTTYPE_SYNC);
-    return intent;
+  protected static void setSyncAutomatically(Account account) {
+    ContentResolver.setMasterSyncAutomatically(true);
+    String authority = BrowserContract.AUTHORITY;
+    Logger.debug(LOG_TAG, "Setting authority " + authority + " to sync automatically.");
+    ContentResolver.setSyncAutomatically(account, authority, true);
+    ContentResolver.setIsSyncable(account, authority, 1);
+  }
+
+  protected static void setClientRecord(Context context, AccountManager accountManager, Account account,
+      String clientName, String clientGuid) {
+    if (clientName != null && clientGuid != null) {
+      Logger.debug(LOG_TAG, "Setting client name to " + clientName + " and client GUID to " + clientGuid + ".");
+      SyncAdapter.setAccountGUID(accountManager, account, clientGuid);
+      SyncAdapter.setClientName(accountManager, account, clientName);
+      return;
+    }
+    Logger.debug(LOG_TAG, "Client name and guid not both non-null, so not setting client data.");
   }
 }

--- a/src/main/java/org/mozilla/gecko/sync/setup/SyncAccounts.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/SyncAccounts.java
@@ -6,6 +6,7 @@ package org.mozilla.gecko.sync.setup;
 
 import org.mozilla.gecko.db.BrowserContract;
 import org.mozilla.gecko.sync.Logger;
+import org.mozilla.gecko.sync.SyncConfiguration;
 import org.mozilla.gecko.sync.Utils;
 import org.mozilla.gecko.sync.repositories.android.RepoUtils;
 import org.mozilla.gecko.sync.syncadapter.SyncAdapter;
@@ -14,6 +15,7 @@ import android.accounts.Account;
 import android.accounts.AccountManager;
 import android.content.ContentResolver;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.util.Log;
@@ -26,7 +28,7 @@ import android.util.Log;
  */
 public class SyncAccounts {
 
-  private final static String DEFAULT_SERVER = "https://auth.services.mozilla.com/";
+  public final static String DEFAULT_SERVER = "https://auth.services.mozilla.com/";
   private static final String LOG_TAG = "SyncAccounts";
   private static final String GLOBAL_LOG_TAG = "FxSync";
 
@@ -215,7 +217,11 @@ public class SyncAccounts {
     // TODO: correctly implement Sync Options.
     Logger.info(LOG_TAG, "Clearing preferences for this account.");
     try {
-      Utils.getSharedPreferences(context, username, serverURL).edit().clear().commit();
+      SharedPreferences.Editor editor = Utils.getSharedPreferences(context, username, serverURL).edit().clear();
+      if (syncAccount.clusterURL != null) {
+        editor.putString(SyncConfiguration.PREF_CLUSTER_URL, syncAccount.clusterURL);
+      }
+      editor.commit();
     } catch (Exception e) {
       Logger.error(LOG_TAG, "Could not clear prefs path!", e);
     }

--- a/src/main/java/org/mozilla/gecko/sync/syncadapter/SyncAdapter.java
+++ b/src/main/java/org/mozilla/gecko/sync/syncadapter/SyncAdapter.java
@@ -421,9 +421,13 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements GlobalSe
     if (accountGUID == null) {
       Logger.info(LOG_TAG, "Account GUID was null. Creating a new one.");
       accountGUID = Utils.generateGuid();
-      mAccountManager.setUserData(localAccount, Constants.ACCOUNT_GUID, accountGUID);
+      setAccountGUID(mAccountManager, localAccount, accountGUID);
     }
     return accountGUID;
+  }
+
+  public static void setAccountGUID(AccountManager accountManager, Account account, String accountGUID) {
+    accountManager.setUserData(account, Constants.ACCOUNT_GUID, accountGUID);
   }
 
   @Override
@@ -431,9 +435,13 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements GlobalSe
     String clientName = mAccountManager.getUserData(localAccount, Constants.CLIENT_NAME);
     if (clientName == null) {
       clientName = GlobalConstants.PRODUCT_NAME + " on " + android.os.Build.MODEL;
-      mAccountManager.setUserData(localAccount, Constants.CLIENT_NAME, clientName);
+      setClientName(mAccountManager, localAccount, clientName);
     }
     return clientName;
+  }
+
+  public static void setClientName(AccountManager accountManager, Account account, String clientName) {
+    accountManager.setUserData(account, Constants.CLIENT_NAME, clientName);
   }
 
   @Override

--- a/test/src/org/mozilla/android/sync/test/TestClientsDataDelegate.java
+++ b/test/src/org/mozilla/android/sync/test/TestClientsDataDelegate.java
@@ -69,18 +69,28 @@ public class TestClientsDataDelegate extends AndroidSyncTestCase {
     });
   }
 
-  public void testGetAccountGUID() {
+  public void testAccountGUID() {
     // Test getAccountGUID() saved the value it returned the first time.
     String accountGUID = clientsDelegate.getAccountGUID();
     assertNotNull(accountGUID);
     assertEquals(accountGUID, clientsDelegate.getAccountGUID());
+
+    // Test setting the GUID.
+    final String TEST_GUID = "testGuid";
+    SyncAdapter.setAccountGUID(accountManager, account, TEST_GUID);
+    assertEquals(TEST_GUID, clientsDelegate.getAccountGUID());
   }
 
-  public void testGetClientName() {
+  public void testClientName() {
     // Test getClientName() saved the value it returned the first time.
     String clientName = clientsDelegate.getClientName();
     assertNotNull(clientName);
     assertEquals(clientName, clientsDelegate.getClientName());
+
+    // Test setting the name.
+    final String TEST_NAME = "testName";
+    SyncAdapter.setClientName(accountManager, account, TEST_NAME);
+    assertEquals(TEST_NAME, clientsDelegate.getClientName());
   }
 
   public void testClientsCount() {

--- a/test/src/org/mozilla/gecko/sync/setup/test/TestSyncAccounts.java
+++ b/test/src/org/mozilla/gecko/sync/setup/test/TestSyncAccounts.java
@@ -1,0 +1,185 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+package org.mozilla.gecko.sync.setup.test;
+
+import java.util.concurrent.TimeUnit;
+
+import org.mozilla.android.sync.test.AndroidSyncTestCase;
+import org.mozilla.gecko.sync.setup.Constants;
+import org.mozilla.gecko.sync.setup.SyncAccounts;
+import org.mozilla.gecko.sync.setup.SyncAccounts.SyncAccountParameters;
+
+import android.accounts.Account;
+import android.accounts.AccountManager;
+import android.accounts.AccountManagerCallback;
+import android.accounts.AccountManagerFuture;
+import android.content.Context;
+
+public class TestSyncAccounts extends AndroidSyncTestCase {
+  private static final String TEST_USERNAME  = "testAccount@mozilla.com";
+  private static final String TEST_SYNCKEY   = "testSyncKey";
+  private static final String TEST_PASSWORD  = "testPassword";
+  private static final String TEST_SERVERURL = "testServerURL";
+
+  private Account account;
+  private Context context;
+  private AccountManager accountManager;
+  private SyncAccountParameters syncAccount;
+
+  public void setUp() {
+    account = null;
+    context = getApplicationContext();
+    accountManager = AccountManager.get(context);
+    syncAccount = new SyncAccountParameters(context, null,
+        TEST_USERNAME, TEST_SYNCKEY, TEST_PASSWORD, null);
+  }
+
+  public void deleteAccount(final Account account) {
+    final AccountManagerCallback<Boolean> callback = new AccountManagerCallback<Boolean>() {
+      @Override
+      public void run(AccountManagerFuture<Boolean> future) {
+        try {
+          future.getResult(5L, TimeUnit.SECONDS);
+          performNotify();
+        } catch (Exception e) {
+          performNotify(e);
+        }
+      }
+    };
+
+    performWait(new Runnable() {
+      @Override
+      public void run() {
+        accountManager.removeAccount(account, callback, null);
+      }
+    });
+  }
+
+  public void tearDown() {
+    if (account == null) {
+      return;
+    }
+    deleteAccount(account);
+  }
+
+  public void testSyncAccountParameters() {
+    assertEquals(TEST_USERNAME, syncAccount.username);
+    assertNull(syncAccount.accountManager);
+    assertNull(syncAccount.serverURL);
+
+    try {
+      syncAccount = new SyncAccountParameters(context, null,
+          null, TEST_SYNCKEY, TEST_PASSWORD, TEST_SERVERURL);
+    } catch (IllegalArgumentException e) {
+      return;
+    } catch (Exception e) {
+      fail("Did not expect exception: " + e);
+    }
+    fail("Expected IllegalArgumentException.");
+  }
+
+  public void testCreateAccount() {
+    int before = accountManager.getAccountsByType(Constants.ACCOUNTTYPE_SYNC).length;
+    account = SyncAccounts.createSyncAccount(syncAccount);
+    int afterCreate = accountManager.getAccountsByType(Constants.ACCOUNTTYPE_SYNC).length;
+    assertTrue(afterCreate > before);
+    deleteAccount(account);
+    account = null;
+    int afterDelete = accountManager.getAccountsByType(Constants.ACCOUNTTYPE_SYNC).length;
+    assertEquals(before, afterDelete);
+  }
+
+  public void testCreateSecondAccount() {
+    int before = accountManager.getAccountsByType(Constants.ACCOUNTTYPE_SYNC).length;
+    account = SyncAccounts.createSyncAccount(syncAccount);
+    int afterFirst = accountManager.getAccountsByType(Constants.ACCOUNTTYPE_SYNC).length;
+    assertTrue(afterFirst > before);
+
+    SyncAccountParameters secondSyncAccount = new SyncAccountParameters(context, null,
+        "second@username.com", TEST_SYNCKEY, TEST_PASSWORD, null);
+
+    Account second = SyncAccounts.createSyncAccount(secondSyncAccount);
+    assertNotNull(second);
+    int afterSecond = accountManager.getAccountsByType(Constants.ACCOUNTTYPE_SYNC).length;
+    assertTrue(afterSecond > afterFirst);
+
+    deleteAccount(second);
+    deleteAccount(account);
+    account = null;
+
+    int afterDelete = accountManager.getAccountsByType(Constants.ACCOUNTTYPE_SYNC).length;
+    assertEquals(before, afterDelete);
+  }
+
+  public void testCreateDuplicateAccount() {
+    int before = accountManager.getAccountsByType(Constants.ACCOUNTTYPE_SYNC).length;
+    account = SyncAccounts.createSyncAccount(syncAccount);
+    int afterCreate = accountManager.getAccountsByType(Constants.ACCOUNTTYPE_SYNC).length;
+    assertTrue(afterCreate > before);
+
+    Account dupe = SyncAccounts.createSyncAccount(syncAccount);
+    assertNull(dupe);
+  }
+
+  public Boolean result;
+
+  public void testAccountsExistTask() {
+    int before = accountManager.getAccountsByType(Constants.ACCOUNTTYPE_SYNC).length;
+    account = SyncAccounts.createSyncAccount(syncAccount);
+    int afterCreate = accountManager.getAccountsByType(Constants.ACCOUNTTYPE_SYNC).length;
+    assertTrue(afterCreate > before);
+
+    final TestSyncAccounts self = this;
+    final SyncAccounts.AccountsExistTask task = new SyncAccounts.AccountsExistTask() {
+      @Override
+      public void onPostExecute(Boolean result) {
+        self.result = result;
+        performNotify();
+      }
+    };
+    performWait(new Runnable() {
+      @Override
+      public void run() {
+        task.execute(context);
+      }
+    });
+
+    assertNotNull(result);
+    assertTrue(result.booleanValue());
+
+    deleteAccount(account);
+    account = null;
+    int afterDelete = accountManager.getAccountsByType(Constants.ACCOUNTTYPE_SYNC).length;
+    assertEquals(before, afterDelete);
+  }
+
+  public void testCreateAccountTask() {
+    int before = accountManager.getAccountsByType(Constants.ACCOUNTTYPE_SYNC).length;
+
+    final TestSyncAccounts self = this;
+    final SyncAccounts.CreateSyncAccountTask task = new SyncAccounts.CreateSyncAccountTask() {
+      @Override
+      public void onPostExecute(Account account) {
+        self.account = account;
+        performNotify();
+      }
+    };
+    performWait(new Runnable() {
+      @Override
+      public void run() {
+        task.execute(syncAccount);
+      }
+    });
+
+    assertNotNull(account);
+
+    int afterCreate = accountManager.getAccountsByType(Constants.ACCOUNTTYPE_SYNC).length;
+    assertTrue(afterCreate > before);
+
+    deleteAccount(account);
+    account = null;
+    int afterDelete = accountManager.getAccountsByType(Constants.ACCOUNTTYPE_SYNC).length;
+    assertEquals(before, afterDelete);
+  }
+}

--- a/test/src/org/mozilla/gecko/sync/setup/test/TestSyncAccounts.java
+++ b/test/src/org/mozilla/gecko/sync/setup/test/TestSyncAccounts.java
@@ -9,6 +9,7 @@ import org.mozilla.android.sync.test.AndroidSyncTestCase;
 import org.mozilla.gecko.sync.setup.Constants;
 import org.mozilla.gecko.sync.setup.SyncAccounts;
 import org.mozilla.gecko.sync.setup.SyncAccounts.SyncAccountParameters;
+import org.mozilla.gecko.sync.syncadapter.SyncAdapter;
 
 import android.accounts.Account;
 import android.accounts.AccountManager;
@@ -181,5 +182,20 @@ public class TestSyncAccounts extends AndroidSyncTestCase {
     account = null;
     int afterDelete = accountManager.getAccountsByType(Constants.ACCOUNTTYPE_SYNC).length;
     assertEquals(before, afterDelete);
+  }
+
+  public void testClientRecord() {
+    final String TEST_NAME = "testName";
+    final String TEST_GUID = "testGuid";
+    syncAccount = new SyncAccountParameters(context, null,
+        TEST_USERNAME, TEST_SYNCKEY, TEST_PASSWORD, null, null, TEST_NAME, TEST_GUID);
+    account = SyncAccounts.createSyncAccount(syncAccount);
+    assertNotNull(account);
+
+    SyncAdapter syncAdapter = new SyncAdapter(context, false);
+    syncAdapter.localAccount = account;
+
+    assertEquals(TEST_GUID, syncAdapter.getAccountGUID());
+    assertEquals(TEST_NAME, syncAdapter.getClientName());
   }
 }


### PR DESCRIPTION
- expressly allows to create two accounts -- see tests.
- will fail on creating exact duplicate account -- see tests.
- introduces possibility of failing in J-PAKE `complete` after successful J-PAKE stage -- not clear that I've handled that scenario well (but it is _exceedingly_ rare, since we don't even start J-PAKE if a sync account is present).
- would appreciate signoff on docs in `SyncAccounts.java` and usage examples in `TestSyncAccounts.java`.
