### PR TITLE
Bug 714304 - Implement handling of "upgrade required" response.

### DIFF
--- a/manifests/SyncAndroidManifest_activities.xml.in
+++ b/manifests/SyncAndroidManifest_activities.xml.in
@@ -18,3 +18,9 @@
             android:name="org.mozilla.gecko.sync.setup.activities.SetupFailureActivity" />
         <activity
             android:name="org.mozilla.gecko.sync.setup.activities.SetupSuccessActivity" />
+        <receiver
+            android:name="org.mozilla.gecko.sync.receivers.UpgradeReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+            </intent-filter>
+        </receiver>

--- a/src/main/java/org/mozilla/gecko/sync/net/SyncStorageResponse.java
+++ b/src/main/java/org/mozilla/gecko/sync/net/SyncStorageResponse.java
@@ -34,6 +34,7 @@ public class SyncStorageResponse extends SyncResponse {
     errors.put("13", "Invalid collection");
     errors.put("14", "User over quota");
     errors.put("15", "The email does not match the username");
+    errors.put("16", "Client upgrade required");
     errors.put("255", "An unexpected server error occurred: pool is empty.");
 
     // Infrastructure-generated errors.

--- a/src/main/java/org/mozilla/gecko/sync/receivers/UpgradeReceiver.java
+++ b/src/main/java/org/mozilla/gecko/sync/receivers/UpgradeReceiver.java
@@ -22,7 +22,6 @@ public class UpgradeReceiver extends BroadcastReceiver {
       @Override
       public void run() {
         Account[] accounts = AccountManager.get(context).getAccounts();
-        Logger.debug(LOG_TAG, "num sync accounts: " + accounts.length);
         SyncAccounts.enableSyncAccounts(accounts, true);
       }
     });

--- a/src/main/java/org/mozilla/gecko/sync/receivers/UpgradeReceiver.java
+++ b/src/main/java/org/mozilla/gecko/sync/receivers/UpgradeReceiver.java
@@ -1,0 +1,30 @@
+package org.mozilla.gecko.sync.receivers;
+
+import org.mozilla.gecko.sync.Logger;
+import org.mozilla.gecko.sync.ThreadPool;
+import org.mozilla.gecko.sync.setup.SyncAccounts;
+
+import android.accounts.Account;
+import android.accounts.AccountManager;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+public class UpgradeReceiver extends BroadcastReceiver {
+  private static final String LOG_TAG = "UpgradeReceiver";
+
+  @Override
+  public void onReceive(final Context context, Intent intent) {
+    Logger.debug(LOG_TAG, "Broadcast received.");
+    // Should filter for specific MY_PACKAGE_REPLACED intent, but Android does
+    // not expose it.
+    ThreadPool.run(new Runnable() {
+      @Override
+      public void run() {
+        Account[] accounts = AccountManager.get(context).getAccounts();
+        Logger.debug(LOG_TAG, "num sync accounts: " + accounts.length);
+        SyncAccounts.enableSyncAccounts(accounts, true);
+      }
+    });
+  }
+}

