### PR TITLE
Bug 755935 - Regression: J-PAKE code is refreshed on device rotation.

### DIFF
--- a/manifests/SyncAndroidManifest_activities.xml.in
+++ b/manifests/SyncAndroidManifest_activities.xml.in
@@ -1,7 +1,7 @@
         <activity
             android:icon="@drawable/sync_ic_launcher"
             android:label="@string/sync_app_name"
-            android:configChanges="orientation"
+            android:configChanges="keyboardHidden|orientation|screenSize"
             android:windowSoftInputMode="adjustResize|stateHidden"
             android:taskAffinity="org.mozilla.gecko.sync.setup"
             android:name="org.mozilla.gecko.sync.setup.activities.SetupSyncActivity" >


### PR DESCRIPTION
New configChanges parameter, screenSize, added in ICS.

http://developer.android.com/reference/android/R.attr.html#configChanges

Wasn't handled before.
