### PR TITLE
generate manifests used for Mozilla build system with one entry per line

### DIFF
--- a/fennec-copy-code.sh
+++ b/fennec-copy-code.sh
@@ -48,8 +48,9 @@ done
 echo "Writing README."
 echo $WARNING > $ANDROID/base/sync/README.txt
 echo $WARNING > $ANDROID/base/httpclientandroidlib/README.txt
+true > $SYNC/java-sources.mn
 for f in $SOURCEFILES ; do
-    echo $f > $SYNC/java-sources.mn
+    echo $f >> $SYNC/java-sources.mn
 done
 true > $SYNC/java-third-party-sources.mn
 for f in $HTTPLIBFILES $JSONLIBFILES $APACHEFILES ; do

--- a/fennec-copy-code.sh
+++ b/fennec-copy-code.sh
@@ -57,8 +57,9 @@ echo "SYNC_RES_LAYOUT := $(find res/layout         -name '*.xml' | xargs)"  >> $
 echo "SYNC_RES_VALUES := res/values/sync_styles.xml" >> $MKFILE
 # Finished creating makefile for Mozilla
 
+true > $SYNC/preprocess-sources.mn
 for f in $PREPROCESS_FILES ; do
-    echo $f > $SYNC/preprocess-sources.mn
+    echo $f >> $SYNC/preprocess-sources.mn
 done
 
 echo "Writing README."

--- a/fennec-copy-code.sh
+++ b/fennec-copy-code.sh
@@ -42,12 +42,19 @@ mkdir -p $ANDROID/base/json-simple/
 rsync -C -a $HTTPLIB $ANDROID/base/
 rsync -C -a $JSONLIB/ $ANDROID/base/json-simple/
 
-echo $PREPROCESS_FILES > $SYNC/preprocess-sources.mn
+for f in $PREPROCESS_FILES ; do
+    echo $f > $SYNC/preprocess-sources.mn
+done
 echo "Writing README."
 echo $WARNING > $ANDROID/base/sync/README.txt
 echo $WARNING > $ANDROID/base/httpclientandroidlib/README.txt
-echo $SOURCEFILES > $SYNC/java-sources.mn
-echo $HTTPLIBFILES $JSONLIBFILES $APACHEFILES > $SYNC/java-third-party-sources.mn
+for f in $SOURCEFILES ; do
+    echo $f > $SYNC/java-sources.mn
+done
+true > $SYNC/java-third-party-sources.mn
+for f in $HTTPLIBFILES $JSONLIBFILES $APACHEFILES ; do
+    echo $f >> $SYNC/java-third-party-sources.mn
+done
 
 echo "Copying resources..."
 # I'm guessing these go here.

--- a/fennec-copy-code.sh
+++ b/fennec-copy-code.sh
@@ -42,9 +42,25 @@ mkdir -p $ANDROID/base/json-simple/
 rsync -C -a $HTTPLIB $ANDROID/base/
 rsync -C -a $JSONLIB/ $ANDROID/base/json-simple/
 
+# Creating makefile for Mozilla
+MKFILE=$ANDROID/base/android-sync-files.mk
+echo "Creating makefile for including in the Mozilla build system at $MKFILE"
+echo "# $WARNING" > $MKFILE
+echo "SYNC_JAVA_FILES := $(echo $SOURCEFILES | xargs)" >> $MKFILE
+echo "SYNC_PP_JAVA_FILES := $(echo $PREPROCESS_FILES | xargs)" >> $MKFILE
+echo "SYNC_THIRDPARTY_JAVA_FILES := $(echo $HTTPLIBFILES $JSONLIBFILES $APACHEFILES | xargs)" >> $MKFILE
+echo "SYNC_RES_DRAWABLE := $(find res/drawable       -name '*.xml' -or -name '*.png' | sed 's,res/,mobile/android/base/resources/,' | xargs)" >> $MKFILE
+echo "SYNC_RES_DRAWABLE_LDPI := $(find res/drawable-ldpi  -name '*.xml' -or -name '*.png' | sed 's,res/,mobile/android/base/resources/,' | xargs)" >> $MKFILE
+echo "SYNC_RES_DRAWABLE_MDPI := $(find res/drawable-mdpi  -name '*.xml' -or -name '*.png' | sed 's,res/,mobile/android/base/resources/,' | xargs)" >> $MKFILE
+echo "SYNC_RES_DRAWABLE_HDPI := $(find find res/drawable-hdpi  -name '*.xml' -or -name '*.png' | sed 's,res/,mobile/android/base/resources/,' | xargs)" >> $MKFILE
+echo "SYNC_RES_LAYOUT := $(find res/layout         -name '*.xml' | xargs)"  >> $MKFILE
+echo "SYNC_RES_VALUES := res/values/sync_styles.xml" >> $MKFILE
+# Finished creating makefile for Mozilla
+
 for f in $PREPROCESS_FILES ; do
     echo $f > $SYNC/preprocess-sources.mn
 done
+
 echo "Writing README."
 echo $WARNING > $ANDROID/base/sync/README.txt
 echo $WARNING > $ANDROID/base/httpclientandroidlib/README.txt


### PR DESCRIPTION
Part of mozilla bug 752873, instead of having the tr overhead on every android build, move the work of generating one file per manifest file line to the android-sync code drop script.  Another approach is to generate a makefile that has the date from the manifests.  This avoids the shell call overhead entirely.
