### PR TITLE
Bug 713542 - batch bookmark inserts and Bug 743153 - Use ContentUris.parseId instead of RepoUtils.getAndroidIdFromUri.

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/Utils.java
+++ b/src/main/java/org/mozilla/gecko/sync/Utils.java
@@ -1,40 +1,6 @@
-/* ***** BEGIN LICENSE BLOCK *****
- * Version: MPL 1.1/GPL 2.0/LGPL 2.1
- *
- * The contents of this file are subject to the Mozilla Public License Version
- * 1.1 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- * http://www.mozilla.org/MPL/
- *
- * Software distributed under the License is distributed on an "AS IS" basis,
- * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
- * for the specific language governing rights and limitations under the
- * License.
- *
- * The Original Code is Android Sync Client.
- *
- * The Initial Developer of the Original Code is
- * the Mozilla Foundation.
- * Portions created by the Initial Developer are Copyright (C) 2011
- * the Initial Developer. All Rights Reserved.
- *
- * Contributor(s):
- * Jason Voll <jvoll@mozilla.com>
- * Richard Newman <rnewman@mozilla.com>
- *
- * Alternatively, the contents of this file may be used under the terms of
- * either the GNU General Public License Version 2 or later (the "GPL"), or
- * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
- * in which case the provisions of the GPL or the LGPL are applicable instead
- * of those above. If you wish to allow use of your version of this file only
- * under the terms of either the GPL or the LGPL, and not to allow others to
- * use your version of this file under the terms of the MPL, indicate your
- * decision by deleting the provisions above and replace them with the notice
- * and other provisions required by the GPL or the LGPL. If you do not delete
- * the provisions above, a recipient may use your version of this file under
- * the terms of any one of the MPL, the GPL or the LGPL.
- *
- * ***** END LICENSE BLOCK ***** */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.gecko.sync;
 
@@ -308,5 +274,19 @@ public class Utils {
       }
     }
     return out;
+  }
+
+  // Because TextUtils.join is not stubbed.
+  public static String join(String delimiter, String... strings) {
+    StringBuilder sb = new StringBuilder();
+    int i = 0;
+    for (String string : strings) {
+      sb.append(string);
+      i += 1;
+      if (i < strings.length) {
+        sb.append(delimiter);
+      }
+    }
+    return sb.toString();
   }
 }

--- a/src/main/java/org/mozilla/gecko/sync/Utils.java
+++ b/src/main/java/org/mozilla/gecko/sync/Utils.java
@@ -12,6 +12,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -277,16 +278,24 @@ public class Utils {
   }
 
   // Because TextUtils.join is not stubbed.
