### PR TITLE
Bug 743098 - migration before bookmarks and history

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/CollectionKeys.java
+++ b/src/main/java/org/mozilla/gecko/sync/CollectionKeys.java
@@ -1,39 +1,6 @@
-/* ***** BEGIN LICENSE BLOCK *****
- * Version: MPL 1.1/GPL 2.0/LGPL 2.1
- *
- * The contents of this file are subject to the Mozilla Public License Version
- * 1.1 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- * http://www.mozilla.org/MPL/
- *
- * Software distributed under the License is distributed on an "AS IS" basis,
- * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
- * for the specific language governing rights and limitations under the
- * License.
- *
- * The Original Code is Android Sync Client.
- *
- * The Initial Developer of the Original Code is
- * the Mozilla Foundation.
- * Portions created by the Initial Developer are Copyright (C) 2011
- * the Initial Developer. All Rights Reserved.
- *
- * Contributor(s):
- *   Richard Newman <rnewman@mozilla.com>
- *
- * Alternatively, the contents of this file may be used under the terms of
- * either the GNU General Public License Version 2 or later (the "GPL"), or
- * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
- * in which case the provisions of the GPL or the LGPL are applicable instead
- * of those above. If you wish to allow use of your version of this file only
- * under the terms of either the GPL or the LGPL, and not to allow others to
- * use your version of this file under the terms of the MPL, indicate your
- * decision by deleting the provisions above and replace them with the notice
- * and other provisions required by the GPL or the LGPL. If you do not delete
- * the provisions above, a recipient may use your version of this file under
- * the terms of any one of the MPL, the GPL or the LGPL.
- *
- * ***** END LICENSE BLOCK ***** */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.gecko.sync;
 

--- a/src/main/java/org/mozilla/gecko/sync/CredentialsSource.java
+++ b/src/main/java/org/mozilla/gecko/sync/CredentialsSource.java
@@ -1,39 +1,6 @@
-/* ***** BEGIN LICENSE BLOCK *****
- * Version: MPL 1.1/GPL 2.0/LGPL 2.1
- *
- * The contents of this file are subject to the Mozilla Public License Version
- * 1.1 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- * http://www.mozilla.org/MPL/
- *
- * Software distributed under the License is distributed on an "AS IS" basis,
- * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
- * for the specific language governing rights and limitations under the
- * License.
- *
- * The Original Code is Android Sync Client.
- *
- * The Initial Developer of the Original Code is
- * the Mozilla Foundation.
- * Portions created by the Initial Developer are Copyright (C) 2011
- * the Initial Developer. All Rights Reserved.
- *
- * Contributor(s):
- *   Richard Newman <rnewman@mozilla.com>
- *
- * Alternatively, the contents of this file may be used under the terms of
- * either the GNU General Public License Version 2 or later (the "GPL"), or
- * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
- * in which case the provisions of the GPL or the LGPL are applicable instead
- * of those above. If you wish to allow use of your version of this file only
- * under the terms of either the GPL or the LGPL, and not to allow others to
- * use your version of this file under the terms of the MPL, indicate your
- * decision by deleting the provisions above and replace them with the notice
- * and other provisions required by the GPL or the LGPL. If you do not delete
- * the provisions above, a recipient may use your version of this file under
- * the terms of any one of the MPL, the GPL or the LGPL.
- *
- * ***** END LICENSE BLOCK ***** */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.gecko.sync;
 

