### PR TITLE
Bug 738676 - Pairing multiple devices.

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSyncActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSyncActivity.java
@@ -157,7 +157,9 @@ public class SetupSyncActivity extends AccountAuthenticatorActivity {
 
   @Override
   public void onNewIntent(Intent intent) {
+    Logger.debug(LOG_TAG, "Started SetupSyncActivity with new intent.");
     setIntent(intent);
+    onResume();
   }
 
   /* Click Handlers */


### PR DESCRIPTION
When existing Setup activity was already on stack, sending an Intent to start Setup would set the intent, but not start the activity. Doh.

This should fix the pairing bug, and quick testing on my device seems to work. Behaviour possibly differs based on device (for QA).
