### PR TITLE
Bug 709323 - key changes

### DIFF
--- a/src/main/java/org/mozilla/android/sync/test/helpers/MockGlobalSession.java
+++ b/src/main/java/org/mozilla/android/sync/test/helpers/MockGlobalSession.java
@@ -22,8 +22,8 @@ public class MockGlobalSession extends GlobalSession {
   public MockSharedPreferences prefs;
 
   public MockGlobalSession(String clusterURL, String username, String password,
-				  KeyBundle syncKeyBundle, GlobalSessionCallback callback)
-    throws SyncConfigurationException, IllegalArgumentException, IOException, ParseException, NonObjectJSONException {
+      KeyBundle syncKeyBundle, GlobalSessionCallback callback)
+          throws SyncConfigurationException, IllegalArgumentException, IOException, ParseException, NonObjectJSONException {
     super(SyncConfiguration.DEFAULT_USER_API, clusterURL, username, password, null, syncKeyBundle, callback, /* context */ null, null, null);
   }
 

--- a/src/main/java/org/mozilla/gecko/sync/CollectionKeys.java
+++ b/src/main/java/org/mozilla/gecko/sync/CollectionKeys.java
@@ -7,7 +7,9 @@ package org.mozilla.gecko.sync;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import org.json.simple.JSONArray;
 import org.json.simple.parser.ParseException;
@@ -16,20 +18,8 @@ import org.mozilla.gecko.sync.crypto.CryptoException;
 import org.mozilla.gecko.sync.crypto.KeyBundle;
 
 public class CollectionKeys {
-  private static final String LOG_TAG = "CollectionKeys";
   private KeyBundle                  defaultKeyBundle     = null;
   private HashMap<String, KeyBundle> collectionKeyBundles = new HashMap<String, KeyBundle>();
-
-  public static CryptoRecord generateCollectionKeysRecord() throws CryptoException {
-    CollectionKeys ck = generateCollectionKeys();
-    try {
-      return ck.asCryptoRecord();
-    } catch (NoCollectionKeysSetException e) {
-      // Cannot occur.
-      Logger.error(LOG_TAG, "generateCollectionKeys returned a value with no default key.", e);
-      throw new IllegalStateException("CollectionKeys should not have null default key.");
-    }
-  }
 
   /**
    * Randomly generate a basic CollectionKeys object.
@@ -144,5 +134,36 @@ public class CollectionKeys {
   public void clear() {
     this.defaultKeyBundle = null;
     this.collectionKeyBundles = new HashMap<String, KeyBundle>();
+  }
+
+  /**
+   * Return set of collections where key is either missing from one collection
+   * or not the same in both collections.
+   * <p>
+   * Does not check for different default keys.
+   */
+  public static Set<String> differences(CollectionKeys a, CollectionKeys b) {
+    Set<String> differences = new HashSet<String>();
+
+    // Iterate through one collection, collecting missing and differences.
+    for (String collection : a.collectionKeyBundles.keySet()) {
+      KeyBundle key = b.collectionKeyBundles.get(collection);
+      if (key == null) {
+        differences.add(collection);
+        continue;
+      }
+      if (!key.equals(a.collectionKeyBundles.get(collection))) {
+        differences.add(collection);
+      }
+    }
+
+    // Now iterate through the other collection, collecting just the missing.
+    for (String collection : b.collectionKeyBundles.keySet()) {
+      if (!a.collectionKeyBundles.containsKey(collection)) {
+        differences.add(collection);
+      }
+    }
+
+    return differences;
   }
 }

--- a/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
+++ b/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
@@ -346,6 +346,10 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
     }
   }
 
