### PR TITLE
Bug 738676 - Pair a device not working a second time.

### DIFF
--- a/manifests/SyncAndroidManifest_activities.xml.in
+++ b/manifests/SyncAndroidManifest_activities.xml.in
@@ -15,8 +15,10 @@
             android:name="org.mozilla.gecko.sync.setup.activities.AccountActivity"
             android:windowSoftInputMode="adjustPan|stateHidden"/>
         <activity
+            android:noHistory="true"
             android:name="org.mozilla.gecko.sync.setup.activities.SetupFailureActivity" />
         <activity
+            android:noHistory="true"
             android:name="org.mozilla.gecko.sync.setup.activities.SetupSuccessActivity" />
         <receiver
             android:name="org.mozilla.gecko.sync.receivers.UpgradeReceiver">

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSuccessActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSuccessActivity.java
@@ -38,6 +38,7 @@
 package org.mozilla.gecko.sync.setup.activities;
 
 import org.mozilla.gecko.R;
+import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.setup.Constants;
 
 import android.app.Activity;
@@ -49,7 +50,6 @@ import android.view.View;
 import android.widget.TextView;
 
 public class SetupSuccessActivity extends Activity {
-  @SuppressWarnings("unused")
   private final static String LOG_TAG = "SetupSuccessActivity";
   private TextView setupSubtitle;
   private Context mContext;
@@ -70,12 +70,17 @@ public class SetupSuccessActivity extends Activity {
     }
   }
 
+  @Override
+  public void onDestroy() {
+    Logger.debug(LOG_TAG, "onDestroy() called.");
+    super.onDestroy();
+  }
+
   /* Click Handlers */
   public void settingsClickHandler(View target) {
     Intent intent = new Intent(Settings.ACTION_SYNC_SETTINGS);
-    intent.setFlags(Constants.FLAG_ACTIVITY_REORDER_TO_FRONT_NO_ANIMATION);
+    intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET);
     startActivity(intent);
-    finish();
   }
 
   public void pairClickHandler(View target) {

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSyncActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSyncActivity.java
@@ -153,13 +153,21 @@ public class SetupSyncActivity extends AccountAuthenticatorActivity {
     if (jClient != null) {
       jClient.abort(Constants.JPAKE_ERROR_USERABORT);
     }
+    if (pairWithPin) {
+      finish();
+    }
   }
 
   @Override
   public void onNewIntent(Intent intent) {
     Logger.debug(LOG_TAG, "Started SetupSyncActivity with new intent.");
     setIntent(intent);
-    onResume();
+  }
+
+  @Override
+  public void onDestroy() {
+    Logger.debug(LOG_TAG, "onDestroy() called.");
+    super.onDestroy();
   }
 
   /* Click Handlers */


### PR DESCRIPTION
Problem had to do with multiple instances of Settings running, and only one instance being able to successfully start the Pair activity through intents. Maybe Android doesn't expect multiple Settings instances to run, and starting intents from the Preferences xml of our Sync account didn't work.

Repro-d bug on my Asus Transformer, no longer appears after fix. Hopefully this is not a device-specific fix (again). QA on different devices will definitely be necessary. 
