### PR TITLE
Bug 742111 - J-PAKE text entry boxes not focused in Pair a Device.

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSyncActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSyncActivity.java
@@ -542,6 +542,8 @@ public class SetupSyncActivity extends AccountAuthenticatorActivity {
           public void onTextChanged(CharSequence s, int start, int before, int count) {
           }
         });
+
+        row1.requestFocus();
       }
     });
   }


### PR DESCRIPTION
During accessibility testing, encountered cases where text box focusing didn't happen.
