### PR TITLE
Bug 754958 - Pairing aborts if device screen turns off.

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/AccountActivity.java
@@ -7,6 +7,7 @@ package org.mozilla.gecko.sync.setup.activities;
 import java.util.Locale;
 
 import org.mozilla.gecko.R;
+import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.setup.Constants;
 import org.mozilla.gecko.sync.setup.InvalidSyncKeyException;
 import org.mozilla.gecko.sync.setup.SyncAccounts;
@@ -22,6 +23,8 @@ import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.Log;
 import android.view.View;
+import android.view.Window;
+import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
@@ -55,6 +58,11 @@ public class AccountActivity extends AccountAuthenticatorActivity {
     mContext = getApplicationContext();
     Log.d(LOG_TAG, "AccountManager.get(" + mContext + ")");
     mAccountManager = AccountManager.get(mContext);
+
+    // Set "screen on" flag.
+    Logger.debug(LOG_TAG, "Setting screen-on flag.");
+    Window w = getWindow();
+    w.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
 
     // Find UI elements.
     usernameInput = (EditText) findViewById(R.id.usernameInput);

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSyncActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSyncActivity.java
@@ -29,6 +29,8 @@ import android.provider.Settings;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.View;
+import android.view.Window;
+import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.LinearLayout;
@@ -101,6 +103,12 @@ public class SetupSyncActivity extends AccountAuthenticatorActivity {
 
   public void finishResume(Account[] accts) {
     Logger.debug(LOG_TAG, "Finishing Resume after fetching accounts.");
+
+    // Set "screen on" flag.
+    Logger.debug(LOG_TAG, "Setting screen-on flag.");
+    Window w = getWindow();
+    w.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+
     if (accts.length == 0) { // Start J-PAKE for pairing if no accounts present.
       Logger.debug(LOG_TAG, "No accounts; starting J-PAKE receiver.");
       displayReceiveNoPin();


### PR DESCRIPTION
Added flags to keep device screen on. Added the flag to AccountActivity as well, because launching and canceling AccountActivity quickly sometimes led to the "screen on" flag not getting applied to the J-PAKE setup activity.