-  public static String join(String delimiter, String... strings) {
+  public static String toDelimitedString(String delimiter, Collection<String> items) {
+    if (items == null || items.size() == 0) {
+      return "";
+    }
+
     StringBuilder sb = new StringBuilder();
     int i = 0;
-    for (String string : strings) {
+    int c = items.size();
+    for (String string : items) {
       sb.append(string);
-      i += 1;
-      if (i < strings.length) {
+      if (++i < c) {
         sb.append(delimiter);
       }
     }
     return sb.toString();
+  }
+
+  public static String toCommaSeparatedString(Collection<String> items) {
+    return toDelimitedString(", ", items);
   }
 }

--- a/src/main/java/org/mozilla/gecko/sync/repositories/Server11RepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/Server11RepositorySession.java
@@ -223,6 +223,8 @@ public class Server11RepositorySession extends RepositorySession {
   }
 
   private String flattenIDs(String[] guids) {
+    // Consider using Utils.toDelimitedString if and when the signature changes
+    // to Collection<String> guids.
     if (guids.length == 0) {
       return "";
     }

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksDataAccessor.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksDataAccessor.java
@@ -16,6 +16,7 @@ import org.mozilla.gecko.sync.repositories.NullCursorException;
 import org.mozilla.gecko.sync.repositories.domain.BookmarkRecord;
 import org.mozilla.gecko.sync.repositories.domain.Record;
 
+import android.content.ContentUris;
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
@@ -249,7 +250,7 @@ public class AndroidBrowserBookmarksDataAccessor extends AndroidBrowserRepositor
     record.title = AndroidBrowserBookmarksRepositorySession.SPECIAL_GUIDS_MAP.get(guid);
     record.type = "folder";
     record.androidParentID = parentId;
-    return(RepoUtils.getAndroidIdFromUri(insert(record)));
+    return ContentUris.parseId(insert(record));
   }
 
   @Override

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
@@ -820,9 +820,10 @@ public class AndroidBrowserBookmarksRepositorySession extends AndroidBrowserRepo
         Logger.warn(LOG_TAG, "Enqueued but didn't insert the following guids: " +
             "(" + Utils.toCommaSeparatedString(eSet) + ")");
       }
+
       iSet.removeAll(new HashSet<String>(enqueuedGuids));
       if (iSet.isEmpty()) {
-        Logger.debug(LOG_TAG, "All inserted guids were enqueued.");
+        // Should always be the case.
       } else {
         Logger.warn(LOG_TAG, "Inserted but didn't enqueue the following guids: " +
             "(" + Utils.toCommaSeparatedString(iSet) + ")");

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
@@ -607,8 +607,7 @@ public class AndroidBrowserBookmarksRepositorySession extends AndroidBrowserRepo
     // TODO: persist records that fail to insert for later retry.
     ArrayList<Record> toStores = new ArrayList<Record>(records.size());
     for (Record record : records) {
-      Record toStore = (BookmarkRecord) prepareRecord(record);
-      toStores.add(toStore);
+      toStores.add(prepareRecord(record));
     }
 
     try {

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
@@ -574,15 +574,15 @@ public class AndroidBrowserBookmarksRepositorySession extends AndroidBrowserRepo
     // A folder that is *not* deleted needs its androidID updated, so that
     // updateBookkeeping can re-parent, etc.
     Record toStore = prepareRecord(record);
-    Uri recordURI = dbHelper.insert(toStore);
-    if (recordURI == null) {
-      delegate.onRecordStoreFailed(new RuntimeException("Got null URI inserting folder with guid " + toStore.guid + "."));
-      return false;
-    }
-    toStore.androidID = ContentUris.parseId(recordURI);
-    Logger.debug(LOG_TAG, "Inserted folder with guid " + toStore.guid + " as androidID " + toStore.androidID);
-
     try {
+      Uri recordURI = dbHelper.insert(toStore);
+      if (recordURI == null) {
+        delegate.onRecordStoreFailed(new RuntimeException("Got null URI inserting folder with guid " + toStore.guid + "."));
+        return false;
+      }
+      toStore.androidID = ContentUris.parseId(recordURI);
+      Logger.debug(LOG_TAG, "Inserted folder with guid " + toStore.guid + " as androidID " + toStore.androidID);
+
       updateBookkeeping(toStore);
     } catch (Exception e) {
       delegate.onRecordStoreFailed(e);

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
@@ -926,8 +926,7 @@ public class AndroidBrowserBookmarksRepositorySession extends AndroidBrowserRepo
       try {
         // Clear our queued deletions.
         deletionManager.clear();
-        // Clearing the insertion manager is not supported yet. To clear, you need
-        // to reset the set of written folder GUIDs, which will need to be re-computed.
+        insertionManager.clear();
         super.run();
       } catch (Exception ex) {
         delegate.onWipeFailed(ex);

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
@@ -808,15 +808,15 @@ public class AndroidBrowserBookmarksRepositorySession extends AndroidBrowserRepo
       if (eSet.isEmpty()) {
         Logger.debug(LOG_TAG, "All enqueued guids were inserted.");
       } else {
-        Logger.warn(LOG_TAG, "Enqueued but didn't insert the following guids: (" +
-            Utils.join(", ", eSet.toArray(new String[eSet.size()])) + ")");
+        Logger.warn(LOG_TAG, "Enqueued but didn't insert the following guids: " +
+            "(" + Utils.toCommaSeparatedString(eSet) + ")");
       }
       iSet.removeAll(new HashSet<String>(enqueuedGuids));
       if (iSet.isEmpty()) {
         Logger.debug(LOG_TAG, "All inserted guids were enqueued.");
       } else {
-        Logger.warn(LOG_TAG, "Inserted but didn't enqueue the following guids: (" +
-            Utils.join(", ", iSet.toArray(new String[eSet.size()])) + ")");
+        Logger.warn(LOG_TAG, "Inserted but didn't enqueue the following guids: " +
+            "(" + Utils.toCommaSeparatedString(iSet) + ")");
       }
     } else {
       Logger.debug(LOG_TAG, "Enqueued and inserted " + enqueuedGuids.size() + " records.");

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
@@ -743,6 +743,9 @@ public class AndroidBrowserBookmarksRepositorySession extends AndroidBrowserRepo
       // updateBookkeeping can re-parent, etc.
       Record toStore = prepareRecord(record);
       Uri recordURI = dbHelper.insert(toStore);
+      if (recordURI == null) {
+        throw new NullCursorException(new RuntimeException("Got null URI inserting folder with guid " + toStore.guid + "."));
+      }
       toStore.androidID = ContentUris.parseId(recordURI);
       Logger.debug(LOG_TAG, "Inserted folder with guid " + toStore.guid + " as androidID " + toStore.androidID);
 

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserBookmarksRepositorySession.java
@@ -511,7 +511,7 @@ public class AndroidBrowserBookmarksRepositorySession extends AndroidBrowserRepo
     Logger.debug(LOG_TAG, "Ignoring record with guid: " + bmk.guid + " and type: " + bmk.type);
     return true;
   }
-  
+
   @Override
   public void begin(RepositorySessionBeginDelegate delegate) throws InvalidSessionTransitionException {
     // Check for the existence of special folders
@@ -533,7 +533,7 @@ public class AndroidBrowserBookmarksRepositorySession extends AndroidBrowserRepo
       delegate.onBeginFailed(e);
       return;
     }
-    
+
     // To deal with parent mapping of bookmarks we have to do some
     // hairy stuff. Here's the setup for it.
 
@@ -557,8 +557,14 @@ public class AndroidBrowserBookmarksRepositorySession extends AndroidBrowserRepo
       cur.close();
     }
     deletionManager = new BookmarksDeletionManager(dataAccessor, DEFAULT_DELETION_FLUSH_THRESHOLD);
+
+    // We just crawled the database enumerating all folders; we'll start the
+    // insertion manager with exactly these folders as the known parents. From
+    // here on, there is no reference to <code>parentGuidToIDMap</code> in the
+    // insertion manager.
+    Set<String> guidsKnownBeforeInsertions = new HashSet<String>(parentGuidToIDMap.keySet());
     insertionManager = new AndroidBrowserBookmarksInsertionManager(DEFAULT_INSERTION_FLUSH_THRESHOLD,
-        parentGuidToIDMap.keySet());
+        guidsKnownBeforeInsertions);
 
     Logger.debug(LOG_TAG, "Done with initial setup of bookmarks session.");
     super.begin(delegate);

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserHistoryRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserHistoryRepositorySession.java
@@ -151,8 +151,7 @@ public class AndroidBrowserHistoryRepositorySession extends AndroidBrowserReposi
    */
   @Override
   protected void insert(Record record) throws NoGuidForIdException, NullCursorException, ParentNotFoundException {
-    HistoryRecord toStore = (HistoryRecord) prepareRecord(record);
-    enqueueNewRecord(toStore);
+    enqueueNewRecord((HistoryRecord) prepareRecord(record));
   }
 
   /**

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserHistoryRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserHistoryRepositorySession.java
@@ -148,17 +148,16 @@ public class AndroidBrowserHistoryRepositorySession extends AndroidBrowserReposi
    *
    * @param record
    *          A <code>Record</code> with a GUID that is not present locally.
-   * @return The <code>Record</code> to be inserted. <b>Warning:</b> the
-   *         <code>androidID</code> is not valid! It will be set after the
-   *         records are flushed to the database.
    */
   @Override
-  protected Record insert(Record record) throws NoGuidForIdException, NullCursorException, ParentNotFoundException {
+  protected void insert(Record record) throws NoGuidForIdException, NullCursorException, ParentNotFoundException {
     HistoryRecord toStore = (HistoryRecord) prepareRecord(record);
     toStore.androidID = -111; // Hopefully this special value will make it easy to catch future errors.
     updateBookkeeping(toStore); // Does not use androidID -- just GUID -> String map.
+    trackRecord(toStore);
+    delegate.onRecordStoreSucceeded(toStore); // Technically this is too early.
+
     enqueueNewRecord(toStore);
-    return toStore;
   }
 
   /**

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserRepositoryDataAccessor.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserRepositoryDataAccessor.java
@@ -187,10 +187,12 @@ public abstract class AndroidBrowserRepositoryDataAccessor {
    * but does <b>not</b> update the <code>androidID</code> of each record.
    *
    * @param records
-   *          The records to insert.
+   *          the records to insert.
+   * @return
+   *          the number of records actually inserted.
    * @throws NullCursorException
    */
-  public void bulkInsert(List<Record> records) throws NullCursorException {
+  public int bulkInsert(List<Record> records) throws NullCursorException {
     if (records.isEmpty()) {
       Logger.debug(LOG_TAG, "No records to insert, returning.");
     }
@@ -203,7 +205,6 @@ public abstract class AndroidBrowserRepositoryDataAccessor {
       index += 1;
     }
 
-    // First update the history records.
     int inserted = context.getContentResolver().bulkInsert(getUri(), cvs);
     if (inserted == size) {
       Logger.debug(LOG_TAG, "Inserted " + inserted + " records, as expected.");
@@ -212,5 +213,6 @@ public abstract class AndroidBrowserRepositoryDataAccessor {
                    inserted + " records but expected " +
                    size     + " records.");
     }
+    return inserted;
   }
 }

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserRepositoryDataAccessor.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserRepositoryDataAccessor.java
@@ -4,6 +4,8 @@
 
 package org.mozilla.gecko.sync.repositories.android;
 
+import java.util.List;
+
 import org.mozilla.gecko.db.BrowserContract;
 import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.repositories.NullCursorException;
@@ -176,5 +178,39 @@ public abstract class AndroidBrowserRepositoryDataAccessor {
       return;
     }
     Logger.warn(LOG_TAG, "Unexpectedly updated " + updated + " rows for guid " + guid);
+  }
+
+  /**
+   * Insert records.
+   * <p>
+   * This inserts all the records (using <code>ContentProvider.bulkInsert</code>),
+   * but does <b>not</b> update the <code>androidID</code> of each record.
+   *
+   * @param records
+   *          The records to insert.
+   * @throws NullCursorException
+   */
+  public void bulkInsert(List<Record> records) throws NullCursorException {
+    if (records.isEmpty()) {
+      Logger.debug(LOG_TAG, "No records to insert, returning.");
+    }
+
+    int size = records.size();
+    ContentValues[] cvs = new ContentValues[size];
+    int index = 0;
+    for (Record record : records) {
+      cvs[index] = getContentValues(record);
+      index += 1;
+    }
+
+    // First update the history records.
+    int inserted = context.getContentResolver().bulkInsert(getUri(), cvs);
+    if (inserted == size) {
+      Logger.debug(LOG_TAG, "Inserted " + inserted + " records, as expected.");
+    } else {
+      Logger.debug(LOG_TAG, "Inserted " +
+                   inserted + " records but expected " +
+                   size     + " records.");
+    }
   }
 }

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserRepositorySession.java
@@ -26,6 +26,7 @@ import org.mozilla.gecko.sync.repositories.delegates.RepositorySessionGuidsSince
 import org.mozilla.gecko.sync.repositories.delegates.RepositorySessionWipeDelegate;
 import org.mozilla.gecko.sync.repositories.domain.Record;
 
+import android.content.ContentUris;
 import android.database.Cursor;
 import android.net.Uri;
 
@@ -514,7 +515,7 @@ public abstract class AndroidBrowserRepositorySession extends StoreTrackingRepos
   protected Record insert(Record record) throws NoGuidForIdException, NullCursorException, ParentNotFoundException {
     Record toStore = prepareRecord(record);
     Uri recordURI = dbHelper.insert(toStore);
-    long id = RepoUtils.getAndroidIdFromUri(recordURI);
+    long id = ContentUris.parseId(recordURI);
     Logger.debug(LOG_TAG, "Inserted as " + id);
 
     toStore.androidID = id;

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserRepositorySession.java
@@ -438,9 +438,7 @@ public abstract class AndroidBrowserRepositorySession extends StoreTrackingRepos
           if (existingRecord == null) {
             // The record is new.
             trace("No match. Inserting.");
-            Record inserted = insert(record);
-            trackRecord(inserted);
-            delegate.onRecordStoreSucceeded(inserted);
+            insert(record);
             return;
           }
 
@@ -512,16 +510,16 @@ public abstract class AndroidBrowserRepositorySession extends StoreTrackingRepos
     delegate.onRecordStoreSucceeded(record);
   }
 
-  protected Record insert(Record record) throws NoGuidForIdException, NullCursorException, ParentNotFoundException {
+  protected void insert(Record record) throws NoGuidForIdException, NullCursorException, ParentNotFoundException {
     Record toStore = prepareRecord(record);
     Uri recordURI = dbHelper.insert(toStore);
-    long id = ContentUris.parseId(recordURI);
-    Logger.debug(LOG_TAG, "Inserted as " + id);
+    toStore.androidID = ContentUris.parseId(recordURI);
 
-    toStore.androidID = id;
     updateBookkeeping(toStore);
-    Logger.debug(LOG_TAG, "insert() returning record " + toStore.guid);
-    return toStore;
+    trackRecord(toStore);
+    delegate.onRecordStoreSucceeded(toStore);
+
+    Logger.debug(LOG_TAG, "Inserted record with guid " + toStore.guid + " as androidID " + toStore.androidID);
   }
 
   protected Record replace(Record newRecord, Record existingRecord) throws NoGuidForIdException, NullCursorException, ParentNotFoundException {

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserRepositorySession.java
@@ -518,6 +518,9 @@ public abstract class AndroidBrowserRepositorySession extends StoreTrackingRepos
   protected void insert(Record record) throws NoGuidForIdException, NullCursorException, ParentNotFoundException {
     Record toStore = prepareRecord(record);
     Uri recordURI = dbHelper.insert(toStore);
+    if (recordURI == null) {
+      throw new NullCursorException(new RuntimeException("Got null URI inserting record with guid " + record.guid));
+    }
     toStore.androidID = ContentUris.parseId(recordURI);
 
     updateBookkeeping(toStore);

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserRepositorySession.java
@@ -337,6 +337,8 @@ public abstract class AndroidBrowserRepositorySession extends StoreTrackingRepos
     this.fetchSince(0, delegate);
   }
 
+  protected int storeCount = 0;
+
   @Override
   public void store(final Record record) throws NoStoreDelegateException {
     if (delegate == null) {
@@ -346,6 +348,9 @@ public abstract class AndroidBrowserRepositorySession extends StoreTrackingRepos
       Logger.error(LOG_TAG, "Record sent to store was null");
       throw new IllegalArgumentException("Null record passed to AndroidBrowserRepositorySession.store().");
     }
+
+    storeCount += 1;
+    Logger.debug(LOG_TAG, "Storing record with GUID " + record.guid + " (stored " + storeCount + " records this session).");
 
     // Store Runnables *must* complete synchronously. It's OK, they
     // run on a background thread.

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/BookmarksInsertionManager.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/BookmarksInsertionManager.java
@@ -244,6 +244,12 @@ public class BookmarksInsertionManager {
     }
   }
 
+  public void clear() {
+    this.insertedFolders.clear();
+    this.nonFoldersToWrite.clear();
+    this.recordsWaitingForParent.clear();
+  }
+
   // For debugging.
   public boolean isClear() {
     return nonFoldersToWrite.isEmpty() && recordsWaitingForParent.isEmpty();

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/BookmarksInsertionManager.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/BookmarksInsertionManager.java
@@ -202,12 +202,11 @@ public abstract class BookmarksInsertionManager {
 
   // For debugging.
   public void dumpState() {
-    String[] readyGuids = new String[readyToWrite.size()];
-    int i = 0;
+    ArrayList<String> readies = new ArrayList<String>();
     for (BookmarkRecord record : readyToWrite) {
-      readyGuids[i++] = record.guid;
+      readies.add(record.guid);
     }
-    String ready = Utils.join(", ", readyGuids);
+    String ready = Utils.toCommaSeparatedString(new ArrayList<String>(readies));
 
     ArrayList<String> waits = new ArrayList<String>();
     for (ArrayList<BookmarkRecord> recs : waitingForParent.values()) {
@@ -215,11 +214,8 @@ public abstract class BookmarksInsertionManager {
         waits.add(rec.guid);
       }
     }
-    String[] waitingGuids = waits.toArray(new String[waits.size()]);
-    String waiting = Utils.join(", ", waitingGuids);
-
-    String[] knownGuids = writtenFolders.toArray(new String[writtenFolders.size()]);
-    String known = Utils.join(", ", knownGuids);
+    String waiting = Utils.toCommaSeparatedString(waits);
+    String known = Utils.toCommaSeparatedString(writtenFolders);
 
     Logger.debug(LOG_TAG, "Q=(" + ready + "), W = (" + waiting + "), P=(" + known + ")");
   }

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/BookmarksInsertionManager.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/BookmarksInsertionManager.java
@@ -1,0 +1,196 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.gecko.sync.repositories.android;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+
+import org.mozilla.gecko.sync.Logger;
+import org.mozilla.gecko.sync.repositories.delegates.RepositorySessionStoreDelegate;
+import org.mozilla.gecko.sync.repositories.domain.BookmarkRecord;
+
+/**
+ * Queue up insertions.
+ *
+ * Note that this class is not thread safe. This should be fine: call it only
+ * from within a store runnable.
+ */
+public abstract class BookmarksInsertionManager {
+  private static final String LOG_TAG = "BookmarkInsert";
+
+  // private RepositorySessionStoreDelegate delegate;
+
+  private final int flushThreshold;
+
+  private final HashSet<String> knownFolders = new HashSet<String>();
+  private final ArrayList<BookmarkRecord> readyToWrite = new ArrayList<BookmarkRecord>();
+  private final HashMap<String, ArrayList<BookmarkRecord>> waitingForParent = new HashMap<String, ArrayList<BookmarkRecord>>();
+
+  /**
+   * Create an instance to be used for tracking insertions in a bookmarks
+   * repository session.
+   *
+   * @param dataAccessor
+   *        Used to effect database changes.
+   *        XXX TODO
+   *
+   * @param flushThreshold
+   *        When this many non-folder records have been stored for insertion,
+   *        an incremental flush occurs.
+   */
+  public BookmarksInsertionManager(int flushThreshold) {
+    this.flushThreshold = flushThreshold;
+    this.clear();
+  }
+
+  /**
+   * Set the delegate to use for callbacks.
+   * If not invoked, no callbacks will be submitted.
+   *
+   * @param delegate a delegate, which should already be a delayed delegate.
+   */
+  public void setDelegate(RepositorySessionStoreDelegate delegate) {
+    // XXX this.delegate = delegate;
+  }
+
+
+  protected void addRecordWithUnknownParent(BookmarkRecord record) {
+    if (!waitingForParent.containsKey(record.parentID)) {
+      waitingForParent.put(record.parentID, new ArrayList<BookmarkRecord>());
+    }
+    waitingForParent.get(record.parentID).add(record);
+  }
+
+  protected void insertFolder(BookmarkRecord record) {
+    Logger.debug(LOG_TAG, "Inserting folder with guid " + record.guid);
+    if (!knownFolders.contains(record.parentID)) {
+      Logger.debug(LOG_TAG, "Folder has unknown parent with guid " + record.parentID + "; keeping until we see the parent.");
+      addRecordWithUnknownParent(record);
+      return;
+    }
+
+    Logger.debug(LOG_TAG, "Folder has known parent with guid " + record.parentID + "; adding to insertion queue.");
+    readyToWrite.add(record);
+
+    knownFolders.add(record.guid);
+    ArrayList<BookmarkRecord> children = waitingForParent.get(record.guid);
+    if (children == null) {
+      return;
+    }
+    waitingForParent.remove(record.guid);
+    readyToWrite.addAll(children);
+    incrementalFlush();
+  }
+
+  public void insertRecord(BookmarkRecord record) {
+    if (record.isFolder()) {
+      insertFolder(record);
+      return;
+    }
+    Logger.debug(LOG_TAG, "Inserting bookmark with guid " + record.guid);
+
+    if (!knownFolders.contains(record.parentID)) {
+      Logger.debug(LOG_TAG, "Bookmark has unknown parent with guid " + record.parentID + "; keeping until we see the parent.");
+      addRecordWithUnknownParent(record);
+      return;
+    }
+
+    Logger.debug(LOG_TAG, "Bookmark has known parent with guid " + record.parentID + "; adding to insertion queue.");
+    readyToWrite.add(record);
+    incrementalFlush();
+  }
+
+  /**
+   * Flush insertions that can be easily taken care of right now.
+   */
+  public void incrementalFlush() {
+    int num = readyToWrite.size();
+    if (num < flushThreshold) {
+      Logger.debug(LOG_TAG, "Incremental flush called with " + num + " < " + flushThreshold + " records; not flushing.");
+      return;
+    }
+    Logger.debug(LOG_TAG, "Incremental flush called with " + num + " records; flushing.");
+    flushAll(System.currentTimeMillis());
+  }
+
+  public void flushAll(long timestamp) {
+    Logger.debug(LOG_TAG, "Full flush called with " + readyToWrite.size() + " records; flushing all.");
+    for (BookmarkRecord record : readyToWrite) {
+      // XXX folders first?
+      try {
+        insert(record);
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    }
+    readyToWrite.clear();
+  }
+
+  /**
+   * Clear state in case of redundancy (e.g., wipe).
+   */
+  public void clear() {
+    String[] SPECIAL_GUIDS = new String[] {
+      // XXX Mobile and desktop places roots have to come first.
+      "places",
+      "mobile",
+      "toolbar",
+      "menu",
+      "unfiled"
+    };
+
+    knownFolders.clear();
+    for (String guid : SPECIAL_GUIDS) {
+      knownFolders.add(guid);
+    }
+    readyToWrite.clear();
+    waitingForParent.clear();
+  }
+
+  // For debugging.
+  public boolean isClear() {
+    return readyToWrite.isEmpty() && waitingForParent.isEmpty();
+  }
+
+  public static String join(String delimiter, String... strings) {
+    StringBuilder sb = new StringBuilder();
+    int i = 0;
+    for (String string : strings) {
+      sb.append(string);
+      i += 1;
+      if (i < strings.length) {
+        sb.append(delimiter);
+      }
+    }
+    return sb.toString();
+  }
+
+  // For debugging.
+  public void dumpState() {
+    String[] readyGuids = new String[readyToWrite.size()];
+    int i = 0;
+    for (BookmarkRecord record : readyToWrite) {
+      readyGuids[i++] = record.guid;
+    }
+    String ready = join(", ", readyGuids);
+
+    ArrayList<String> waits = new ArrayList<String>();
+    for (ArrayList<BookmarkRecord> recs : waitingForParent.values()) {
+      for (BookmarkRecord rec : recs) {
+        waits.add(rec.guid);
+      }
+    }
+    String[] waitingGuids = waits.toArray(new String[waits.size()]);
+    String waiting = join(", ", waitingGuids);
+
+    String[] knownGuids = knownFolders.toArray(new String[knownFolders.size()]);
+    String known = join(", ", knownGuids);
+
+    System.out.println("Q=(" + ready + "), W = (" + waiting + "), P=(" + known + ")");
+  }
+
+  protected abstract void insert(BookmarkRecord record) throws Exception;
+}

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/BookmarksInsertionManager.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/BookmarksInsertionManager.java
@@ -9,7 +9,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -180,8 +179,7 @@ public class BookmarksInsertionManager {
   }
 
   /**
-   * Flush non-folder insertions in batches of <code>flushThreshold</code> size,
-   * possibly not emptying the insertion queue entirely.
+   * Flush non-folder insertions; empties the insertion queue entirely.
    */
   protected void incrementalFlush() {
     int num = nonFoldersToWrite.size();
@@ -191,18 +189,8 @@ public class BookmarksInsertionManager {
     }
     Logger.debug(LOG_TAG, "Incremental flush called with " + num + " non-folders; flushing in batches of " + flushThreshold);
 
-    // bulkInsert non folders in batches.  First copy to array, then slice up array, then re-insert into ordered set.
-    ArrayList<BookmarkRecord> toWrite = new ArrayList<BookmarkRecord>(nonFoldersToWrite);
-    int beg = 0;
-    int end = flushThreshold;
-    while (end <= num) {
-      List<BookmarkRecord> batch = toWrite.subList(beg, end);
-      inserter.bulkInsertNonFolders(batch);
-      beg += flushThreshold;
-      end += flushThreshold;
-    }
+    inserter.bulkInsertNonFolders(nonFoldersToWrite);
     nonFoldersToWrite.clear();
-    nonFoldersToWrite.addAll(toWrite.subList(beg, num));
   }
 
   /**

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/BookmarksInsertionManager.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/BookmarksInsertionManager.java
@@ -114,11 +114,11 @@ public abstract class BookmarksInsertionManager {
       return;
     }
     Logger.debug(LOG_TAG, "Incremental flush called with " + num + " records; flushing.");
-    flushAll(System.currentTimeMillis());
+    flushReadyToWrite();
   }
 
-  public void flushAll(long timestamp) {
-    Logger.debug(LOG_TAG, "Full flush called with " + readyToWrite.size() + " records; flushing all.");
+  public void flushReadyToWrite() {
+    Logger.debug(LOG_TAG, "Flush ready to write called with " + readyToWrite.size() + " records; flushing all.");
 
     if (readyToWrite.isEmpty()) {
       return;
@@ -149,6 +149,17 @@ public abstract class BookmarksInsertionManager {
     } catch (Exception e) {
       e.printStackTrace();
     }
+  }
+
+  public void flushAll(long timestamp) {
+    int num = 0;
+    for (ArrayList<BookmarkRecord> records : waitingForParent.values()) {
+      readyToWrite.addAll(records);
+      num += records.size();
+    }
+    Logger.debug(LOG_TAG, "Flush all called with " + readyToWrite.size() + " ready records " +
+        "and " + num + " records without known parents; flushing all.");
+    flushReadyToWrite();
   }
 
   /**

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/BookmarksInsertionManager.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/BookmarksInsertionManager.java
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.gecko.sync.repositories.android;
 
 import java.util.ArrayList;

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/PasswordsRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/PasswordsRepositorySession.java
@@ -28,6 +28,7 @@ import org.mozilla.gecko.sync.repositories.domain.PasswordRecord;
 import org.mozilla.gecko.sync.repositories.domain.Record;
 
 import android.content.ContentProviderClient;
+import android.content.ContentUris;
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
@@ -445,7 +446,7 @@ public class PasswordsRepositorySession extends
     // record.timeLastUsed = now();
     ContentValues cv = getContentValues(record);
     Uri insertedUri = passwordsProvider.insert(BrowserContractHelpers.PASSWORDS_CONTENT_URI, cv);
-    record.androidID = RepoUtils.getAndroidIdFromUri(insertedUri);
+    record.androidID = ContentUris.parseId(insertedUri);
     return record;
   }
 

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/PasswordsRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/PasswordsRepositorySession.java
@@ -446,6 +446,9 @@ public class PasswordsRepositorySession extends
     // record.timeLastUsed = now();
     ContentValues cv = getContentValues(record);
     Uri insertedUri = passwordsProvider.insert(BrowserContractHelpers.PASSWORDS_CONTENT_URI, cv);
+    if (insertedUri == null) {
+      throw new RemoteException(); // Not much to be done here, save throw.
+    }
     record.androidID = ContentUris.parseId(insertedUri);
     return record;
   }

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/RepoUtils.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/RepoUtils.java
@@ -119,14 +119,6 @@ public class RepoUtils {
     }
   }
 
-  // Returns android id from the URI that we get after inserting a
-  // bookmark into the local Android store.
-  public static long getAndroidIdFromUri(Uri uri) {
-    String path = uri.getPath();
-    int lastSlash = path.lastIndexOf('/');
-    return Long.parseLong(path.substring(lastSlash + 1));
-  }
-
   //Create a HistoryRecord object from a cursor on a row with a Moz History record in it
   public static HistoryRecord historyFromMirrorCursor(Cursor cur) {
 

--- a/src/test/java/org/mozilla/android/sync/net/test/TestClientsEngineStage.java
+++ b/src/test/java/org/mozilla/android/sync/net/test/TestClientsEngineStage.java
@@ -33,7 +33,6 @@ import org.mozilla.gecko.sync.CollectionKeys;
 import org.mozilla.gecko.sync.CryptoRecord;
 import org.mozilla.gecko.sync.ExtendedJSONObject;
 import org.mozilla.gecko.sync.GlobalSession;
-import org.mozilla.gecko.sync.NoCollectionKeysSetException;
 import org.mozilla.gecko.sync.NonObjectJSONException;
 import org.mozilla.gecko.sync.SyncConfigurationException;
 import org.mozilla.gecko.sync.Utils;

--- a/src/test/java/org/mozilla/android/sync/net/test/TestJSONParsing.java
+++ b/src/test/java/org/mozilla/android/sync/net/test/TestJSONParsing.java
@@ -43,6 +43,7 @@ public class TestJSONParsing {
     assertEquals(null, o.getTimestamp("foo"));
   }
 
+  @SuppressWarnings("unused")
   private static void ensureNumberFormatException(ExtendedJSONObject o, String key) {
     try {
       o.getIntegerSafely(key);

--- a/src/test/java/org/mozilla/android/sync/test/TestUtils.java
+++ b/src/test/java/org/mozilla/android/sync/test/TestUtils.java
@@ -5,6 +5,8 @@ package org.mozilla.android.sync.test;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.ArrayList;
+
 import org.junit.Test;
 import org.mozilla.gecko.sync.Utils;
 
@@ -15,5 +17,18 @@ public class TestUtils {
     for (int i = 0; i < 1000; ++i) {
       assertEquals(12, Utils.generateGuid().length());
     }
+  }
+
+  @Test
+  public void testToCommaSeparatedString() {
+    ArrayList<String> xs = new ArrayList<String>();
+    assertEquals("", Utils.toCommaSeparatedString(null));
+    assertEquals("", Utils.toCommaSeparatedString(xs));
+    xs.add("test1");
+    assertEquals("test1", Utils.toCommaSeparatedString(xs));
+    xs.add("test2");
+    assertEquals("test1, test2", Utils.toCommaSeparatedString(xs));
+    xs.add("test3");
+    assertEquals("test1, test2, test3", Utils.toCommaSeparatedString(xs));
   }
 }

--- a/src/test/java/org/mozilla/gecko/sync/repositories/android/test/TestBookmarksInsertionManager.java
+++ b/src/test/java/org/mozilla/gecko/sync/repositories/android/test/TestBookmarksInsertionManager.java
@@ -30,9 +30,9 @@ public class TestBookmarksInsertionManager {
     Set<String> writtenFolders = new HashSet<String>();
     writtenFolders.add("mobile");
 
-    manager = new BookmarksInsertionManager(3, writtenFolders) {
+    BookmarksInsertionManager.BookmarkInserter inserter = new BookmarksInsertionManager.BookmarkInserter() {
       @Override
-      protected boolean insertFolder(BookmarkRecord record) {
+      public boolean insertFolder(BookmarkRecord record) {
         if (record.guid == "fail") {
           return false;
         }
@@ -42,7 +42,7 @@ public class TestBookmarksInsertionManager {
       }
 
       @Override
-      protected void bulkInsertNonFolders(Collection<BookmarkRecord> records) {
+      public void bulkInsertNonFolders(Collection<BookmarkRecord> records) {
         ArrayList<String> guids = new ArrayList<String>();
         for (BookmarkRecord record : records) {
           guids.add(record.guid);
@@ -52,6 +52,7 @@ public class TestBookmarksInsertionManager {
         Logger.debug(BookmarksInsertionManager.LOG_TAG, "Inserted non-folders (" + Utils.toCommaSeparatedString(guids) + ").");
       }
     };
+    manager = new BookmarksInsertionManager(3, writtenFolders, inserter);
     BookmarksInsertionManager.DEBUG = true;
   }
 

--- a/src/test/java/org/mozilla/gecko/sync/repositories/android/test/TestBookmarksInsertionManager.java
+++ b/src/test/java/org/mozilla/gecko/sync/repositories/android/test/TestBookmarksInsertionManager.java
@@ -45,7 +45,7 @@ public class TestBookmarksInsertionManager {
         }
         String[] guidList = guids.toArray(new String[guids.size()]);
         insertions.add(guidList);
-        Logger.debug(BookmarksInsertionManager.LOG_TAG, "Inserted non-folders (" + Utils.join(", ", guidList) + ").");
+        Logger.debug(BookmarksInsertionManager.LOG_TAG, "Inserted non-folders (" + Utils.toCommaSeparatedString(guids) + ").");
       }
     };
     BookmarksInsertionManager.DEBUG = true;

--- a/src/test/java/org/mozilla/gecko/sync/repositories/android/test/TestBookmarksInsertionManager.java
+++ b/src/test/java/org/mozilla/gecko/sync/repositories/android/test/TestBookmarksInsertionManager.java
@@ -8,8 +8,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import org.junit.Before;
@@ -32,13 +32,17 @@ public class TestBookmarksInsertionManager {
 
     manager = new BookmarksInsertionManager(3, writtenFolders) {
       @Override
-      protected void insertFolder(BookmarkRecord record) throws Exception {
+      protected boolean insertFolder(BookmarkRecord record) {
+        if (record.guid == "fail") {
+          return false;
+        }
         Logger.debug(BookmarksInsertionManager.LOG_TAG, "Inserted folder (" + record.guid + ").");
         insertions.add(new String[] { record.guid });
+        return true;
       }
 
       @Override
-      protected void bulkInsertNonFolders(List<BookmarkRecord> records) throws Exception {
+      protected void bulkInsertNonFolders(Collection<BookmarkRecord> records) {
         ArrayList<String> guids = new ArrayList<String>();
         for (BookmarkRecord record : records) {
           guids.add(record.guid);
@@ -76,8 +80,8 @@ public class TestBookmarksInsertionManager {
     manager.enqueueRecord(child2);
     assertTrue(insertions.isEmpty());
     manager.enqueueRecord(folder);
-    assertEquals(2, insertions.size());
-    manager.flushAll(0);
+    assertEquals(1, insertions.size());
+    manager.finishUp();
     assertTrue(manager.isClear());
     assertEquals(2, insertions.size());
     assertArrayEquals(new String[] { "folder" }, insertions.get(0));
@@ -93,10 +97,10 @@ public class TestBookmarksInsertionManager {
     manager.enqueueRecord(child1);
     assertTrue(insertions.isEmpty());
     manager.enqueueRecord(folder);
-    assertEquals(0, insertions.size());
+    assertEquals(1, insertions.size());
     manager.enqueueRecord(child2);
-    assertEquals(2, insertions.size());
-    manager.flushAll(0);
+    assertEquals(1, insertions.size());
+    manager.finishUp();
     assertTrue(manager.isClear());
     assertEquals(2, insertions.size());
     assertArrayEquals(new String[] { "folder" }, insertions.get(0));
@@ -108,44 +112,43 @@ public class TestBookmarksInsertionManager {
     manager.enqueueRecord(bookmark("child1", "folder1"));
     assertEquals(0, insertions.size());
     manager.enqueueRecord(folder("folder1", "mobile"));
-    assertEquals(0, insertions.size());
-    manager.enqueueRecord(bookmark("child3", "folder2"));
-    assertEquals(0, insertions.size());
+    assertEquals(1, insertions.size());
+    manager.enqueueRecord(bookmark("child2", "folder2"));
+    assertEquals(1, insertions.size());
     manager.enqueueRecord(folder("folder2", "folder1"));
-    assertEquals(3, insertions.size()); // 2 folders and 1 regular record.
-    manager.enqueueRecord(bookmark("child2", "folder1"));
+    assertEquals(2, insertions.size());
+    manager.enqueueRecord(bookmark("child3", "folder1"));
     manager.enqueueRecord(bookmark("child4", "folder2"));
     assertEquals(3, insertions.size());
 
-    manager.flushAll(0);
+    manager.finishUp();
     assertTrue(manager.isClear());
     assertEquals(4, insertions.size());
     assertArrayEquals(new String[] { "folder1" }, insertions.get(0));
     assertArrayEquals(new String[] { "folder2" }, insertions.get(1));
-    assertArrayEquals(new String[] { "child1", "child3" }, insertions.get(2));
-    assertArrayEquals(new String[] { "child2", "child4" }, insertions.get(3));
+    assertArrayEquals(new String[] { "child1", "child2", "child3" }, insertions.get(2));
+    assertArrayEquals(new String[] { "child4" }, insertions.get(3));
   }
 
   @Test
   public void testFolderRecursion() {
     manager.enqueueRecord(folder("1", "mobile"));
     manager.enqueueRecord(folder("2", "1"));
+    assertEquals(2, insertions.size());
     manager.enqueueRecord(bookmark("3a", "3"));
     manager.enqueueRecord(bookmark("3b", "3"));
     manager.enqueueRecord(bookmark("3c", "3"));
-    manager.enqueueRecord(bookmark("3d", "3"));
-    manager.enqueueRecord(bookmark("3e", "3"));
     manager.enqueueRecord(bookmark("4a", "4"));
     manager.enqueueRecord(bookmark("4b", "4"));
     manager.enqueueRecord(bookmark("4c", "4"));
-    assertEquals(0, insertions.size());
+    assertEquals(2, insertions.size());
     manager.enqueueRecord(folder("3", "2"));
-    assertEquals(5, insertions.size());
+    assertEquals(4, insertions.size());
     manager.enqueueRecord(folder("4", "2"));
-    assertEquals(7, insertions.size());
+    assertEquals(6, insertions.size());
 
     assertTrue(manager.isClear());
-    manager.flushAll(0);
+    manager.finishUp();
     assertTrue(manager.isClear());
     // Folders in order.
     assertArrayEquals(new String[] { "1" }, insertions.get(0));
@@ -153,9 +156,64 @@ public class TestBookmarksInsertionManager {
     assertArrayEquals(new String[] { "3" }, insertions.get(2));
     // Then children in batches of 3.
     assertArrayEquals(new String[] { "3a", "3b", "3c" }, insertions.get(3));
-    assertArrayEquals(new String[] { "3d", "3e" }, insertions.get(4));
     // Then last folder.
-    assertArrayEquals(new String[] { "4" }, insertions.get(5));
-    assertArrayEquals(new String[] { "4a", "4b", "4c" }, insertions.get(6));
+    assertArrayEquals(new String[] { "4" }, insertions.get(4));
+    assertArrayEquals(new String[] { "4a", "4b", "4c" }, insertions.get(5));
+  }
+
+  @Test
+  public void testFailedFolderInsertion() {
+    manager.enqueueRecord(bookmark("failA", "fail"));
+    manager.enqueueRecord(bookmark("failB", "fail"));
+    assertEquals(0, insertions.size());
+    manager.enqueueRecord(folder("fail", "mobile"));
+    assertEquals(0, insertions.size());
+    manager.enqueueRecord(bookmark("failC", "fail"));
+    assertEquals(0, insertions.size());
+    manager.finishUp(); // Children inserted at the end; they will be treated as orphans.
+    assertTrue(manager.isClear());
+    assertEquals(1, insertions.size());
+    assertArrayEquals(new String[] { "failA", "failB", "failC" }, insertions.get(0));
+  }
+
+  @Test
+  public void testIncrementalFlush() {
+    manager.enqueueRecord(bookmark("a", "1"));
+    manager.enqueueRecord(bookmark("b", "1"));
+    manager.enqueueRecord(folder("1", "mobile"));
+    assertEquals(1, insertions.size());
+    manager.enqueueRecord(bookmark("c", "1"));
+    assertEquals(2, insertions.size());
+    manager.enqueueRecord(bookmark("d", "1"));
+    manager.enqueueRecord(bookmark("e", "1"));
+    manager.enqueueRecord(bookmark("f", "1"));
+    assertEquals(3, insertions.size());
+    manager.enqueueRecord(bookmark("g", "1")); // Start of new batch.
+    assertEquals(3, insertions.size());
+    manager.finishUp(); // Children inserted at the end; they will be treated as orphans.
+    assertTrue(manager.isClear());
+    assertEquals(4, insertions.size());
+    assertArrayEquals(new String[] { "1" }, insertions.get(0));
+    assertArrayEquals(new String[] { "a", "b", "c"}, insertions.get(1));
+    assertArrayEquals(new String[] { "d", "e", "f"}, insertions.get(2));
+    assertArrayEquals(new String[] { "g" }, insertions.get(3));
+  }
+
+  @Test
+  public void testFinishUp() {
+    manager.enqueueRecord(bookmark("a", "1"));
+    manager.enqueueRecord(bookmark("b", "1"));
+    manager.enqueueRecord(folder("2", "1"));
+    manager.enqueueRecord(bookmark("c", "1"));
+    manager.enqueueRecord(bookmark("d", "1"));
+    manager.enqueueRecord(folder("3", "1"));
+    assertEquals(0, insertions.size());
+    manager.finishUp(); // Children inserted at the end; they will be treated as orphans.
+    assertTrue(manager.isClear());
+    assertEquals(4, insertions.size());
+    assertArrayEquals(new String[] { "2" }, insertions.get(0));
+    assertArrayEquals(new String[] { "3" }, insertions.get(1));
+    assertArrayEquals(new String[] { "a", "b", "c"}, insertions.get(2));
+    assertArrayEquals(new String[] { "d" }, insertions.get(3)); // Don't want to miss the last insertion.
   }
 }

--- a/src/test/java/org/mozilla/gecko/sync/repositories/android/test/TestBookmarksInsertionManager.java
+++ b/src/test/java/org/mozilla/gecko/sync/repositories/android/test/TestBookmarksInsertionManager.java
@@ -1,0 +1,112 @@
+package org.mozilla.gecko.sync.repositories.android.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mozilla.gecko.sync.Logger;
+import org.mozilla.gecko.sync.repositories.android.BookmarksInsertionManager;
+import org.mozilla.gecko.sync.repositories.domain.BookmarkRecord;
+
+public class TestBookmarksInsertionManager {
+  public BookmarksInsertionManager manager;
+  public ArrayList<String> insertions;
+
+  @Before
+  public void setUp() {
+    Logger.LOG_TO_STDOUT = true;
+    insertions = new ArrayList<String>();
+    manager = new BookmarksInsertionManager(3) {
+      @Override
+      protected void insert(BookmarkRecord record) throws Exception {
+        insertions.add(record.guid);
+      }
+    };
+  }
+
+  protected static BookmarkRecord bookmark(String guid, String parent) {
+    BookmarkRecord bookmark = new BookmarkRecord(guid);
+    bookmark.type = "bookmark";
+    bookmark.parentID = parent;
+    return bookmark;
+  }
+
+  protected static BookmarkRecord folder(String guid, String parent) {
+    BookmarkRecord bookmark = new BookmarkRecord(guid);
+    bookmark.type = "folder";
+    bookmark.parentID = parent;
+    return bookmark;
+  }
+
+  @Test
+  public void testChildrenBeforeFolder() {
+    BookmarkRecord folder = folder("folder", "mobile");
+    BookmarkRecord child1 = bookmark("child1", "folder");
+    BookmarkRecord child2 = bookmark("child2", "folder");
+
+    manager.insertRecord(child1);
+    manager.dumpState();
+    assertTrue(insertions.isEmpty());
+    manager.insertRecord(child2);
+    manager.dumpState();
+    assertTrue(insertions.isEmpty());
+    manager.insertRecord(folder);
+    manager.dumpState();
+    assertEquals(3, insertions.size());
+    manager.flushAll(0);
+    manager.dumpState();
+    assertTrue(manager.isClear());
+    assertEquals(3, insertions.size());
+    assertArrayEquals(new String[] { "folder", "child1", "child2" },
+        insertions.toArray(new String[insertions.size()]));
+  }
+
+  @Test
+  public void testChildAfterFolder() {
+    BookmarkRecord folder = folder("folder", "mobile");
+    BookmarkRecord child1 = bookmark("child1", "folder");
+    BookmarkRecord child2 = bookmark("child2", "folder");
+
+    manager.insertRecord(child1);
+    manager.dumpState();
+    assertTrue(insertions.isEmpty());
+    manager.insertRecord(folder);
+    manager.dumpState();
+    assertEquals(0, insertions.size());
+    manager.insertRecord(child2);
+    manager.dumpState();
+    assertEquals(3, insertions.size());
+    manager.flushAll(0);
+    manager.dumpState();
+    assertTrue(manager.isClear());
+    assertEquals(3, insertions.size());
+    assertArrayEquals(new String[] { "folder", "child1", "child2" },
+        insertions.toArray(new String[insertions.size()]));
+  }
+
+  @Test
+  public void testFolderAfterFolder() {
+    BookmarkRecord folder1 = folder("folder1", "mobile");
+    BookmarkRecord child1 = bookmark("child1", "folder1");
+    BookmarkRecord child2 = bookmark("child2", "folder1");
+    BookmarkRecord folder2 = folder("folder2", "folder1");
+    BookmarkRecord child3 = bookmark("child3", "folder2");
+    BookmarkRecord child4 = bookmark("child4", "folder2");
+
+    manager.insertRecord(child1);
+    manager.insertRecord(folder1);
+    manager.insertRecord(child3);
+    manager.insertRecord(folder2);
+    manager.insertRecord(child2);
+    manager.insertRecord(child4);
+    manager.flushAll(0);
+    assertTrue(manager.isClear());
+    assertEquals(6, insertions.size());
+    assertArrayEquals(new String[] { "folder1", "child1", "folder2", "child3", "child2", "child4" },
+        insertions.toArray(new String[insertions.size()]));
+  }
+}

--- a/src/test/java/org/mozilla/gecko/sync/repositories/android/test/TestBookmarksInsertionManager.java
+++ b/src/test/java/org/mozilla/gecko/sync/repositories/android/test/TestBookmarksInsertionManager.java
@@ -211,10 +211,9 @@ public class TestBookmarksInsertionManager {
     assertEquals(0, insertions.size());
     manager.finishUp(); // Children inserted at the end; they will be treated as orphans.
     assertTrue(manager.isClear());
-    assertEquals(4, insertions.size());
+    assertEquals(3, insertions.size());
     assertArrayEquals(new String[] { "2" }, insertions.get(0));
     assertArrayEquals(new String[] { "3" }, insertions.get(1));
-    assertArrayEquals(new String[] { "a", "b", "c"}, insertions.get(2));
-    assertArrayEquals(new String[] { "d" }, insertions.get(3)); // Don't want to miss the last insertion.
+    assertArrayEquals(new String[] { "a", "b", "c", "d" }, insertions.get(2)); // Last insertion could be big.
   }
 }

--- a/src/test/java/org/mozilla/gecko/sync/repositories/android/test/TestBookmarksInsertionManager.java
+++ b/src/test/java/org/mozilla/gecko/sync/repositories/android/test/TestBookmarksInsertionManager.java
@@ -1,3 +1,6 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
 package org.mozilla.gecko.sync.repositories.android.test;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -5,11 +8,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mozilla.gecko.sync.Logger;
+import org.mozilla.gecko.sync.Utils;
 import org.mozilla.gecko.sync.repositories.android.BookmarksInsertionManager;
 import org.mozilla.gecko.sync.repositories.domain.BookmarkRecord;
 
@@ -21,7 +27,10 @@ public class TestBookmarksInsertionManager {
   public void setUp() {
     Logger.LOG_TO_STDOUT = true;
     insertions = new ArrayList<String[]>();
-    manager = new BookmarksInsertionManager(3) {
+    Set<String> writtenFolders = new HashSet<String>();
+    writtenFolders.add("mobile");
+
+    manager = new BookmarksInsertionManager(3, writtenFolders) {
       @Override
       protected void insertFolder(BookmarkRecord record) throws Exception {
         Logger.debug(BookmarksInsertionManager.LOG_TAG, "Inserted folder (" + record.guid + ").");
@@ -36,7 +45,7 @@ public class TestBookmarksInsertionManager {
         }
         String[] guidList = guids.toArray(new String[guids.size()]);
         insertions.add(guidList);
-        Logger.debug(BookmarksInsertionManager.LOG_TAG, "Inserted non-folders (" + BookmarksInsertionManager.join(", ", guidList) + ").");
+        Logger.debug(BookmarksInsertionManager.LOG_TAG, "Inserted non-folders (" + Utils.join(", ", guidList) + ").");
       }
     };
     BookmarksInsertionManager.DEBUG = true;

--- a/src/test/java/org/mozilla/gecko/sync/stage/test/TestEnsureClusterURLStage.java
+++ b/src/test/java/org/mozilla/gecko/sync/stage/test/TestEnsureClusterURLStage.java
@@ -20,7 +20,6 @@ import org.mozilla.android.sync.test.helpers.HTTPServerTestHelper;
 import org.mozilla.android.sync.test.helpers.MockGlobalSession;
 import org.mozilla.android.sync.test.helpers.MockGlobalSessionCallback;
 import org.mozilla.android.sync.test.helpers.MockServer;
-import org.mozilla.android.sync.test.helpers.MockServerSyncStage;
 import org.mozilla.android.sync.test.helpers.WaitHelper;
 import org.mozilla.gecko.sync.AlreadySyncingException;
 import org.mozilla.gecko.sync.GlobalSession;

--- a/test/src/org/mozilla/android/sync/test/AndroidBrowserHistoryRepositoryTest.java
+++ b/test/src/org/mozilla/android/sync/test/AndroidBrowserHistoryRepositoryTest.java
@@ -406,10 +406,9 @@ public class AndroidBrowserHistoryRepositoryTest extends AndroidBrowserRepositor
     records.add(HistoryHelpers.createHistory1());
     records.add(HistoryHelpers.createHistory2());
     records.add(HistoryHelpers.createHistory3());
-    db.bulkInsert(records, true);
-    assertTrue(records.get(0).androidID > 0); // Special sentinel value is negative.
+    db.bulkInsert(records);
 
-    performWait(fetchAllRunnable(session, preparedExpectFetchDelegate(records.toArray(new Record[0]))));
+    performWait(fetchAllRunnable(session, preparedExpectFetchDelegate(records.toArray(new Record[records.size()]))));
     session.abort();
   }
 

--- a/test/src/org/mozilla/android/sync/test/BookmarkPositioningTest.java
+++ b/test/src/org/mozilla/android/sync/test/BookmarkPositioningTest.java
@@ -25,7 +25,6 @@ import org.mozilla.gecko.sync.repositories.RepositorySessionBundle;
 import org.mozilla.gecko.sync.repositories.android.AndroidBrowserBookmarksDataAccessor;
 import org.mozilla.gecko.sync.repositories.android.AndroidBrowserBookmarksRepository;
 import org.mozilla.gecko.sync.repositories.android.BrowserContractHelpers;
-import org.mozilla.gecko.sync.repositories.android.RepoUtils;
 import org.mozilla.gecko.sync.repositories.delegates.RepositorySessionBeginDelegate;
 import org.mozilla.gecko.sync.repositories.delegates.RepositorySessionCreationDelegate;
 import org.mozilla.gecko.sync.repositories.delegates.RepositorySessionFetchRecordsDelegate;
@@ -34,6 +33,7 @@ import org.mozilla.gecko.sync.repositories.domain.BookmarkRecord;
 import org.mozilla.gecko.sync.repositories.domain.Record;
 
 import android.content.ContentResolver;
+import android.content.ContentUris;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.net.Uri;
@@ -679,7 +679,7 @@ public class BookmarkPositioningTest extends AndroidSyncTestCase {
 
     if (updated == 0) {
       Uri insert = cr.insert(appendProfile(BrowserContractHelpers.BOOKMARKS_CONTENT_URI), values);
-      long idFromUri = RepoUtils.getAndroidIdFromUri(insert);
+      long idFromUri = ContentUris.parseId(insert);
       Log.i(getName(), "Inserted " + uri + " as " + idFromUri);
       Log.i(getName(), "Position is " + getPosition(idFromUri));
     }


### PR DESCRIPTION
I have not explicitly unit tested that this preserves positions (beyond what was already tested in BookmarkPositioningTest).

I have tested this on device, and batch inserting of bookmarks and folders worked well, and positioning worked as well.
