### PR TITLE
Return focus to fennec after cancelled Sync Setup.

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSyncActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSyncActivity.java
@@ -598,7 +598,7 @@ public class SetupSyncActivity extends AccountAuthenticatorActivity {
 
   @Override
   public void onActivityResult(int requestCode, int resultCode, Intent data) {
-    switch(resultCode) {
+    switch (resultCode) {
     case Activity.RESULT_OK:
       // Setup completed in manual setup.
       finish();

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSyncActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSyncActivity.java
@@ -19,6 +19,7 @@ import org.mozilla.gecko.sync.setup.SyncAccounts.SyncAccountParameters;
 import android.accounts.Account;
 import android.accounts.AccountAuthenticatorActivity;
 import android.accounts.AccountManager;
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.net.ConnectivityManager;
@@ -182,7 +183,7 @@ public class SetupSyncActivity extends AccountAuthenticatorActivity {
   public void manualClickHandler(View target) {
     Intent accountIntent = new Intent(this, AccountActivity.class);
     accountIntent.setFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
-    startActivity(accountIntent);
+    startActivityForResult(accountIntent, 0);
     overridePendingTransition(0, 0);
   }
 
@@ -593,5 +594,14 @@ public class SetupSyncActivity extends AccountAuthenticatorActivity {
         }
       }
     });
+  }
+
+  @Override
+  public void onActivityResult(int requestCode, int resultCode, Intent data) {
+    switch(resultCode) {
+    case Activity.RESULT_OK:
+      // Setup completed in manual setup.
+      finish();
+    }
   }
 }


### PR DESCRIPTION
Finish J-PAKE setup screen if manual setup completed successfully. While testing a different fix, I found that one can return to the J-PAKE screen after successfully doing manual setup.