+  public InfoCollections getInfoCollections() {
+    return this.config.infoCollections;
+  }
+
   public void fetchInfoCollections(InfoCollectionsDelegate callback) throws URISyntaxException {
     if (this.config.infoCollections == null) {
       this.config.infoCollections = new InfoCollections(config.infoURL(), credentials());
@@ -353,6 +357,15 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
     this.config.infoCollections.fetch(callback);
   }
 
+  /**
+   * Upload new crypto/keys.
+   *
+   * @param keysRecord
+   *          new keys record; will be encrypted with
+   *          <code>config.syncKeyBundle</code>.
+   * @param keyUploadDelegate
+   *          a delegate.
+   */
   public void uploadKeys(CryptoRecord keysRecord,
                          final KeyUploadDelegate keyUploadDelegate) {
     SyncStorageRecordRequest request;

--- a/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
+++ b/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
@@ -629,7 +629,7 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
    * Reset our state. Clear our sync ID, reset each engine, drop any
    * cached records.
    */
-  private void resetClient(String[] engines) {
+  public void resetClient(String[] engines) {
     if (engines == null) {
       // Set `engines` to be *all* the engines.
     }

--- a/src/main/java/org/mozilla/gecko/sync/InfoCollections.java
+++ b/src/main/java/org/mozilla/gecko/sync/InfoCollections.java
@@ -25,17 +25,10 @@ public class InfoCollections implements SyncStorageRequestDelegate {
   // Fields.
   // Rather than storing decimal/double timestamps, as provided by the
   // server, we convert immediately to milliseconds since epoch.
-  private HashMap<String, Long> timestamps;
-
-  public HashMap<String, Long> getTimestamps() {
-    if (this.timestamps == null) {
-      throw new IllegalStateException("No record fetched.");
-    }
-    return this.timestamps;
-  }
+  private final HashMap<String, Long> timestamps;
 
   public Long getTimestamp(String collection) {
-    return this.getTimestamps().get(collection);
+    return timestamps.get(collection);
   }
 
   /**
@@ -69,12 +62,13 @@ public class InfoCollections implements SyncStorageRequestDelegate {
   private InfoCollectionsDelegate callback;
 
   public InfoCollections(String metaURL, String credentials) {
+    timestamps = new HashMap<String, Long>();
     this.infoURL     = metaURL;
     this.credentials = credentials;
   }
 
   public void fetch(InfoCollectionsDelegate callback) {
-    if (this.timestamps == null) {
+    if (timestamps.isEmpty()) {
       this.callback = callback;
       this.doFetch();
       return;
@@ -127,7 +121,8 @@ public class InfoCollections implements SyncStorageRequestDelegate {
       }
       Log.w(LOG_TAG, "Skipping info/collections entry for " + key);
     }
-    this.timestamps = map;
+    this.timestamps.clear();
+    this.timestamps.putAll(map);
   }
 
   // SyncStorageRequestDelegate methods for fetching.

--- a/src/main/java/org/mozilla/gecko/sync/crypto/KeyBundle.java
+++ b/src/main/java/org/mozilla/gecko/sync/crypto/KeyBundle.java
@@ -47,6 +47,7 @@ import javax.crypto.Mac;
 import org.mozilla.apache.commons.codec.binary.Base64;
 import org.mozilla.gecko.sync.Utils;
 import java.security.InvalidKeyException;
+import java.util.Arrays;
 import java.util.Locale;
 
 public class KeyBundle {
@@ -177,5 +178,15 @@ public class KeyBundle {
 
     public void setHMACKey(byte[] hmacKey) {
         this.hmacKey = hmacKey;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (!(o instanceof KeyBundle)) {
+        return false;
+      }
+      KeyBundle other = (KeyBundle) o;
+      return Arrays.equals(other.encryptionKey, this.encryptionKey) &&
+             Arrays.equals(other.hmacKey, this.hmacKey);
     }
 }

--- a/src/main/java/org/mozilla/gecko/sync/crypto/PersistedCrypto5Keys.java
+++ b/src/main/java/org/mozilla/gecko/sync/crypto/PersistedCrypto5Keys.java
@@ -78,6 +78,10 @@ public class PersistedCrypto5Keys {
     }
   }
 
+  public boolean persistedKeysExist() {
+    return lastModified() > 0;
+  }
+
   public long lastModified() {
     return prefs.getLong(CRYPTO5_KEYS_LAST_MODIFIED, -1);
   }

--- a/src/main/java/org/mozilla/gecko/sync/delegates/KeyUploadDelegate.java
+++ b/src/main/java/org/mozilla/gecko/sync/delegates/KeyUploadDelegate.java
@@ -1,43 +1,12 @@
-/* ***** BEGIN LICENSE BLOCK *****
- * Version: MPL 1.1/GPL 2.0/LGPL 2.1
- *
- * The contents of this file are subject to the Mozilla Public License Version
- * 1.1 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- * http://www.mozilla.org/MPL/
- *
- * Software distributed under the License is distributed on an "AS IS" basis,
- * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
- * for the specific language governing rights and limitations under the
- * License.
- *
- * The Original Code is Android Sync Client.
- *
- * The Initial Developer of the Original Code is
- * the Mozilla Foundation.
- * Portions created by the Initial Developer are Copyright (C) 2011
- * the Initial Developer. All Rights Reserved.
- *
- * Contributor(s):
- *   Richard Newman <rnewman@mozilla.com>
- *
- * Alternatively, the contents of this file may be used under the terms of
- * either the GNU General Public License Version 2 or later (the "GPL"), or
- * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
- * in which case the provisions of the GPL or the LGPL are applicable instead
- * of those above. If you wish to allow use of your version of this file only
- * under the terms of either the GPL or the LGPL, and not to allow others to
- * use your version of this file under the terms of the MPL, indicate your
- * decision by deleting the provisions above and replace them with the notice
- * and other provisions required by the GPL or the LGPL. If you do not delete
- * the provisions above, a recipient may use your version of this file under
- * the terms of any one of the MPL, the GPL or the LGPL.
- *
- * ***** END LICENSE BLOCK ***** */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.gecko.sync.delegates;
 
+import org.mozilla.gecko.sync.CollectionKeys;
+
 public interface KeyUploadDelegate {
-  void onKeysUploaded();
+  void onKeysUploaded(CollectionKeys keys, long timestamp);
   void onKeyUploadFailed(Exception e);
 }

--- a/src/main/java/org/mozilla/gecko/sync/stage/EnsureCrypto5KeysStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/EnsureCrypto5KeysStage.java
@@ -33,7 +33,7 @@ public class EnsureCrypto5KeysStage implements GlobalSyncStage, SyncStorageReque
   public void execute(GlobalSession session) throws NoSuchStageException {
     this.session = session;
 
-    InfoCollections infoCollections = session.config.infoCollections;
+    InfoCollections infoCollections = session.getInfoCollections();
     if (infoCollections == null) {
       session.abort(null, "No info/collections set in EnsureCrypto5KeysStage.");
       return;

--- a/src/main/java/org/mozilla/gecko/sync/stage/EnsureCrypto5KeysStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/EnsureCrypto5KeysStage.java
@@ -6,6 +6,7 @@ package org.mozilla.gecko.sync.stage;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Set;
 
 import org.json.simple.parser.ParseException;
 import org.mozilla.gecko.sync.CollectionKeys;
@@ -14,8 +15,10 @@ import org.mozilla.gecko.sync.ExtendedJSONObject;
 import org.mozilla.gecko.sync.GlobalSession;
 import org.mozilla.gecko.sync.InfoCollections;
 import org.mozilla.gecko.sync.Logger;
+import org.mozilla.gecko.sync.NoCollectionKeysSetException;
 import org.mozilla.gecko.sync.NonObjectJSONException;
 import org.mozilla.gecko.sync.crypto.CryptoException;
+import org.mozilla.gecko.sync.crypto.KeyBundle;
 import org.mozilla.gecko.sync.crypto.PersistedCrypto5Keys;
 import org.mozilla.gecko.sync.delegates.KeyUploadDelegate;
 import org.mozilla.gecko.sync.net.SyncStorageRecordRequest;
@@ -40,7 +43,7 @@ public class EnsureCrypto5KeysStage implements GlobalSyncStage, SyncStorageReque
 
     PersistedCrypto5Keys pck = session.config.persistedCryptoKeys();
     long lastModified = pck.lastModified();
-    if (!infoCollections.updateNeeded(CRYPTO_COLLECTION, lastModified)) {
+    if (retrying || !infoCollections.updateNeeded(CRYPTO_COLLECTION, lastModified)) {
       // Try to use our local collection keys for this session.
       Logger.info(LOG_TAG, "Trying to use persisted collection keys for this session.");
       CollectionKeys keys = pck.keys();
@@ -103,15 +106,62 @@ public class EnsureCrypto5KeysStage implements GlobalSyncStage, SyncStorageReque
       return;
     }
 
-    // New keys! Persist keys and server timestamp.
-    Logger.info(LOG_TAG, "Setting fetched keys for this session.");
-    session.config.setCollectionKeys(k);
-    Logger.trace(LOG_TAG, "Persisting fetched keys and last modified.");
     PersistedCrypto5Keys pck = session.config.persistedCryptoKeys();
-    pck.persistKeys(k);
-    // Take the timestamp from the response since it is later than the timestamp from info/collections.
-    pck.persistLastModified(response.normalizedWeaveTimestamp());
+    if (!pck.persistedKeysExist()) {
+      // New keys, and no old keys! Persist keys and server timestamp.
+      Logger.info(LOG_TAG, "Setting fetched keys for this session.");
+      session.config.setCollectionKeys(k);
+      Logger.trace(LOG_TAG, "Persisting fetched keys and last modified.");
+      pck.persistKeys(k);
+      // Take the timestamp from the response since it is later than the timestamp from info/collections.
+      pck.persistLastModified(response.normalizedWeaveTimestamp());
+      session.advance();
+      return;
+    }
 
+    // New keys, but we had old keys.  Check for differences.
+    CollectionKeys oldKeys = pck.keys();
+    boolean defaultKeyChanged = false;
+    try {
+      KeyBundle a = oldKeys.defaultKeyBundle();
+      KeyBundle b = k.defaultKeyBundle();
+      defaultKeyChanged = !a.equals(b);
+    } catch (NoCollectionKeysSetException e) {
+      session.abort(e, "NoCollectionKeysSetException in EnsureCrypto5KeysStage");
+      return;
+    }
+
+    if (defaultKeyChanged) {
+      // New keys with a different default/sync key. Reset all the things!
+      Logger.info(LOG_TAG, "Fetched keys default key is not the same as persisted keys default key; " +
+          "persisting fetched keys and last modified before resetting everything.");
+      session.config.setCollectionKeys(k);
+      pck.persistKeys(k);
+      pck.persistLastModified(response.normalizedWeaveTimestamp());
+      session.resetClient(null);
+      session.abort(null, "crypto/keys default key changed on server.");
+      return;
+    }
+
+    Set<String> changedKeys = CollectionKeys.differences(oldKeys, k);
+    if (!changedKeys.isEmpty()) {
+      // New keys, different from old keys.
+      Logger.info(LOG_TAG, "Fetched keys are not the same as persisted keys; " +
+          "setting fetched keys for this session before resetting changed engines.");
+      session.config.setCollectionKeys(k);
+      Logger.trace(LOG_TAG, "Persisting fetched keys and last modified.");
+      pck.persistKeys(k);
+      // Take the timestamp from the response since it is later than the timestamp from info/collections.
+      pck.persistLastModified(response.normalizedWeaveTimestamp());
+      session.resetClient(changedKeys.toArray(new String[changedKeys.size()]));
+      session.abort(null, "crypto/keys changed on server.");
+      return;
+    }
+
+    // New keys don't differ from old keys; persist timestamp and move on.
+    Logger.trace(LOG_TAG, "Fetched keys are the same as persisted keys; persisting last modified.");
+    session.config.setCollectionKeys(oldKeys);
+    pck.persistLastModified(response.normalizedWeaveTimestamp());
     session.advance();
   }
 

--- a/src/main/java/org/mozilla/gecko/sync/stage/EnsureCrypto5KeysStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/EnsureCrypto5KeysStage.java
@@ -5,7 +5,6 @@
 package org.mozilla.gecko.sync.stage;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
 
 import org.json.simple.parser.ParseException;
@@ -119,6 +118,9 @@ public class EnsureCrypto5KeysStage implements GlobalSyncStage, SyncStorageReque
   @Override
   public void handleRequestFailure(SyncStorageResponse response) {
     if (retrying) {
+      // Should never happen -- this means we uploaded our crypto/keys
+      // successfully, but somehow didn't have them persisted correctly and
+      // tried to re-download (unsuccessfully).
       session.handleHTTPError(response, "Failure in refetching uploaded keys.");
       return;
     }
@@ -127,25 +129,14 @@ public class EnsureCrypto5KeysStage implements GlobalSyncStage, SyncStorageReque
     Logger.debug(LOG_TAG, "Got " + statusCode + " fetching keys.");
     if (statusCode == 404) {
       // No keys. Generate and upload, then refetch.
-      CryptoRecord keysWBO;
+      CollectionKeys keys;
       try {
-        keysWBO = CollectionKeys.generateCollectionKeysRecord();
+        keys = CollectionKeys.generateCollectionKeys();
       } catch (CryptoException e) {
         session.abort(e, "Couldn't generate new key bundle.");
         return;
       }
-      keysWBO.keyBundle = session.config.syncKeyBundle;
-      try {
-        keysWBO.encrypt();
-      } catch (UnsupportedEncodingException e) {
-        // Shouldn't occur, so let's not waste too much time on niceties. TODO
-        session.abort(e, "Couldn't encrypt new key bundle: unsupported encoding.");
-        return;
-      } catch (CryptoException e) {
-        session.abort(e, "Couldn't encrypt new key bundle.");
-        return;
-      }
-      session.uploadKeys(keysWBO, this);
+      session.uploadKeys(keys, this);
       return;
     }
     session.handleHTTPError(response, "Failure fetching keys.");
@@ -157,10 +148,13 @@ public class EnsureCrypto5KeysStage implements GlobalSyncStage, SyncStorageReque
   }
 
   @Override
-  public void onKeysUploaded() {
-    Logger.debug(LOG_TAG, "New keys uploaded. Starting stage again to fetch them.");
+  public void onKeysUploaded(CollectionKeys keys, long timestamp) {
+    Logger.debug(LOG_TAG, "New keys uploaded. Persisting before starting stage again.");
     try {
       retrying = true;
+      PersistedCrypto5Keys pck = session.config.persistedCryptoKeys();
+      pck.persistKeys(keys);
+      pck.persistLastModified(timestamp);
       this.execute(this.session);
     } catch (NoSuchStageException e) {
       session.abort(e, "No such stage.");

--- a/src/main/java/org/mozilla/gecko/sync/stage/FetchMetaGlobalStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/FetchMetaGlobalStage.java
@@ -52,7 +52,7 @@ public class FetchMetaGlobalStage implements GlobalSyncStage {
 
   @Override
   public void execute(GlobalSession session) throws NoSuchStageException {
-    InfoCollections infoCollections = session.config.infoCollections;
+    InfoCollections infoCollections = session.getInfoCollections();
     if (infoCollections == null) {
       session.abort(null, "No info/collections set in FetchMetaGlobalStage.");
       return;

--- a/src/test/java/org/mozilla/android/sync/test/TestCollectionKeys.java
+++ b/src/test/java/org/mozilla/android/sync/test/TestCollectionKeys.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Set;
 
 import org.json.simple.JSONArray;
 import org.json.simple.parser.ParseException;
@@ -115,5 +116,34 @@ public class TestCollectionKeys {
     // Compare decrypted keys to the keys that were set upon creation
     assertArrayEquals(ck.defaultKeyBundle().getEncryptionKey(), ckDecrypted.defaultKeyBundle().getEncryptionKey());
     assertArrayEquals(ck.defaultKeyBundle().getHMACKey(), ckDecrypted.defaultKeyBundle().getHMACKey());
+  }
+
+  @Test
+  public void testDifferences() throws CryptoException {
+    KeyBundle kb1 = KeyBundle.withRandomKeys();
+    KeyBundle kb2 = KeyBundle.withRandomKeys();
+    KeyBundle kb3 = KeyBundle.withRandomKeys();
+    CollectionKeys a = CollectionKeys.generateCollectionKeys();
+    CollectionKeys b = CollectionKeys.generateCollectionKeys();
+    Set<String> diffs;
+
+    a.setKeyBundleForCollection("1", kb1);
+    b.setKeyBundleForCollection("1", kb1);
+    diffs = CollectionKeys.differences(a, b);
+    assertTrue(diffs.isEmpty());
+
+    a.setKeyBundleForCollection("2", kb2);
+    diffs = CollectionKeys.differences(a, b);
+    assertArrayEquals(new String[] { "2" }, diffs.toArray(new String[diffs.size()]));
+
+    b.setKeyBundleForCollection("3", kb3);
+    diffs = CollectionKeys.differences(a, b);
+    assertEquals(2, diffs.size());
+    assertTrue(diffs.contains("2"));
+    assertTrue(diffs.contains("3"));
+
+    b.setKeyBundleForCollection("1", KeyBundle.withRandomKeys());
+    diffs = CollectionKeys.differences(a, b);
+    assertEquals(3, diffs.size());
   }
 }

--- a/src/test/java/org/mozilla/android/sync/test/integration/TestBasicFetch.java
+++ b/src/test/java/org/mozilla/android/sync/test/integration/TestBasicFetch.java
@@ -48,7 +48,7 @@ public class TestBasicFetch {
 
       if (shouldDecrypt) {
         try {
-          System.out.println("Attempting decrypt.");
+          System.out.println("Attempting to decrypt.");
           CryptoRecord rec;
           rec = CryptoRecord.fromJSONRecord(body);
           rec.keyBundle = new KeyBundle(USERNAME, SYNC_KEY);

--- a/src/test/java/org/mozilla/gecko/sync/crypto/test/TestKeyBundle.java
+++ b/src/test/java/org/mozilla/gecko/sync/crypto/test/TestKeyBundle.java
@@ -5,6 +5,8 @@ package org.mozilla.gecko.sync.crypto.test;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.UnsupportedEncodingException;
 import java.security.NoSuchAlgorithmException;
@@ -54,5 +56,19 @@ public class TestKeyBundle {
 
     boolean equal = Arrays.equals(keys.getEncryptionKey(), keys.getHMACKey());
     assertEquals(false, equal);
+  }
+
+  @Test
+  public void testEquals() throws CryptoException {
+    KeyBundle k = KeyBundle.withRandomKeys();
+    KeyBundle o = KeyBundle.withRandomKeys();
+    assertFalse(k.equals("test"));
+    assertFalse(k.equals(o));
+    assertTrue(k.equals(k));
+    assertTrue(o.equals(o));
+    o.setHMACKey(k.getHMACKey());
+    assertFalse(o.equals(k));
+    o.setEncryptionKey(k.getEncryptionKey());
+    assertTrue(o.equals(k));
   }
 }

--- a/src/test/java/org/mozilla/gecko/sync/stage/test/TestEnsureCrypto5KeysStage.java
+++ b/src/test/java/org/mozilla/gecko/sync/stage/test/TestEnsureCrypto5KeysStage.java
@@ -1,0 +1,297 @@
+package org.mozilla.gecko.sync.stage.test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertArrayEquals;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.json.simple.parser.ParseException;
+import org.junit.Before;
+import org.junit.Test;
+import org.mozilla.android.sync.test.helpers.HTTPServerTestHelper;
+import org.mozilla.android.sync.test.helpers.MockGlobalSession;
+import org.mozilla.android.sync.test.helpers.MockGlobalSessionCallback;
+import org.mozilla.android.sync.test.helpers.MockServer;
+import org.mozilla.android.sync.test.helpers.WaitHelper;
+import org.mozilla.gecko.sync.AlreadySyncingException;
+import org.mozilla.gecko.sync.CollectionKeys;
+import org.mozilla.gecko.sync.CryptoRecord;
+import org.mozilla.gecko.sync.ExtendedJSONObject;
+import org.mozilla.gecko.sync.GlobalSession;
+import org.mozilla.gecko.sync.HTTPFailureException;
+import org.mozilla.gecko.sync.InfoCollections;
+import org.mozilla.gecko.sync.NoCollectionKeysSetException;
+import org.mozilla.gecko.sync.NonObjectJSONException;
+import org.mozilla.gecko.sync.SyncConfigurationException;
+import org.mozilla.gecko.sync.crypto.CryptoException;
+import org.mozilla.gecko.sync.crypto.KeyBundle;
+import org.mozilla.gecko.sync.stage.EnsureCrypto5KeysStage;
+import org.simpleframework.http.Request;
+import org.simpleframework.http.Response;
+
+public class TestEnsureCrypto5KeysStage extends EnsureCrypto5KeysStage {
+  private int          TEST_PORT                = 15325;
+  private final String TEST_CLUSTER_URL         = "http://localhost:" + TEST_PORT;
+  private final String TEST_USERNAME            = "johndoe";
+  private final String TEST_PASSWORD            = "password";
+  private final String TEST_SYNC_KEY            = "abcdeabcdeabcdeabcdeabcdea";
+
+  private final String TEST_JSON_NO_CRYPTO =
+      "{\"history\":1.3319567131E9}";
+  private final String TEST_JSON_OLD_CRYPTO =
+      "{\"history\":1.3319567131E9,\"crypto\":1.1E9}";
+  private final String TEST_JSON_NEW_CRYPTO =
+      "{\"history\":1.3319567131E9,\"crypto\":3.1E9}";
+
+  private HTTPServerTestHelper data = new HTTPServerTestHelper(TEST_PORT);
+
+  private InfoCollections infoCollections;
+  private KeyBundle syncKeyBundle;
+  private MockGlobalSessionCallback callback;
+  private GlobalSession session;
+
+  private boolean calledClientReset;
+  private String[] enginesReset;
+
+  @Before
+  public void setUp()
+      throws IllegalStateException, NonObjectJSONException, IOException,
+      ParseException, CryptoException, SyncConfigurationException, IllegalArgumentException, URISyntaxException {
+
+    // Set info collections to not have crypto.
+    infoCollections = new InfoCollections(null, null);
+    infoCollections.setFromRecord(ExtendedJSONObject.parseJSONObject(TEST_JSON_NO_CRYPTO));
+
+    syncKeyBundle = new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY);
+    callback = new MockGlobalSessionCallback();
+    session = new MockGlobalSession(TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD,
+      syncKeyBundle, callback) {
+      @Override
+      protected void prepareStages() {
+        super.prepareStages();
+        stages.put(Stage.ensureKeysStage, new EnsureCrypto5KeysStage());
+      }
+
+      @Override
+      public InfoCollections getInfoCollections() {
+        return infoCollections;
+      }
+
+      @Override
+      public void resetClient(String[] engines) {
+        calledClientReset = true;
+        enginesReset = engines;
+      }
+    };
+    session.config.setClusterURL(new URI(TEST_CLUSTER_URL));
+    calledClientReset = false;
+    enginesReset = null;
+  }
+
+  public void doSession(MockServer server) {
+    data.startHTTPServer(server);
+    WaitHelper.getTestWaiter().performWait(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          session.start();
+        } catch (AlreadySyncingException e) {
+          WaitHelper.getTestWaiter().performNotify(e);
+        }
+      }
+    });
+    data.stopHTTPServer();
+  }
+
+  @Test
+  public void testUploadKeysFails() throws SyncConfigurationException, IllegalArgumentException, NonObjectJSONException, IOException, ParseException, CryptoException, URISyntaxException {
+    MockServer server = new MockServer() {
+      public void handle(Request request, Response response) {
+        if (request.getMethod().equals("PUT")) {
+          this.handle(request, response, 400, "denied");
+          return;
+        }
+        this.handle(request, response, 404, "not found");
+      }
+    };
+    doSession(server);
+
+    assertTrue(callback.calledError);
+    assertTrue(callback.calledErrorException instanceof HTTPFailureException);
+  }
+
+  @Test
+  public void testUploadKeysSucceeds() throws SyncConfigurationException, IllegalArgumentException, NonObjectJSONException, IOException, ParseException, CryptoException, URISyntaxException {
+    assertNull(session.config.collectionKeys);
+
+    final AtomicBoolean keysUploaded = new AtomicBoolean(false);
+    final CollectionKeys uploadedKeys = new CollectionKeys();
+
+    MockServer server = new MockServer() {
+      public void handle(Request request, Response response) {
+        if (request.getMethod().equals("PUT")) {
+          try {
+            ExtendedJSONObject body = ExtendedJSONObject.parseJSONObject(request.getContent());
+            System.out.println(body.toJSONString());
+            assertTrue(body.containsKey("payload"));
+            assertFalse(body.containsKey("default"));
+
+            CryptoRecord rec = CryptoRecord.fromJSONRecord(body);
+            uploadedKeys.setKeyPairsFromWBO(rec, syncKeyBundle); // Decrypt.
+            keysUploaded.set(true);
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+          this.handle(request, response, 200, "success");
+          return;
+        }
+        if (keysUploaded.get()) {
+          try {
+            CryptoRecord rec = uploadedKeys.asCryptoRecord();
+            rec.keyBundle = syncKeyBundle;
+            rec.encrypt();
+            this.handle(request, response, 200, rec.toJSONString());
+            return;
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
+        }
+        this.handle(request, response, 404, "not found");
+      }
+    };
+
+    doSession(server);
+
+    assertTrue(callback.calledSuccess);
+    assertTrue(keysUploaded.get());
+    assertNotNull(session.config.collectionKeys);
+    assertTrue(CollectionKeys.differences(session.config.collectionKeys, uploadedKeys).isEmpty());
+  }
+
+  @Test
+  public void testDownloadUsesPersisted() throws SyncConfigurationException, IllegalArgumentException, NonObjectJSONException, IOException, ParseException, CryptoException, URISyntaxException {
+    infoCollections.setFromRecord(ExtendedJSONObject.parseJSONObject(TEST_JSON_OLD_CRYPTO));
+    session.config.persistedCryptoKeys().persistLastModified(System.currentTimeMillis());
+
+    assertNull(session.config.collectionKeys);
+    final CollectionKeys keys = CollectionKeys.generateCollectionKeys();
+    keys.setDefaultKeyBundle(syncKeyBundle);
+    session.config.persistedCryptoKeys().persistKeys(keys);
+
+    MockServer server = new MockServer() {
+      public void handle(Request request, Response response) {
+        this.handle(request, response, 404, "should not be called!");
+      }
+    };
+
+    doSession(server);
+
+    assertTrue(callback.calledSuccess);
+    assertNotNull(session.config.collectionKeys);
+    assertTrue(CollectionKeys.differences(session.config.collectionKeys, keys).isEmpty());
+  }
+
+  @Test
+  public void testDownloadFetchesNew()
+      throws SyncConfigurationException, IllegalArgumentException, NonObjectJSONException,
+      IOException, ParseException, CryptoException, URISyntaxException, NoCollectionKeysSetException {
+    infoCollections.setFromRecord(ExtendedJSONObject.parseJSONObject(TEST_JSON_NEW_CRYPTO));
+    session.config.persistedCryptoKeys().persistLastModified(System.currentTimeMillis());
+
+    assertNull(session.config.collectionKeys);
+    final CollectionKeys keys = CollectionKeys.generateCollectionKeys();
+    keys.setDefaultKeyBundle(syncKeyBundle);
+    session.config.persistedCryptoKeys().persistKeys(keys);
+
+    MockServer server = new MockServer() {
+      public void handle(Request request, Response response) {
+        try {
+          CryptoRecord rec = keys.asCryptoRecord();
+          rec.keyBundle = syncKeyBundle;
+          rec.encrypt();
+          this.handle(request, response, 200, rec.toJSONString());
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      }
+    };
+
+    doSession(server);
+
+    assertTrue(callback.calledSuccess);
+    assertNotNull(session.config.collectionKeys);
+    assertTrue(session.config.collectionKeys.defaultKeyBundle().equals(keys.defaultKeyBundle()));
+    assertTrue(CollectionKeys.differences(session.config.collectionKeys, keys).isEmpty());
+  }
+
+  @Test
+  public void testDownloadResetsAllOnDifferentDefaultKey()
+      throws SyncConfigurationException, IllegalArgumentException, NonObjectJSONException,
+      IOException, ParseException, CryptoException, URISyntaxException, NoCollectionKeysSetException {
+    infoCollections.setFromRecord(ExtendedJSONObject.parseJSONObject(TEST_JSON_NEW_CRYPTO));
+    session.config.persistedCryptoKeys().persistLastModified(System.currentTimeMillis());
+
+    assertNull(session.config.collectionKeys);
+    final CollectionKeys keys = CollectionKeys.generateCollectionKeys();
+    session.config.persistedCryptoKeys().persistKeys(keys);
+    keys.setDefaultKeyBundle(syncKeyBundle); // Change the default key bundle.
+
+    MockServer server = new MockServer() {
+      public void handle(Request request, Response response) {
+        try {
+          CryptoRecord rec = keys.asCryptoRecord();
+          rec.keyBundle = syncKeyBundle;
+          rec.encrypt();
+          this.handle(request, response, 200, rec.toJSONString());
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      }
+    };
+
+    doSession(server);
+
+    assertTrue(calledClientReset);
+    assertNull(enginesReset);
+    assertTrue(callback.calledError);
+  }
+
+  @Test
+  public void testDownloadResetsEngineOnDifferentKey()
+      throws SyncConfigurationException, IllegalArgumentException, NonObjectJSONException,
+      IOException, ParseException, CryptoException, URISyntaxException, NoCollectionKeysSetException {
+    infoCollections.setFromRecord(ExtendedJSONObject.parseJSONObject(TEST_JSON_NEW_CRYPTO));
+    session.config.persistedCryptoKeys().persistLastModified(System.currentTimeMillis());
+
+    assertNull(session.config.collectionKeys);
+    final CollectionKeys keys = CollectionKeys.generateCollectionKeys();
+    session.config.persistedCryptoKeys().persistKeys(keys);
+    keys.setKeyBundleForCollection("history", syncKeyBundle); // Change one key bundle.
+
+    MockServer server = new MockServer() {
+      public void handle(Request request, Response response) {
+        try {
+          CryptoRecord rec = keys.asCryptoRecord();
+          rec.keyBundle = syncKeyBundle;
+          rec.encrypt();
+          this.handle(request, response, 200, rec.toJSONString());
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      }
+    };
+
+    doSession(server);
+
+    assertTrue(calledClientReset);
+    assertNotNull(enginesReset);
+    assertArrayEquals(new String[] { "history" }, enginesReset);
+    assertTrue(callback.calledError);
+  }
+}

--- a/src/test/java/org/mozilla/gecko/sync/test/TestInfoCollections.java
+++ b/src/test/java/org/mozilla/gecko/sync/test/TestInfoCollections.java
@@ -5,7 +5,6 @@ package org.mozilla.gecko.sync.test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -32,7 +31,6 @@ public class TestInfoCollections {
     ExtendedJSONObject record = ExtendedJSONObject.parseJSONObject(TEST_JSON);
     infoCollections.setFromRecord(record);
 
-    assertNotNull(infoCollections.getTimestamps());
     assertEquals(Utils.decimalSecondsToMilliseconds(1.3319567131E9), infoCollections.getTimestamp("history").longValue());
     assertEquals(Utils.decimalSecondsToMilliseconds(1.321E9), infoCollections.getTimestamp("meta").longValue());
     assertEquals(Utils.decimalSecondsToMilliseconds(1.35E9), infoCollections.getTimestamp("tabs").longValue());


### PR DESCRIPTION
Calls resetClient() with appropriate engines on key changes.

_Warning:_ this has not had any device testing; would love direction on how much effort to put into unit/integration testing this.  I can definitely factor this into a more testable form, but we won't end up testing much actual code after all the stubbing is done.
