### PR TITLE
Bug 714304 - Implement handling of "upgrade required" response.

### DIFF
--- a/manifests/SyncAndroidManifest_activities.xml.in
+++ b/manifests/SyncAndroidManifest_activities.xml.in
@@ -18,3 +18,9 @@
             android:name="org.mozilla.gecko.sync.setup.activities.SetupFailureActivity" />
         <activity
             android:name="org.mozilla.gecko.sync.setup.activities.SetupSuccessActivity" />
+        <receiver
+            android:name="org.mozilla.gecko.sync.receivers.UpgradeReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+            </intent-filter>
+        </receiver>

--- a/src/main/java/org/mozilla/android/sync/test/helpers/DefaultGlobalSessionCallback.java
+++ b/src/main/java/org/mozilla/android/sync/test/helpers/DefaultGlobalSessionCallback.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.android.sync.test.helpers;
 
 import java.net.URI;

--- a/src/main/java/org/mozilla/android/sync/test/helpers/DefaultGlobalSessionCallback.java
+++ b/src/main/java/org/mozilla/android/sync/test/helpers/DefaultGlobalSessionCallback.java
@@ -37,6 +37,10 @@ public class DefaultGlobalSessionCallback implements GlobalSessionCallback {
   }
 
   @Override
+  public void informUpgradeRequiredResponse(GlobalSession session) {
+  }
+
+  @Override
   public void handleAborted(GlobalSession globalSession, String reason) {
   }
 