--- a/src/main/java/org/mozilla/gecko/sync/InfoCollections.java
+++ b/src/main/java/org/mozilla/gecko/sync/InfoCollections.java
@@ -1,39 +1,6 @@
-/* ***** BEGIN LICENSE BLOCK *****
- * Version: MPL 1.1/GPL 2.0/LGPL 2.1
- *
- * The contents of this file are subject to the Mozilla Public License Version
- * 1.1 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- * http://www.mozilla.org/MPL/
- *
- * Software distributed under the License is distributed on an "AS IS" basis,
- * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
- * for the specific language governing rights and limitations under the
- * License.
- *
- * The Original Code is Android Sync Client.
- *
- * The Initial Developer of the Original Code is
- * the Mozilla Foundation.
- * Portions created by the Initial Developer are Copyright (C) 2011
- * the Initial Developer. All Rights Reserved.
- *
- * Contributor(s):
- * Richard Newman <rnewman@mozilla.com>
- *
- * Alternatively, the contents of this file may be used under the terms of
- * either the GNU General Public License Version 2 or later (the "GPL"), or
- * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
- * in which case the provisions of the GPL or the LGPL are applicable instead
- * of those above. If you wish to allow use of your version of this file only
- * under the terms of either the GPL or the LGPL, and not to allow others to
- * use your version of this file under the terms of the MPL, indicate your
- * decision by deleting the provisions above and replace them with the notice
- * and other provisions required by the GPL or the LGPL. If you do not delete
- * the provisions above, a recipient may use your version of this file under
- * the terms of any one of the MPL, the GPL or the LGPL.
- *
- * ***** END LICENSE BLOCK ***** */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.gecko.sync;
 

--- a/src/main/java/org/mozilla/gecko/sync/MetaGlobal.java
+++ b/src/main/java/org/mozilla/gecko/sync/MetaGlobal.java
@@ -1,39 +1,6 @@
-/* ***** BEGIN LICENSE BLOCK *****
- * Version: MPL 1.1/GPL 2.0/LGPL 2.1
- *
- * The contents of this file are subject to the Mozilla Public License Version
- * 1.1 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- * http://www.mozilla.org/MPL/
- *
- * Software distributed under the License is distributed on an "AS IS" basis,
- * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
- * for the specific language governing rights and limitations under the
- * License.
- *
- * The Original Code is Android Sync Client.
- *
- * The Initial Developer of the Original Code is
- * the Mozilla Foundation.
- * Portions created by the Initial Developer are Copyright (C) 2011
- * the Initial Developer. All Rights Reserved.
- *
- * Contributor(s):
- * Richard Newman <rnewman@mozilla.com>
- *
- * Alternatively, the contents of this file may be used under the terms of
- * either the GNU General Public License Version 2 or later (the "GPL"), or
- * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
- * in which case the provisions of the GPL or the LGPL are applicable instead
- * of those above. If you wish to allow use of your version of this file only
- * under the terms of either the GPL or the LGPL, and not to allow others to
- * use your version of this file under the terms of the MPL, indicate your
- * decision by deleting the provisions above and replace them with the notice
- * and other provisions required by the GPL or the LGPL. If you do not delete
- * the provisions above, a recipient may use your version of this file under
- * the terms of any one of the MPL, the GPL or the LGPL.
- *
- * ***** END LICENSE BLOCK ***** */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.gecko.sync;
 

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/FennecControlHelper.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/FennecControlHelper.java
@@ -1,0 +1,112 @@
+package org.mozilla.gecko.sync.repositories.android;
+
+import org.mozilla.gecko.db.BrowserContract.Control;
+import org.mozilla.gecko.sync.Logger;
+import org.mozilla.gecko.sync.repositories.NoContentProviderException;
+
+import android.content.ContentProviderClient;
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+
+/**
+ * This class provides an interface to Fenec's control content provider, which
+ * exposes some of Fennec's internal state.
+ */
+public class FennecControlHelper {
+  public static String LOG_TAG = "FennecControlHelper";
+
+  protected static Uri FENNEC_CONTROL_URI = Control.CONTENT_URI;
+
+  protected ContentProviderClient providerClient;
+  protected final RepoUtils.QueryHelper queryHelper;
+
+  public FennecControlHelper(Context context)
+      throws NoContentProviderException {
+    providerClient = acquireContentProvider(context);
+    queryHelper = new RepoUtils.QueryHelper(context, FENNEC_CONTROL_URI, LOG_TAG);
+  }
+
+  /**
+   * Acquire the content provider client.
+   * <p>
+   * The caller is responsible for releasing the client.
+   *
+   * @param context The application context.
+   * @return The <code>ContentProviderClient</code>.
+   * @throws NoContentProviderException
+   */
+  public static ContentProviderClient acquireContentProvider(final Context context)
+      throws NoContentProviderException {
+    Uri uri = FENNEC_CONTROL_URI;
+    ContentProviderClient client = context.getContentResolver().acquireContentProviderClient(uri);
+    if (client == null) {
+      throw new NoContentProviderException(uri);
+    }
+    return client;
+  }
+
+  public void releaseProviders() {
+    try {
+      if (providerClient != null) {
+        providerClient.release();
+      }
+    } catch (Exception e) {
+    }
+    providerClient = null;
+  }
+
+  // Only used for testing.
+  public ContentProviderClient getFormsProvider() {
+    return providerClient;
+  }
+
+  protected static String[] HISTORY_MIGRATION_COLUMNS = new String[] { Control.ENSURE_HISTORY_MIGRATED };
+  protected static String[] BOOKMARKS_MIGRATION_COLUMNS = new String[] { Control.ENSURE_BOOKMARKS_MIGRATED };
+
+  protected boolean isColumnMigrated(String column) {
+    String[] columns = new String[] { column };
+    Cursor cursor = null;
+    try {
+      cursor = queryHelper.safeQuery(providerClient, ".isColumnMigrated(" + column + ")", columns, null, null, null);
+      if (!cursor.moveToFirst()) {
+        return false;
+      }
+      int value = RepoUtils.getIntFromCursor(cursor, column);
+      return value > 0;
+    } catch (Exception e) {
+      Logger.warn(LOG_TAG, "Caught exception checking if Fennec has migrated column " + column + ".", e);
+      return false;
+    } finally {
+      if (cursor != null) {
+        cursor.close();
+      }
+    }
+  }
+
+  protected static boolean isColumnMigrated(Context context, String column) {
+    if (context == null) {
+      return false;
+    }
+    FennecControlHelper control = null;
+    try {
+      control = new FennecControlHelper(context);
+      return control.isColumnMigrated(column);
+    } catch (Exception e) {
+      Logger.warn(LOG_TAG, "Caught exception checking if Fennec has migrated column " + column + ".", e);
+      return false;
+    } finally {
+      if (control != null) {
+        control.releaseProviders();
+      }
+    }
+  }
+
+  public static boolean isHistoryMigrated(Context context) {
+    return isColumnMigrated(context, Control.ENSURE_HISTORY_MIGRATED);
+  }
+
+  public static boolean areBookmarksMigrated(Context context) {
+    return isColumnMigrated(context, Control.ENSURE_BOOKMARKS_MIGRATED);
+  }
+}

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/FennecControlHelper.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/FennecControlHelper.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.gecko.sync.repositories.android;
 
 import org.mozilla.gecko.db.BrowserContract.Control;