--- a/src/main/java/org/mozilla/gecko/sync/setup/SyncAccounts.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/SyncAccounts.java
@@ -271,6 +271,9 @@ public class SyncAccounts {
   public static void enableAccounts(Account[] accounts, boolean toEnable) {
     String authority = BrowserContract.AUTHORITY;
     for (Account a : accounts) {
+      if (!Constants.ACCOUNTTYPE_SYNC.equals(a.type)) {
+        continue;
+      }
       Logger.debug(LOG_TAG, "Setting authority " + authority + " to " + (toEnable ? "" : "not") + "sync automatically.");
       ContentResolver.setSyncAutomatically(a, authority, toEnable);
       ContentResolver.setIsSyncable(a, authority, toEnable ? 1 : 0);

--- a/src/main/java/org/mozilla/gecko/sync/setup/SyncAccounts.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/SyncAccounts.java
@@ -259,4 +259,22 @@ public class SyncAccounts {
     }
     Logger.debug(LOG_TAG, "Client name and guid not both non-null, so not setting client data.");
   }
+
+  /**
+   * Enable or disable all Sync accounts.
+   *
+   * @param context
+   *        Context containing accounts
+   * @param toEnable
+   *        boolean for account activity state
+   */
+  public static void enableAccounts(Context context, boolean toEnable) {
+    Account[] accounts = AccountManager.get(context).getAccountsByType(Constants.ACCOUNTTYPE_SYNC);
+    String authority = BrowserContract.AUTHORITY;
+    for (Account a : accounts) {
+      Logger.debug(LOG_TAG, "Setting authority " + authority + " to " + (toEnable ? "" : "not") + "sync automatically.");
+      ContentResolver.setSyncAutomatically(a, authority, toEnable);
+      ContentResolver.setIsSyncable(a, authority, toEnable ? 1 : 0);
+    }
+  }
 }

--- a/src/main/java/org/mozilla/gecko/sync/setup/SyncAccounts.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/SyncAccounts.java
@@ -268,7 +268,7 @@ public class SyncAccounts {
    * @param toEnable
    *        boolean for account activity state
    */
-  public static void enableAccounts(Account[] accounts, boolean toEnable) {
+  public static void enableSyncAccounts(Account[] accounts, boolean toEnable) {
     String authority = BrowserContract.AUTHORITY;
     for (Account a : accounts) {
       if (!Constants.ACCOUNTTYPE_SYNC.equals(a.type)) {

--- a/src/main/java/org/mozilla/gecko/sync/setup/SyncAccounts.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/SyncAccounts.java
@@ -268,8 +268,7 @@ public class SyncAccounts {
    * @param toEnable
    *        boolean for account activity state
    */
-  public static void enableAccounts(Context context, boolean toEnable) {
-    Account[] accounts = AccountManager.get(context).getAccountsByType(Constants.ACCOUNTTYPE_SYNC);
+  public static void enableAccounts(Account[] accounts, boolean toEnable) {
     String authority = BrowserContract.AUTHORITY;
     for (Account a : accounts) {
       Logger.debug(LOG_TAG, "Setting authority " + authority + " to " + (toEnable ? "" : "not") + "sync automatically.");

--- a/src/test/java/org/mozilla/gecko/sync/stage/test/TestEnsureClusterURLStage.java
+++ b/src/test/java/org/mozilla/gecko/sync/stage/test/TestEnsureClusterURLStage.java
@@ -33,6 +33,7 @@ import org.mozilla.gecko.sync.stage.EnsureClusterURLStage;
 import org.mozilla.gecko.sync.stage.GlobalSyncStage;
 import org.mozilla.gecko.sync.stage.GlobalSyncStage.Stage;
 
+import android.accounts.Account;
 import ch.boye.httpclientandroidlib.HttpResponse;
 import ch.boye.httpclientandroidlib.ProtocolVersion;
 import ch.boye.httpclientandroidlib.message.BasicHttpResponse;
@@ -102,7 +103,7 @@ public class TestEnsureClusterURLStage {
       @Override
       public void run() {
         try {
-          EnsureClusterURLStage.fetchClusterURL(TEST_NW_URL, delegate);
+          EnsureClusterURLStage.fetchClusterURL(TEST_NW_URL, delegate, new Account[0]);
         } catch (URISyntaxException e) {
           WaitHelper.getTestWaiter().performNotify(e);
         }

--- a/src/test/java/org/mozilla/gecko/sync/stage/test/TestEnsureClusterURLStage.java
+++ b/src/test/java/org/mozilla/gecko/sync/stage/test/TestEnsureClusterURLStage.java
@@ -33,7 +33,6 @@ import org.mozilla.gecko.sync.stage.EnsureClusterURLStage;
 import org.mozilla.gecko.sync.stage.GlobalSyncStage;
 import org.mozilla.gecko.sync.stage.GlobalSyncStage.Stage;
 
-import android.accounts.Account;
 import ch.boye.httpclientandroidlib.HttpResponse;
 import ch.boye.httpclientandroidlib.ProtocolVersion;
 import ch.boye.httpclientandroidlib.message.BasicHttpResponse;
@@ -103,7 +102,7 @@ public class TestEnsureClusterURLStage {
       @Override
       public void run() {
         try {
-          EnsureClusterURLStage.fetchClusterURL(TEST_NW_URL, delegate, new Account[0]);
+          EnsureClusterURLStage.fetchClusterURL(TEST_NW_URL, delegate, null);
         } catch (URISyntaxException e) {
           WaitHelper.getTestWaiter().performNotify(e);
         }

--- a/test/src/org/mozilla/android/sync/test/TestUpgradeRequired.java
+++ b/test/src/org/mozilla/android/sync/test/TestUpgradeRequired.java
@@ -1,0 +1,121 @@
+package org.mozilla.android.sync.test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.mozilla.android.sync.test.helpers.HTTPServerTestHelper;
+import org.mozilla.android.sync.test.helpers.MockServer;
+import org.mozilla.android.sync.test.helpers.WaitHelper;
+import org.mozilla.gecko.db.BrowserContract;
+import org.mozilla.gecko.sync.setup.Constants;
+import org.mozilla.gecko.sync.setup.SyncAccounts;
+import org.mozilla.gecko.sync.setup.SyncAccounts.SyncAccountParameters;
+import org.mozilla.gecko.sync.stage.EnsureClusterURLStage;
+
+import android.accounts.Account;
+import android.accounts.AccountManager;
+import android.content.ContentResolver;
+import android.content.Context;
+import ch.boye.httpclientandroidlib.HttpResponse;
+
+/**
+ * When syncing and a server responds with a 400 "Upgrade Required," Sync
+ * accounts should be disabled.
+ *
+ * (We are not testing for package updating, because MY_PACKAGE_REPLACED
+ * broadcasts can only be sent by the system. Testing for package replacement
+ * needs to be done manually on a device.)
+ *
+ * @author liuche
+ *
+ */
+public class TestUpgradeRequired extends AndroidSyncTestCase {
+  private static final int     TEST_PORT        = 15325;
+  private static final String  TEST_SERVER      = "http://localhost:" + TEST_PORT + "/";
+  private static final String  TEST_NW_URL      = TEST_SERVER + "/1.0/c6o7dvmr2c4ud2fyv6woz2u4zi22bcyd/node/weave";
+  private HTTPServerTestHelper data             = new HTTPServerTestHelper(TEST_PORT);
+
+  private final String TEST_USERNAME1           = "user1";
+  private final String TEST_PASSWORD1           = "pass1";
+  private final String TEST_SYNC_KEY1           = "abcdeabcdeabcdeabcdeabcdea";
+
+  private Context context;
+  private AccountManager accountManager;
+  private Account account;
+
+  @Override
+  public void setUp() {
+    context = getApplicationContext();
+
+    // Set up and enable Sync accounts.
+    accountManager = AccountManager.get(context);
+    SyncAccountParameters syncAccountParams = new SyncAccountParameters(context, accountManager, TEST_USERNAME1, TEST_PASSWORD1, TEST_SYNC_KEY1, TEST_SERVER, null, null, null);
+    account = SyncAccounts.createSyncAccount(syncAccountParams);
+    SyncAccounts.setSyncAutomatically(account);
+  }
+
+  public class MockClusterURLFetchDelegate implements EnsureClusterURLStage.ClusterURLFetchDelegate {
+    public boolean      failureCalled   = false;
+    public HttpResponse failureResponse = null;
+
+    @Override
+    public void handleSuccess(URI url) {
+      WaitHelper.getTestWaiter().performNotify();
+    }
+
+    @Override
+    public void handleThrottled() {
+      WaitHelper.getTestWaiter().performNotify();
+    }
+
+    @Override
+    public void handleFailure(HttpResponse response) {
+      failureCalled = true;
+      failureResponse = response;
+      WaitHelper.getTestWaiter().performNotify();
+    }
+
+    @Override
+    public void handleError(Exception e) {
+      WaitHelper.getTestWaiter().performNotify(e);
+    }
+  }
+
+  public MockClusterURLFetchDelegate doFetchClusterURL() {
+    final MockClusterURLFetchDelegate delegate = new MockClusterURLFetchDelegate();
+    WaitHelper.getTestWaiter().performWait(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          EnsureClusterURLStage.fetchClusterURL(TEST_NW_URL, delegate, new Account[] { account });
+        } catch (URISyntaxException e) {
+          WaitHelper.getTestWaiter().performNotify(e);
+        }
+      }
+    });
+    return delegate;
+  }
+  /**
+   * Sync accounts should be disabled when the server responds with a 400
+   * response and the "Upgrade Required" response code.
+   */
+  public void testUpgradeResponse() {
+    // Use server that responds with "Upgrade Required" response code.
+    data.startHTTPServer(new MockServer(400, "16"));
+    MockClusterURLFetchDelegate delegate = doFetchClusterURL();
+    data.stopHTTPServer();
+
+    // 400 error should have occurred.
+    assertTrue(delegate.failureCalled);
+    assertEquals(400, delegate.failureResponse.getStatusLine().getStatusCode());
+
+    // Sync accounts should be disabled.
+    Account[] accounts = accountManager.getAccountsByType(Constants.ACCOUNTTYPE_SYNC);
+    for (Account a : accounts) {
+      assertFalse(ContentResolver.getSyncAutomatically(a, BrowserContract.AUTHORITY));
+      assertEquals(0, ContentResolver.getIsSyncable(a, BrowserContract.AUTHORITY));
+    }
+    // Delete account.
+    accountManager.removeAccount(account, null, null);
+  }
+}

--- a/test/src/org/mozilla/android/sync/test/TestUpgradeRequired.java
+++ b/test/src/org/mozilla/android/sync/test/TestUpgradeRequired.java
@@ -87,7 +87,7 @@ public class TestUpgradeRequired extends AndroidSyncTestCase {
       @Override
       public void run() {
         try {
-          EnsureClusterURLStage.fetchClusterURL(TEST_NW_URL, delegate, new Account[] { account });
+          EnsureClusterURLStage.fetchClusterURL(TEST_NW_URL, delegate, context);
         } catch (URISyntaxException e) {
           WaitHelper.getTestWaiter().performNotify(e);
         }


### PR DESCRIPTION
Adds handling of HTTP 400: Upgrade Required responses from server in EnsureClusterURLStage.

On receiving an "upgrade required," disable automatic syncing and sync accounts and disable syncing of accounts. On reinstall of the Fennec + Sync package, the sync accounts are re-enabled and set to automatically sync.

This may require changes once we move to supporting multiple Firefox versions, because the sync accounts will still be set to not sync automatically, and be disabled.

Feedback requested, not ready for merging with develop because of mvn test dependencies for MockServer et al.
