### PR TITLE
Bug 742104 - turn on forms

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/InfoCollections.java
+++ b/src/main/java/org/mozilla/gecko/sync/InfoCollections.java
@@ -5,7 +5,6 @@
 package org.mozilla.gecko.sync;
 
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map.Entry;
 import java.util.Set;

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/FormHistoryRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/FormHistoryRepositorySession.java
@@ -79,7 +79,9 @@ public class FormHistoryRepositorySession extends
 
   protected void releaseProviders() {
     try {
-      formsProvider.release();
+      if (formsProvider != null) {
+        formsProvider.release();
+      }
     } catch (Exception e) {
     }
   }

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/FormHistoryRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/FormHistoryRepositorySession.java
@@ -40,6 +40,11 @@ public class FormHistoryRepositorySession extends
   protected static Uri FORM_HISTORY_CONTENT_URI = BrowserContractHelpers.FORM_HISTORY_CONTENT_URI;
   protected static Uri DELETED_FORM_HISTORY_CONTENT_URI = BrowserContractHelpers.DELETED_FORM_HISTORY_CONTENT_URI;
 
+  /**
+   * Number of records to insert in one batch.
+   */
+  protected static final int INSERT_ITEM_THRESHOLD = 200;
+
   public static class FormHistoryRepository extends Repository {
 
     @Override
@@ -438,54 +443,39 @@ public class FormHistoryRepositorySession extends
 
   protected Object recordsBufferMonitor = new Object();
   protected ArrayList<ContentValues> recordsBuffer = new ArrayList<ContentValues>();
-  private static final int INSERT_ITEM_THRESHOLD = 5;
 
   protected void enqueueRegularRecord(Record record) {
     synchronized (recordsBufferMonitor) {
       if (recordsBuffer.size() >= INSERT_ITEM_THRESHOLD) {
         // Insert the existing contents, then enqueue.
-        flushInsertQueue();
+        try {
+          flushInsertQueue();
+        } catch (RemoteException e) {
+          delegate.onRecordStoreFailed(e);
+          return;
+        }
       }
       // Store the ContentValues, rather than the record.
       recordsBuffer.add(contentValuesForRegularRecord(record));
     }
   }
 
-  public class RecordInsertRunnable implements Runnable {
-    ContentValues[] queue;
-
-    public RecordInsertRunnable(ArrayList<ContentValues> queue) {
-      ContentValues[] values = new ContentValues[queue.size()];
-      this.queue = queue.toArray(values);
-    }
-
-    @Override
-    public void run() {
-      if (queue == null || queue.length == 0) {
-        Logger.debug(LOG_TAG, "No form history items to insert: RecordInsertRunnable returning immediately.");
-        return;
-      }
-
-      try {
-        Logger.debug(LOG_TAG, "Inserting " + queue.length + " form history items...");
-        long before = System.currentTimeMillis();
-        formsProvider.bulkInsert(FORM_HISTORY_CONTENT_URI, queue);
-        long after = System.currentTimeMillis();
-        Logger.debug(LOG_TAG, "Inserting " + queue.length + " form history items... DONE (" + (after - before) + " milliseconds).");
-      } catch (RemoteException e) {
-        // TODO: REALLY HANDLE THIS ERROR by making this not be a Runnable and handling errors inline.
-        e.printStackTrace();
-      }
-    }
-  }
-
   // Should always be called from storeWorkQueue.
-  protected void flushInsertQueue() {
+  protected void flushInsertQueue() throws RemoteException {
     synchronized (recordsBufferMonitor) {
       if (recordsBuffer.size() > 0) {
-        final ArrayList<ContentValues> outgoing = recordsBuffer;
+        final ContentValues[] outgoing = recordsBuffer.toArray(new ContentValues[0]);
         recordsBuffer = new ArrayList<ContentValues>();
-        new RecordInsertRunnable(outgoing).run();
+
+        if (outgoing == null || outgoing.length == 0) {
+          Logger.debug(LOG_TAG, "No form history items to insert; returning immediately.");
+          return;
+        }
+
+        long before = System.currentTimeMillis();
+        formsProvider.bulkInsert(FORM_HISTORY_CONTENT_URI, outgoing);
+        long after = System.currentTimeMillis();
+        Logger.debug(LOG_TAG, "Inserted " + outgoing.length + " form history items in (" + (after - before) + " milliseconds).");
       }
     }
   }
@@ -496,10 +486,14 @@ public class FormHistoryRepositorySession extends
       @Override
       public void run() {
         Logger.debug(LOG_TAG, "Checking for residual form history items to insert.");
-        synchronized (recordsBufferMonitor) {
-          flushInsertQueue();
+        try {
+          synchronized (recordsBufferMonitor) {
+            flushInsertQueue();
+          }
+          storeDone(now());
+        } catch (RemoteException e) {
+          delegate.onRecordStoreFailed(e);
         }
-        storeDone(now()); // XXX?
       }
     };
     storeWorkQueue.execute(command);

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/FormHistoryRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/FormHistoryRepositorySession.java
@@ -37,13 +37,13 @@ public class FormHistoryRepositorySession extends
     StoreTrackingRepositorySession {
   public static String LOG_TAG = "FormHistoryRepoSess";
 
-  protected static Uri FORM_HISTORY_CONTENT_URI = BrowserContractHelpers.FORM_HISTORY_CONTENT_URI;
-  protected static Uri DELETED_FORM_HISTORY_CONTENT_URI = BrowserContractHelpers.DELETED_FORM_HISTORY_CONTENT_URI;
-
   /**
    * Number of records to insert in one batch.
    */
-  protected static final int INSERT_ITEM_THRESHOLD = 200;
+  public static final int INSERT_ITEM_THRESHOLD = 200;
+
+  private static Uri FORM_HISTORY_CONTENT_URI = BrowserContractHelpers.FORM_HISTORY_CONTENT_URI;
+  private static Uri DELETED_FORM_HISTORY_CONTENT_URI = BrowserContractHelpers.DELETED_FORM_HISTORY_CONTENT_URI;
 
   public static class FormHistoryRepository extends Repository {
 
@@ -177,7 +177,7 @@ public class FormHistoryRepositorySession extends
     delegateQueue.execute(command);
   }
 
-  protected FormHistoryRecord retrieveDuringFetch(Cursor cursor) {
+  protected static FormHistoryRecord retrieveDuringFetch(final Cursor cursor) {
     // A simple and efficient way to distinguish two tables.
     if (cursor.getColumnCount() == BrowserContractHelpers.FormHistoryColumns.length) {
       return formHistoryRecordFromCursor(cursor);
@@ -186,7 +186,7 @@ public class FormHistoryRepositorySession extends
     }
   }
 
-  protected FormHistoryRecord formHistoryRecordFromCursor(Cursor cursor) {
+  protected static FormHistoryRecord formHistoryRecordFromCursor(final Cursor cursor) {
     String guid = RepoUtils.getStringFromCursor(cursor, FormHistory.GUID);
     String collection = "forms";
     FormHistoryRecord record = new FormHistoryRecord(guid, collection, 0, false);
@@ -201,7 +201,7 @@ public class FormHistoryRepositorySession extends
     return record;
   }
 
-  protected FormHistoryRecord deletedFormHistoryRecordFromCursor(Cursor cursor) {
+  protected static FormHistoryRecord deletedFormHistoryRecordFromCursor(final Cursor cursor) {
     String guid = RepoUtils.getStringFromCursor(cursor, DeletedFormHistory.GUID);
     String collection = "forms";
     FormHistoryRecord record = new FormHistoryRecord(guid, collection, 0, false);
@@ -215,7 +215,7 @@ public class FormHistoryRepositorySession extends
     return record;
   }
 
-  protected void fetchFromCursor(Cursor cursor, RecordFilter filter, final RepositorySessionFetchRecordsDelegate delegate)
+  protected static void fetchFromCursor(final Cursor cursor, final RecordFilter filter, final RepositorySessionFetchRecordsDelegate delegate)
       throws NullCursorException {
     Logger.debug(LOG_TAG, "Fetch from cursor");
     if (cursor == null) {
@@ -277,12 +277,12 @@ public class FormHistoryRepositorySession extends
     delegateQueue.execute(command);
   }
 
-  protected String regularBetween(long start, long end) {
+  protected static String regularBetween(long start, long end) {
     return FormHistory.FIRST_USED + " >= " + Long.toString(1000 * start) + " AND " +
            FormHistory.FIRST_USED + " <= " + Long.toString(1000 * end); // Microseconds.
   }
 
-  protected String deletedBetween(long start, long end) {
+  protected static String deletedBetween(long start, long end) {
     return DeletedFormHistory.TIME_DELETED + " >= " + Long.toString(start) + " AND " +
            DeletedFormHistory.TIME_DELETED + " <= " + Long.toString(end); // Milliseconds.
   }
@@ -418,8 +418,7 @@ public class FormHistoryRepositorySession extends
    *          The local <code>Record</code> to replace.
    * @throws RemoteException
    */
-  protected void deleteExistingRecord(Record existingRecord)
-      throws RemoteException {
+  protected void deleteExistingRecord(Record existingRecord) throws RemoteException {
     if (existingRecord.deleted) {
       formsProvider.delete(DELETED_FORM_HISTORY_CONTENT_URI, GUID_IS, new String[] { existingRecord.guid });
       return;
@@ -427,7 +426,7 @@ public class FormHistoryRepositorySession extends
     formsProvider.delete(FORM_HISTORY_CONTENT_URI, GUID_IS, new String[] { existingRecord.guid });
   }
 
-  protected ContentValues contentValuesForRegularRecord(Record rawRecord) {
+  protected static ContentValues contentValuesForRegularRecord(Record rawRecord) {
     if (rawRecord.deleted) {
       throw new IllegalArgumentException("Deleted record passed to insertNewRegularRecord.");
     }
@@ -450,7 +449,7 @@ public class FormHistoryRepositorySession extends
         // Insert the existing contents, then enqueue.
         try {
           flushInsertQueue();
-        } catch (RemoteException e) {
+        } catch (Exception e) {
           delegate.onRecordStoreFailed(e);
           return;
         }
@@ -491,7 +490,7 @@ public class FormHistoryRepositorySession extends
             flushInsertQueue();
           }
           storeDone(now());
-        } catch (RemoteException e) {
+        } catch (Exception e) {
           delegate.onRecordStoreFailed(e);
         }
       }

--- a/src/main/java/org/mozilla/gecko/sync/repositories/domain/FormHistoryRecord.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/domain/FormHistoryRecord.java
@@ -22,6 +22,7 @@ public class FormHistoryRecord extends Record {
   public static final String  COLLECTION_NAME = "forms";
   private static final String PAYLOAD_NAME    = "name";
   private static final String PAYLOAD_VALUE   = "value";
+  public static final long FORMS_TTL = 60 * 24 * 60 * 60; // 60 days in seconds.
 
   /**
    * The name of the saved form field.
@@ -35,22 +36,23 @@ public class FormHistoryRecord extends Record {
 
   public FormHistoryRecord(String guid, String collection, long lastModified, boolean deleted) {
     super(guid, collection, lastModified, deleted);
+    this.ttl = FORMS_TTL;
   }
 
   public FormHistoryRecord(String guid, String collection, long lastModified) {
-    super(guid, collection, lastModified, false);
+    this(guid, collection, lastModified, false);
   }
 
   public FormHistoryRecord(String guid, String collection) {
-    super(guid, collection, 0, false);
+    this(guid, collection, 0, false);
   }
 
   public FormHistoryRecord(String guid) {
-    super(guid, COLLECTION_NAME, 0, false);
+    this(guid, COLLECTION_NAME, 0, false);
   }
 
   public FormHistoryRecord() {
-    super(Utils.generateGuid(), COLLECTION_NAME, 0, false);
+    this(Utils.generateGuid(), COLLECTION_NAME, 0, false);
   }
 
   @Override

--- a/src/main/java/org/mozilla/gecko/sync/stage/FormHistoryServerSyncStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/FormHistoryServerSyncStage.java
@@ -64,9 +64,4 @@ public class FormHistoryServerSyncStage extends ServerSyncStage {
   protected RecordFactory getRecordFactory() {
     return new FormHistoryRecordFactory();
   }
-
-  @Override
-  public boolean isEnabled() {
-    return false;
-  }
 }

--- a/src/main/java/org/mozilla/gecko/sync/stage/PasswordsServerSyncStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/PasswordsServerSyncStage.java
@@ -42,4 +42,10 @@ public class PasswordsServerSyncStage extends ServerSyncStage {
     }
   }
 
+  @Override
+  protected boolean isEnabled() {
+    // Disabled until Bug 744816 (Fennec crashes in concurrent access of
+    // password db) is fixed.
+    return false;
+  }
 }

--- a/src/test/java/org/mozilla/gecko/sync/repositories/domain/test/TestFormHistoryRecord.java
+++ b/src/test/java/org/mozilla/gecko/sync/repositories/domain/test/TestFormHistoryRecord.java
@@ -78,4 +78,12 @@ public class TestFormHistoryRecord {
     FormHistoryRecord fr3 = (FormHistoryRecord)fr2.copyWithIDs(Utils.generateGuid(), 9999);
     assertFalse(fr2.equals(fr3));
   }
+
+  @Test
+  public void testTTL() {
+    FormHistoryRecord fr = withIdFieldNameAndValue(0, "username", "aUsername");
+    assertEquals(FormHistoryRecord.FORMS_TTL, fr.ttl);
+    CryptoRecord rec = fr.getEnvelope();
+    assertEquals(FormHistoryRecord.FORMS_TTL, rec.ttl);
+  }
 }


### PR DESCRIPTION
- cleans forms batching to get rid of an unneeded runnable.
- fetches at most 5000 form history items (too high?) and applies in batches of 200.
- INCLUDES COMMIT TO DISABLE PASSWORDS.

This is very snappy on my Transformer Prime now.
