### PR TITLE
Bug 750746 - Wrong instructions Fennec Sync setup screen.

### DIFF
--- a/res/layout/sync_setup_pair.xml
+++ b/res/layout/sync_setup_pair.xml
@@ -26,7 +26,7 @@
         style="@style/SyncTextItem"
         android:layout_marginTop="20dp"
         android:layout_marginBottom="10dp"
-        android:text="@string/sync_subtitle_connect" />
+        android:text="@string/sync_subtitle_pair" />
 
       <TextView
         style="@style/SyncLinkItem"

--- a/strings/strings.xml.in
+++ b/strings/strings.xml.in
@@ -5,7 +5,7 @@
   <!-- J-PAKE PIN Screen -->
   <string name="sync_subtitle_header">&sync.subtitle.header.label;</string>
   <string name="sync_subtitle_connect">&sync.subtitle.connectlocation.label;</string>
-  <string name="sync_subtitle_pair">&sync.subtitle.pair.label;</string>
+  <string name="sync_subtitle_pair">&sync.pair.connectlocation.label;</string>
   <string name="sync_pin_default">&sync.pin.oneline.label;</string>
   <string name="sync_link_show"><u>&sync.link.show.label;</u></string>
   <string name="sync_link_advancedsetup"><u>&sync.link.advancedsetup.label;</u></string>

--- a/strings/sync_strings.dtd.in
+++ b/strings/sync_strings.dtd.in
@@ -46,6 +46,7 @@
 
 <!-- Pair Device -->
 <!ENTITY sync.pair.tryagain.label 'Please try again.'>
+<!ENTITY sync.pair.connectlocation.label 'To activate your new device, select “Set up &syncBrand.shortName.label;” on the device, and then select “I Have an Account.”'>
 
 <!-- Firefox SyncAdapter Settings Screen -->
 <!ENTITY sync.settings.options.label 'Options'>


### PR DESCRIPTION
New string:

To activate your new device, select "Set up Sync" on the device, and then select "I Have an Account."

This pertains mainly to pairing with desktop.