--- a/src/main/java/org/mozilla/gecko/sync/stage/AndroidBrowserBookmarksServerSyncStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/AndroidBrowserBookmarksServerSyncStage.java
@@ -39,13 +39,17 @@ package org.mozilla.gecko.sync.stage;
 
 import java.net.URISyntaxException;
 
+import org.mozilla.gecko.sync.Logger;
+import org.mozilla.gecko.sync.MetaGlobalException;
 import org.mozilla.gecko.sync.repositories.ConstrainedServer11Repository;
 import org.mozilla.gecko.sync.repositories.RecordFactory;
 import org.mozilla.gecko.sync.repositories.Repository;
 import org.mozilla.gecko.sync.repositories.android.AndroidBrowserBookmarksRepository;
+import org.mozilla.gecko.sync.repositories.android.FennecControlHelper;
 import org.mozilla.gecko.sync.repositories.domain.BookmarkRecordFactory;
 
 public class AndroidBrowserBookmarksServerSyncStage extends ServerSyncStage {
+  protected static final String LOG_TAG = "BookmarksStage";
 
   // Eventually this kind of sync stage will be data-driven,
   // and all this hard-coding can go away.
@@ -79,5 +83,17 @@ public class AndroidBrowserBookmarksServerSyncStage extends ServerSyncStage {
   @Override
   protected RecordFactory getRecordFactory() {
     return new BookmarkRecordFactory();
+  }
+
+  @Override
+  protected boolean isEnabled() throws MetaGlobalException {
+    if (session == null || session.getContext() == null) {
+      return false;
+    }
+    boolean migrated = FennecControlHelper.areBookmarksMigrated(session.getContext());
+    if (!migrated) {
+      Logger.warn(LOG_TAG, "Not enabling bookmarks engine since Fennec bookmarks are not migrated.");
+    }
+    return super.isEnabled() && migrated;
   }
 }

--- a/src/main/java/org/mozilla/gecko/sync/stage/AndroidBrowserHistoryServerSyncStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/AndroidBrowserHistoryServerSyncStage.java
@@ -39,13 +39,17 @@ package org.mozilla.gecko.sync.stage;
 
 import java.net.URISyntaxException;
 
+import org.mozilla.gecko.sync.Logger;
+import org.mozilla.gecko.sync.MetaGlobalException;
 import org.mozilla.gecko.sync.repositories.ConstrainedServer11Repository;
 import org.mozilla.gecko.sync.repositories.RecordFactory;
 import org.mozilla.gecko.sync.repositories.Repository;
 import org.mozilla.gecko.sync.repositories.android.AndroidBrowserHistoryRepository;
+import org.mozilla.gecko.sync.repositories.android.FennecControlHelper;
 import org.mozilla.gecko.sync.repositories.domain.HistoryRecordFactory;
 
 public class AndroidBrowserHistoryServerSyncStage extends ServerSyncStage {
+  protected static final String LOG_TAG = "HistoryStage";
 
   // Eventually this kind of sync stage will be data-driven,
   // and all this hard-coding can go away.
@@ -79,5 +83,17 @@ public class AndroidBrowserHistoryServerSyncStage extends ServerSyncStage {
   @Override
   protected RecordFactory getRecordFactory() {
     return new HistoryRecordFactory();
+  }
+
+  @Override
+  protected boolean isEnabled() throws MetaGlobalException {
+    if (session == null || session.getContext() == null) {
+      return false;
+    }
+    boolean migrated = FennecControlHelper.isHistoryMigrated(session.getContext());
+    if (!migrated) {
+      Logger.warn(LOG_TAG, "Not enabling history engine since Fennec history is not migrated.");
+    }
+    return super.isEnabled() && migrated;
   }
 }

--- a/test/src/org/mozilla/gecko/sync/repositories/android/test/TestFennecControlHelper.java
+++ b/test/src/org/mozilla/gecko/sync/repositories/android/test/TestFennecControlHelper.java
@@ -1,3 +1,6 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
 package org.mozilla.gecko.sync.repositories.android.test;
 
 import org.mozilla.android.sync.test.AndroidSyncTestCase;

--- a/test/src/org/mozilla/gecko/sync/repositories/android/test/TestFennecControlHelper.java
+++ b/test/src/org/mozilla/gecko/sync/repositories/android/test/TestFennecControlHelper.java
@@ -1,0 +1,21 @@
+package org.mozilla.gecko.sync.repositories.android.test;
+
+import org.mozilla.android.sync.test.AndroidSyncTestCase;
+import org.mozilla.gecko.sync.repositories.android.FennecControlHelper;
+
+public class TestFennecControlHelper extends AndroidSyncTestCase {
+  public void testIsMigrated() {
+    assertTrue(FennecControlHelper.areBookmarksMigrated(getApplicationContext()));
+    // Might take a few shots, but we should be able to migrate if we haven't already.
+    int numMigrations = 15;
+    int i = numMigrations;
+    while (i > 0) {
+      if (FennecControlHelper.isHistoryMigrated(getApplicationContext())) {
+        return;
+      }
+      i -= 1;
+    }
+    fail("Could not migrate Fennec history in " + numMigrations +
+        " trial migrations; this could happen if your Fennec history is very large.");
+  }
+}


### PR DESCRIPTION
Due to Fennec passwords CP crashiness, hasn't been tested on device.

This disables the engine if the Fennec dbs aren't marked as migrated.