--- a/src/main/java/org/mozilla/gecko/sync/HTTPFailureException.java
+++ b/src/main/java/org/mozilla/gecko/sync/HTTPFailureException.java
@@ -69,6 +69,8 @@ public class HTTPFailureException extends SyncException {
       // Node reassignment 401s get handled internally.
       syncResult.stats.numAuthExceptions++;
       return;
+    case 400:
+      syncResult.stats.numConflictDetectedExceptions++;
     case 500:
     case 501:
     case 503:

--- a/src/main/java/org/mozilla/gecko/sync/delegates/GlobalSessionCallback.java
+++ b/src/main/java/org/mozilla/gecko/sync/delegates/GlobalSessionCallback.java
@@ -51,10 +51,16 @@ public interface GlobalSessionCallback {
    */
   void informNodeAuthenticationFailed(GlobalSession globalSession, URI failedClusterURL);
 
+  /**
+   * Called when an HTTP failure indicates that a software upgrade is required.
+   */
+  void informUpgradeRequiredResponse(GlobalSession session);
+
   void handleAborted(GlobalSession globalSession, String reason);
   void handleError(GlobalSession globalSession, Exception ex);
   void handleSuccess(GlobalSession globalSession);
   void handleStageCompleted(Stage currentState, GlobalSession globalSession);
 
   boolean shouldBackOff();
+
 }

--- a/src/main/java/org/mozilla/gecko/sync/net/SyncStorageResponse.java
+++ b/src/main/java/org/mozilla/gecko/sync/net/SyncStorageResponse.java
@@ -13,6 +13,9 @@ import ch.boye.httpclientandroidlib.HttpResponse;
 
 public class SyncStorageResponse extends SyncResponse {
 
+  // Responses that are actionable get constant status codes.
+  public static final String RESPONSE_CLIENT_UPGRADE_REQUIRED = "16";
+
   private static final String LOG_TAG = "SyncStorageResponse";
   public static HashMap<String, String> SERVER_ERROR_MESSAGES;
   static {
@@ -34,7 +37,7 @@ public class SyncStorageResponse extends SyncResponse {
     errors.put("13", "Invalid collection");
     errors.put("14", "User over quota");
     errors.put("15", "The email does not match the username");
-    errors.put("16", "Client upgrade required");
+    errors.put(RESPONSE_CLIENT_UPGRADE_REQUIRED, "Client upgrade required");
     errors.put("255", "An unexpected server error occurred: pool is empty.");
 
     // Infrastructure-generated errors.

--- a/src/main/java/org/mozilla/gecko/sync/net/SyncStorageResponse.java
+++ b/src/main/java/org/mozilla/gecko/sync/net/SyncStorageResponse.java
@@ -34,6 +34,7 @@ public class SyncStorageResponse extends SyncResponse {
     errors.put("13", "Invalid collection");
     errors.put("14", "User over quota");
     errors.put("15", "The email does not match the username");
+    errors.put("16", "Client upgrade required");
     errors.put("255", "An unexpected server error occurred: pool is empty.");
 
     // Infrastructure-generated errors.

--- a/src/main/java/org/mozilla/gecko/sync/receivers/UpgradeReceiver.java
+++ b/src/main/java/org/mozilla/gecko/sync/receivers/UpgradeReceiver.java
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.gecko.sync.receivers;
+
+import org.mozilla.gecko.sync.Logger;
+import org.mozilla.gecko.sync.ThreadPool;
+import org.mozilla.gecko.sync.setup.Constants;
+import org.mozilla.gecko.sync.setup.SyncAccounts;
+
+import android.accounts.Account;
+import android.accounts.AccountManager;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+public class UpgradeReceiver extends BroadcastReceiver {
+  private static final String LOG_TAG = "UpgradeReceiver";
+
+  @Override
+  public void onReceive(final Context context, Intent intent) {
+    Logger.debug(LOG_TAG, "Broadcast received.");
+    // Should filter for specific MY_PACKAGE_REPLACED intent, but Android does
+    // not expose it.
+    ThreadPool.run(new Runnable() {
+      @Override
+      public void run() {
+        AccountManager accountManager = AccountManager.get(context);
+        Account[] accounts = accountManager.getAccounts();
+        for (Account a : accounts) {
+          if ("1".equals(accountManager.getUserData(a, Constants.DATA_ENABLE_ON_UPGRADE))) {
+            SyncAccounts.setSyncAutomatically(a, true);
+            accountManager.setUserData(a, Constants.DATA_ENABLE_ON_UPGRADE, "0");
+          }
+        }
+      }
+    });
+  }
+}

--- a/src/main/java/org/mozilla/gecko/sync/setup/Constants.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/Constants.java
@@ -16,6 +16,7 @@ public class Constants {
   public static final String ACCOUNT_GUID         = "account.guid";
   public static final String CLIENT_NAME          = "account.clientName";
   public static final String NUM_CLIENTS          = "account.numClients";
+  public static final String DATA_ENABLE_ON_UPGRADE = "data.enableOnUpgrade";
 
   // Constants for Activities.
   public static final String INTENT_EXTRA_IS_SETUP = "isSetup";

--- a/src/test/java/org/mozilla/android/sync/test/helpers/MockGlobalSessionCallback.java
+++ b/src/test/java/org/mozilla/android/sync/test/helpers/MockGlobalSessionCallback.java
@@ -32,6 +32,7 @@ public class MockGlobalSessionCallback implements GlobalSessionCallback {
   public boolean calledInformNodeAuthenticationFailed = false;
   public boolean calledInformNodeAssigned = false;
   public boolean calledInformUnauthorizedResponse = false;
+  public boolean calledInformUpgradeRequiredResponse = false;
   public URI calledInformNodeAuthenticationFailedClusterURL = null;
   public URI calledInformNodeAssignedOldClusterURL = null;
   public URI calledInformNodeAssignedNewClusterURL = null;
@@ -87,6 +88,11 @@ public class MockGlobalSessionCallback implements GlobalSessionCallback {
   public void informUnauthorizedResponse(GlobalSession session, URI clusterURL) {
     this.calledInformUnauthorizedResponse = true;
     this.calledInformUnauthorizedResponseClusterURL = clusterURL;
+  }
+
+  @Override
+  public void informUpgradeRequiredResponse(GlobalSession session) {
+    this.calledInformUpgradeRequiredResponse = true;
   }
 
   @Override

--- a/test/src/org/mozilla/android/sync/stage/test/TestGlobalSession.java
+++ b/test/src/org/mozilla/android/sync/stage/test/TestGlobalSession.java
@@ -67,6 +67,11 @@ public class TestGlobalSession extends AndroidSyncTestCase {
     }
 
     @Override
+    public void informUpgradeRequiredResponse(GlobalSession session) {
+      fail("Not expecting informUnauthorizedResponse.");
+    }
+
+    @Override
     public void handleAborted(GlobalSession globalSession, String reason) {
       fail("Not expecting abort.");
     }

--- a/test/src/org/mozilla/android/sync/test/TestUpgradeRequired.java
+++ b/test/src/org/mozilla/android/sync/test/TestUpgradeRequired.java
@@ -309,6 +309,11 @@ public class TestUpgradeRequired extends AndroidSyncTestCase {
     }
 
     @Override
+    public void informUpgradeRequiredResponse(GlobalSession session) {
+      // Do nothing.
+    }
+
+    @Override
     public boolean shouldBackOff() {
       return false;
     }

--- a/test/src/org/mozilla/android/sync/test/TestUpgradeRequired.java
+++ b/test/src/org/mozilla/android/sync/test/TestUpgradeRequired.java
@@ -1,0 +1,248 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.android.sync.test;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.json.simple.parser.ParseException;
+import org.mozilla.android.sync.test.helpers.MockGlobalSession;
+import org.mozilla.android.sync.test.helpers.MockGlobalSessionCallback;
+import org.mozilla.android.sync.test.helpers.MockResourceDelegate;
+import org.mozilla.android.sync.test.helpers.MockServerSyncStage;
+import org.mozilla.android.sync.test.helpers.WaitHelper;
+import org.mozilla.gecko.db.BrowserContract;
+import org.mozilla.gecko.sync.AlreadySyncingException;
+import org.mozilla.gecko.sync.GlobalSession;
+import org.mozilla.gecko.sync.HTTPFailureException;
+import org.mozilla.gecko.sync.Logger;
+import org.mozilla.gecko.sync.NonObjectJSONException;
+import org.mozilla.gecko.sync.SyncConfigurationException;
+import org.mozilla.gecko.sync.Utils;
+import org.mozilla.gecko.sync.crypto.CryptoException;
+import org.mozilla.gecko.sync.crypto.KeyBundle;
+import org.mozilla.gecko.sync.net.BaseResource;
+import org.mozilla.gecko.sync.net.SyncResourceDelegate;
+import org.mozilla.gecko.sync.net.SyncStorageResponse;
+import org.mozilla.gecko.sync.setup.Constants;
+import org.mozilla.gecko.sync.setup.SyncAccounts;
+import org.mozilla.gecko.sync.setup.SyncAccounts.SyncAccountParameters;
+import org.mozilla.gecko.sync.stage.GlobalSyncStage;
+import org.mozilla.gecko.sync.stage.GlobalSyncStage.Stage;
+import org.simpleframework.http.Request;
+import org.simpleframework.http.Response;
+import org.simpleframework.http.core.Container;
+import org.simpleframework.transport.connect.Connection;
+import org.simpleframework.transport.connect.SocketConnection;
+
+import ch.boye.httpclientandroidlib.HttpResponse;
+
+import android.accounts.Account;
+import android.accounts.AccountManager;
+import android.content.ContentResolver;
+import android.content.Context;
+
+/**
+ * When syncing and a server responds with a 400 "Upgrade Required," Sync
+ * accounts should be disabled.
+ *
+ * (We are not testing for package updating, because MY_PACKAGE_REPLACED
+ * broadcasts can only be sent by the system. Testing for package replacement
+ * needs to be done manually on a device.)
+ *
+ * @author liuche
+ *
+ */
+public class TestUpgradeRequired extends AndroidSyncTestCase {
+  private final int     TEST_PORT        = 15325;
+  private final String  TEST_SERVER      = "http://localhost:" + TEST_PORT + "/";
+
+  private final String TEST_USERNAME     = "user1";
+  private final String TEST_PASSWORD     = "pass1";
+  private final String TEST_SYNC_KEY     = "abcdeabcdeabcdeabcdeabcdea";
+
+  private Context context;
+  private AccountManager accountManager;
+  private Account account;
+
+  // Mock server
+  private Container upgradeServer;
+  private Connection connection;
+
+  @Override
+  public void setUp() {
+    context = getApplicationContext();
+
+    // Set up and enable Sync accounts.
+    accountManager = AccountManager.get(context);
+    SyncAccountParameters syncAccountParams = new SyncAccountParameters(context, accountManager, TEST_USERNAME, TEST_PASSWORD, TEST_SYNC_KEY, TEST_SERVER, null, null, null);
+    account = SyncAccounts.createSyncAccount(syncAccountParams);
+    SyncAccounts.setSyncAutomatically(account);
+
+    // Create mock server.
+    upgradeServer = new Container() {
+
+      @Override
+      public void handle(Request request, Response response) {
+        Logger.debug(LOG_TAG, "Handling request...");
+        try {
+          // Default response fields.
+          long time = System.currentTimeMillis();
+          response.set("Content-Type", "text/plain");
+          response.set("Server", "HelloWorld/1.0 (Simple 4.0)");
+          response.setDate("Date", time);
+          response.setDate("Last-Modified", time);
+
+          final String timestampHeader = Utils.millisecondsToDecimalSecondsString(time);
+          response.set("X-Weave-Timestamp", timestampHeader);
+          System.out.println("> X-Weave-Timestamp header: " + timestampHeader);
+
+          // HTTP response and response code in body for requiring upgrade.
+          response.setCode(400);
+          PrintStream bodyStream = response.getPrintStream();
+          bodyStream.println("16");
+          bodyStream.close();
+        } catch (IOException e) {
+          fail("Failed on IO error.");
+        }
+      }
+    };
+  }
+
+  /**
+   * Sync accounts should be disabled when the server responds with a 400
+   * response and the "Upgrade Required" response code.
+   * @throws CryptoException
+   * @throws ParseException
+   * @throws IOException
+   * @throws NonObjectJSONException
+   * @throws IllegalArgumentException
+   * @throws SyncConfigurationException
+   */
+  public void testUpgradeResponse() throws SyncConfigurationException, IllegalArgumentException, NonObjectJSONException, IOException, ParseException, CryptoException {
+    final Map<Stage, GlobalSyncStage> stagesToRun = new HashMap<Stage, GlobalSyncStage>();
+
+    // Mock GlobalSession.
+    final MockGlobalSessionCallback callback = new MockGlobalSessionCallback();
+    final GlobalSession session = new MockGlobalSession(TEST_SERVER, TEST_USERNAME, TEST_PASSWORD,
+        new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY), callback) {
+      @Override
+      protected void prepareStages() {
+        super.prepareStages();
+        stagesToRun.putAll(this.stages);
+        this.stages = stagesToRun;
+      }
+    };
+
+    // Stage that makes a get() to upgradeServer.
+    MockServerSyncStage stage = new MockServerSyncStage(session) {
+      @Override
+      public void execute() {
+        Logger.warn(LOG_TAG, "execute()");
+        final WaitHelper innerWaitHelper = new WaitHelper();
+        innerWaitHelper.performWait(new Runnable() {
+          @Override
+          public void run() {
+            try {
+              Logger.debug(LOG_TAG, "run()");
+              final BaseResource r = new BaseResource(TEST_SERVER);
+              r.delegate = new MockResourceDelegate(innerWaitHelper) {
+                @Override
+                public void handleHttpResponse(HttpResponse response) {
+                  Logger.warn(LOG_TAG, "handleHttpResponse()");
+                  if (response.getStatusLine().getStatusCode() != 200) {
+                    session.interpretHTTPFailure(response);
+                  }
+                  BaseResource.consumeEntity(response);
+                  waitHelper.performNotify();
+                }
+              };
+              Logger.debug(LOG_TAG, "get()");
+              r.get();
+            } catch (URISyntaxException e) {
+              innerWaitHelper.performNotify(e);
+            }
+          }
+        });
+      }
+    };
+    stagesToRun.put(Stage.ensureClusterURL, stage);
+
+    startServer(upgradeServer);
+    // Run session.
+    WaitHelper.getTestWaiter().performWait(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          session.start();
+        } catch (AlreadySyncingException e) {
+          WaitHelper.getTestWaiter().performNotify(e);
+          fail(e.toString());
+        }
+      }
+    });
+    stopServer();
+
+    assertTrue(callback.calledAborted);
+    assertTrue(callback.calledError);
+    assertTrue(callback.calledErrorException instanceof HTTPFailureException);
+
+    // 400 error should have occurred.
+    SyncStorageResponse httpResponse = ((HTTPFailureException) callback.calledErrorException).response;
+    assertEquals(400, httpResponse.getStatusCode());
+    try {
+      assertEquals("16", httpResponse.body());
+    } catch (Exception e) {
+      fail("Exception in checking HTTP response body: " + e.toString());
+    }
+
+    // Sync accounts should be disabled and have flags.
+    Account[] accounts = accountManager.getAccountsByType(Constants.ACCOUNTTYPE_SYNC);
+    for (Account a : accounts) {
+      assertFalse(ContentResolver.getSyncAutomatically(a, BrowserContract.AUTHORITY));
+      assertEquals(0, ContentResolver.getIsSyncable(a, BrowserContract.AUTHORITY));
+      assertEquals("1", accountManager.getUserData(a, Constants.DATA_ENABLE_ON_UPGRADE));
+    }
+  }
+
+  @Override
+  public void tearDown() {
+    // Delete account.
+    accountManager.removeAccount(account, null, null);
+  }
+  private void startServer(Container server) {
+    SyncResourceDelegate.connectionTimeoutInMillis = 1000;
+    try {
+      Logger.info(LOG_TAG, "Starting HTTP server on port " + TEST_PORT + "...");
+      connection = new SocketConnection(server);
+      SocketAddress address = new InetSocketAddress(TEST_PORT);
+      connection.connect(address);
+      Logger.info(LOG_TAG, "Starting HTTP server on port " + TEST_PORT + "... DONE");
+    } catch (IOException e) {
+      fail("Failed while starting mock server: " + e.toString());
+    }
+  }
+
+  private void stopServer() {
+    Logger.info(LOG_TAG, "Stopping HTTP server on port " + TEST_PORT + "...");
+    try {
+      if (connection != null) {
+        connection.close();
+      }
+      connection = null;
+      Logger.info(LOG_TAG, "Closing connection pool...");
+      BaseResource.shutdownConnectionManager();
+      Logger.info(LOG_TAG, "Stopping HTTP server on port " + TEST_PORT + "... DONE");
+    } catch (IOException ex) {
+      Logger.error(LOG_TAG, "Error stopping HTTP server on port " + TEST_PORT + "... DONE", ex);
+      fail("Failed while stopping server: " + ex.toString());
+    }
+  }
+}


### PR DESCRIPTION
Addressed comments made in pull request #177.

Also decoupled testing from MockServer and HTTPTestServerHelper, but request hangs and doesn't complete. Feedback requested for TestUpgradeRequired.

Requiring an upgrade will uncheck the checkboxes in the account settings if checked, and set a flag for the accounts that have been changed this way. (AFAICT, there isn't a way to filter by accounts associated with a particular Authenticator.)

Upgrading the package will check the checkboxes for accounts that have a flag and clear the flag.

Note: setSyncAutomatically controls checkbox behavior, setIsSyncable controls whether a Firefox installation associated with an account appears at all in Account Settings.
