### PR TITLE
Bug 714657 - Persist earliest next sync in Android Account data rather t...

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/Utils.java
+++ b/src/main/java/org/mozilla/gecko/sync/Utils.java
@@ -176,22 +176,61 @@ public class Utils {
     return (long)(decimal * 1000);
   }
 
-  public static byte[] sha1(String utf8)
+  protected static byte[] sha1(String utf8)
       throws NoSuchAlgorithmException, UnsupportedEncodingException {
     MessageDigest sha1 = MessageDigest.getInstance("SHA-1");
     return sha1.digest(utf8.getBytes("UTF-8"));
   }
 
-  public static String sha1Base32(String utf8)
+  protected static String sha1Base32(String utf8)
       throws NoSuchAlgorithmException, UnsupportedEncodingException {
     return new Base32().encodeAsString(sha1(utf8)).toLowerCase(Locale.US);
   }
 
-  public static String getPrefsPath(String username, String serverURL)
-    throws NoSuchAlgorithmException, UnsupportedEncodingException {
-    return "sync.prefs." + sha1Base32(serverURL + ":" + username);
+  /**
+   * If we encounter characters not allowed by the API (as found for
+   * instance in an email address), hash the value.
+   * @param account
+   *        An account string.
+   * @return
+   *        An acceptable string.
+   * @throws UnsupportedEncodingException
+   * @throws NoSuchAlgorithmException
+   */
+  public static String usernameFromAccount(String account) throws NoSuchAlgorithmException, UnsupportedEncodingException {
+    if (account == null || account.equals("")) {
+      throw new IllegalArgumentException("No account name provided.");
+    }
+    if (account.matches("^[A-Za-z0-9._-]+$")) {
+      return account.toLowerCase(Locale.US);
+    }
+    return sha1Base32(account.toLowerCase(Locale.US));
   }
 
+  /**
+   * Get shared preferences path for a Sync account.
+   *
+   * @param username the Sync account name, optionally encoded with <code>Utils.usernameFromAccount</code>.
+   * @param serverURL the Sync account server URL.
+   * @return the path.
+   * @throws NoSuchAlgorithmException
+   * @throws UnsupportedEncodingException
+   */
+  public static String getPrefsPath(String username, String serverURL)
+    throws NoSuchAlgorithmException, UnsupportedEncodingException {
+    return "sync.prefs." + sha1Base32(serverURL + ":" + usernameFromAccount(username));
+  }
+
+  /**
+   * Get shared preferences for a Sync account.
+   *
+   * @param context Android <code>Context</code>.
+   * @param username the Sync account name, optionally encoded with <code>Utils.usernameFromAccount</code>.
+   * @param serverURL the Sync account server URL.
+   * @return a <code>SharedPreferences</code>.
+   * @throws NoSuchAlgorithmException
+   * @throws UnsupportedEncodingException
+   */
   public static SharedPreferences getSharedPreferences(Context context, String username, String serverURL) throws NoSuchAlgorithmException, UnsupportedEncodingException {
     String prefsPath = getPrefsPath(username, serverURL);
     Logger.debug(LOG_TAG, "Shared preferences: " + prefsPath);

--- a/src/main/java/org/mozilla/gecko/sync/Utils.java
+++ b/src/main/java/org/mozilla/gecko/sync/Utils.java
@@ -176,13 +176,13 @@ public class Utils {
     return (long)(decimal * 1000);
   }
 
-  protected static byte[] sha1(String utf8)
+  protected static byte[] sha1(final String utf8)
       throws NoSuchAlgorithmException, UnsupportedEncodingException {
     MessageDigest sha1 = MessageDigest.getInstance("SHA-1");
     return sha1.digest(utf8.getBytes("UTF-8"));
   }
 
-  protected static String sha1Base32(String utf8)
+  protected static String sha1Base32(final String utf8)
       throws NoSuchAlgorithmException, UnsupportedEncodingException {
     return new Base32().encodeAsString(sha1(utf8)).toLowerCase(Locale.US);
   }
@@ -197,7 +197,7 @@ public class Utils {
    * @throws UnsupportedEncodingException
    * @throws NoSuchAlgorithmException
    */
-  public static String usernameFromAccount(String account) throws NoSuchAlgorithmException, UnsupportedEncodingException {
+  public static String usernameFromAccount(final String account) throws NoSuchAlgorithmException, UnsupportedEncodingException {
     if (account == null || account.equals("")) {
       throw new IllegalArgumentException("No account name provided.");
     }
@@ -227,7 +227,7 @@ public class Utils {
    * @param context Android <code>Context</code>.
    * @param username the Sync account name, optionally encoded with <code>Utils.usernameFromAccount</code>.
    * @param serverURL the Sync account server URL.
-   * @return a <code>SharedPreferences</code>.
+   * @return a <code>SharedPreferences</code> instance.
    * @throws NoSuchAlgorithmException
    * @throws UnsupportedEncodingException
    */

--- a/src/main/java/org/mozilla/gecko/sync/crypto/KeyBundle.java
+++ b/src/main/java/org/mozilla/gecko/sync/crypto/KeyBundle.java
@@ -5,16 +5,15 @@
 package org.mozilla.gecko.sync.crypto;
 
 import java.io.UnsupportedEncodingException;
+import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 
 import javax.crypto.KeyGenerator;
 import javax.crypto.Mac;
 
 import org.mozilla.apache.commons.codec.binary.Base64;
 import org.mozilla.gecko.sync.Utils;
-import java.security.InvalidKeyException;
-import java.util.Arrays;
-import java.util.Locale;
 
 public class KeyBundle {
     private static final String KEY_ALGORITHM_SPEC = "AES";
@@ -27,29 +26,6 @@ public class KeyBundle {
     private static final byte[] EMPTY_BYTES      = {};
     private static final byte[] ENCR_INPUT_BYTES = {1};
     private static final byte[] HMAC_INPUT_BYTES = {2};
-
-    /**
-     * If we encounter characters not allowed by the API (as found for
-     * instance in an email address), hash the value.
-     * @param account
-     *        An account string.
-     * @return
-     *        An acceptable string.
-     * @throws UnsupportedEncodingException
-     * @throws NoSuchAlgorithmException
-     */
-    public static String usernameFromAccount(String account) throws NoSuchAlgorithmException, UnsupportedEncodingException {
-      if (account == null || account.equals("")) {
-        throw new IllegalArgumentException("No account name provided.");
-      }
-      if (account.matches("^[A-Za-z0-9._-]+$")) {
-        return account.toLowerCase(Locale.US);
-      }
-      return Utils.sha1Base32(account.toLowerCase(Locale.US));
-    }
-
-    // If we encounter characters not allowed by the API (as found for
-    // instance in an email address), hash the value.
 
     /*
      * Mozilla's use of HKDF for getting keys from the Sync Key string.
@@ -67,7 +43,7 @@ public class KeyBundle {
       }
       // Hash appropriately.
       try {
-        username = usernameFromAccount(username);
+        username = Utils.usernameFromAccount(username);
       } catch (NoSuchAlgorithmException e) {
         throw new IllegalArgumentException("Invalid username.");
       } catch (UnsupportedEncodingException e) {

--- a/src/main/java/org/mozilla/gecko/sync/setup/SyncAccounts.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/SyncAccounts.java
@@ -215,8 +215,8 @@ public class SyncAccounts {
     Logger.debug(LOG_TAG, "Finished setting syncables.");
 
     // TODO: correctly implement Sync Options.
-    Logger.info(LOG_TAG, "Clearing preferences for this account.");
     try {
+      Logger.info(LOG_TAG, "Clearing preferences path " + Utils.getPrefsPath(username, serverURL) + " for this account.");
       SharedPreferences.Editor editor = Utils.getSharedPreferences(context, username, serverURL).edit().clear();
       if (syncAccount.clusterURL != null) {
         editor.putString(SyncConfiguration.PREF_CLUSTER_URL, syncAccount.clusterURL);

--- a/src/main/java/org/mozilla/gecko/sync/setup/SyncAccounts.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/SyncAccounts.java
@@ -214,6 +214,8 @@ public class SyncAccounts {
     // TODO: for each, also add to res/xml to make visible in account settings
     Logger.debug(LOG_TAG, "Finished setting syncables.");
 
+    // Purging global prefs assumes we have only a single Sync account at one time.
+    // TODO: Bug 761682: don't do anything with global prefs here.
     Logger.info(LOG_TAG, "Clearing global prefs.");
     SyncAdapter.purgeGlobalPrefs(context);
 

--- a/src/main/java/org/mozilla/gecko/sync/setup/SyncAccounts.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/SyncAccounts.java
@@ -214,7 +214,9 @@ public class SyncAccounts {
     // TODO: for each, also add to res/xml to make visible in account settings
     Logger.debug(LOG_TAG, "Finished setting syncables.");
 
-    // TODO: correctly implement Sync Options.
+    Logger.info(LOG_TAG, "Clearing global prefs.");
+    SyncAdapter.purgeGlobalPrefs(context);
+
     try {
       Logger.info(LOG_TAG, "Clearing preferences path " + Utils.getPrefsPath(username, serverURL) + " for this account.");
       SharedPreferences.Editor editor = Utils.getSharedPreferences(context, username, serverURL).edit().clear();

--- a/src/main/java/org/mozilla/gecko/sync/setup/SyncAuthenticatorService.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/SyncAuthenticatorService.java
@@ -8,7 +8,7 @@ import java.io.UnsupportedEncodingException;
 import java.security.NoSuchAlgorithmException;
 
 import org.mozilla.gecko.sync.Logger;
-import org.mozilla.gecko.sync.crypto.KeyBundle;
+import org.mozilla.gecko.sync.Utils;
 import org.mozilla.gecko.sync.setup.activities.SetupSyncActivity;
 
 import android.accounts.AbstractAccountAuthenticator;
@@ -118,7 +118,7 @@ public class SyncAuthenticatorService extends Service {
 
         // Username after hashing.
         try {
-          String username = KeyBundle.usernameFromAccount(account.name);
+          String username = Utils.usernameFromAccount(account.name);
           Logger.pii(LOG_TAG, "Account " + account.name + " hashes to " + username);
           Logger.info(LOG_TAG, "Setting username. Null? " + (username == null));
           result.putString(Constants.OPTION_USERNAME, username);

--- a/src/main/java/org/mozilla/gecko/sync/setup/auth/AccountAuthenticator.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/auth/AccountAuthenticator.java
@@ -9,7 +9,7 @@ import java.util.Queue;
 
 import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.ThreadPool;
-import org.mozilla.gecko.sync.crypto.KeyBundle;
+import org.mozilla.gecko.sync.Utils;
 import org.mozilla.gecko.sync.setup.activities.AccountActivity;
 
 import android.util.Log;
@@ -52,7 +52,7 @@ public class AccountAuthenticator {
 
     // Calculate and save username hash.
     try {
-      username = KeyBundle.usernameFromAccount(account);
+      username = Utils.usernameFromAccount(account);
     } catch (Exception e) {
       abort(AuthenticationResult.FAILURE_OTHER, e);
       return;

--- a/src/main/java/org/mozilla/gecko/sync/syncadapter/SyncAdapter.java
+++ b/src/main/java/org/mozilla/gecko/sync/syncadapter/SyncAdapter.java
@@ -68,25 +68,31 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements GlobalSe
     mAccountManager = AccountManager.get(context);
   }
 
-  private SharedPreferences getGlobalPrefs() {
-    return mContext.getSharedPreferences("sync.prefs.global", SHARED_PREFERENCES_MODE);
+  public static SharedPreferences getGlobalPrefs(Context context) {
+    return context.getSharedPreferences("sync.prefs.global", SHARED_PREFERENCES_MODE);
+  }
+
+  public static void purgeGlobalPrefs(Context context) {
+    getGlobalPrefs(context).edit().clear().commit();
+    final SharedPreferences prefs = context.getSharedPreferences("sync.prefs", SHARED_PREFERENCES_MODE);
+    prefs.edit().remove("global").commit();
   }
 
   /**
    * Backoff.
    */
   public synchronized long getEarliestNextSync() {
-    SharedPreferences sharedPreferences = getGlobalPrefs();
+    SharedPreferences sharedPreferences = getGlobalPrefs(mContext);
     return sharedPreferences.getLong(PREFS_EARLIEST_NEXT_SYNC, 0);
   }
   public synchronized void setEarliestNextSync(long next) {
-    SharedPreferences sharedPreferences = getGlobalPrefs();
+    SharedPreferences sharedPreferences = getGlobalPrefs(mContext);
     Editor edit = sharedPreferences.edit();
     edit.putLong(PREFS_EARLIEST_NEXT_SYNC, next);
     edit.commit();
   }
   public synchronized void extendEarliestNextSync(long next) {
-    SharedPreferences sharedPreferences = getGlobalPrefs();
+    SharedPreferences sharedPreferences = getGlobalPrefs(mContext);
     if (sharedPreferences.getLong(PREFS_EARLIEST_NEXT_SYNC, 0) >= next) {
       return;
     }
@@ -96,17 +102,17 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements GlobalSe
   }
 
   public synchronized boolean getShouldInvalidateAuthToken() {
-    SharedPreferences sharedPreferences = getGlobalPrefs();
+    SharedPreferences sharedPreferences = getGlobalPrefs(mContext);
     return sharedPreferences.getBoolean(PREFS_INVALIDATE_AUTH_TOKEN, false);
   }
   public synchronized void clearShouldInvalidateAuthToken() {
-    SharedPreferences sharedPreferences = getGlobalPrefs();
+    SharedPreferences sharedPreferences = getGlobalPrefs(mContext);
     Editor edit = sharedPreferences.edit();
     edit.remove(PREFS_INVALIDATE_AUTH_TOKEN);
     edit.commit();
   }
   public synchronized void setShouldInvalidateAuthToken() {
-    SharedPreferences sharedPreferences = getGlobalPrefs();
+    SharedPreferences sharedPreferences = getGlobalPrefs(mContext);
     Editor edit = sharedPreferences.edit();
     edit.putBoolean(PREFS_INVALIDATE_AUTH_TOKEN, true);
     edit.commit();
@@ -515,12 +521,12 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements GlobalSe
   }
 
   public synchronized boolean getClusterURLIsStale() {
-    SharedPreferences sharedPreferences = getGlobalPrefs();
+    SharedPreferences sharedPreferences = getGlobalPrefs(mContext);
     return sharedPreferences.getBoolean(PREFS_CLUSTER_URL_IS_STALE, false);
   }
 
   public synchronized void setClusterURLIsStale(boolean clusterURLIsStale) {
-    SharedPreferences sharedPreferences = getGlobalPrefs();
+    SharedPreferences sharedPreferences = getGlobalPrefs(mContext);
     Editor edit = sharedPreferences.edit();
     edit.putBoolean(PREFS_CLUSTER_URL_IS_STALE, clusterURLIsStale);
     edit.commit();

--- a/src/main/java/org/mozilla/gecko/sync/syncadapter/SyncAdapter.java
+++ b/src/main/java/org/mozilla/gecko/sync/syncadapter/SyncAdapter.java
@@ -74,8 +74,6 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements GlobalSe
 
   public static void purgeGlobalPrefs(Context context) {
     getGlobalPrefs(context).edit().clear().commit();
-    final SharedPreferences prefs = context.getSharedPreferences("sync.prefs", SHARED_PREFERENCES_MODE);
-    prefs.edit().remove("global").commit();
   }
 
   /**

--- a/src/test/java/org/mozilla/android/sync/net/test/TestAccountAuthenticatorStage.java
+++ b/src/test/java/org/mozilla/android/sync/net/test/TestAccountAuthenticatorStage.java
@@ -18,7 +18,6 @@ import org.junit.Test;
 import org.mozilla.android.sync.test.helpers.HTTPServerTestHelper;
 import org.mozilla.android.sync.test.helpers.MockServer;
 import org.mozilla.android.sync.test.helpers.WaitHelper;
-import org.mozilla.android.sync.test.helpers.WaitHelper.InnerError;
 import org.mozilla.gecko.sync.setup.auth.AuthenticateAccountStage;
 import org.mozilla.gecko.sync.setup.auth.AuthenticateAccountStage.AuthenticateAccountStageDelegate;
 import org.simpleframework.http.Request;
@@ -32,8 +31,6 @@ import ch.boye.httpclientandroidlib.HttpResponse;
  *
  */
 public class TestAccountAuthenticatorStage {
-  private final String LOG_TAG = "TestAcctAuthStage";
-
   private static final int TEST_PORT      = 15325;
   private static final String TEST_SERVER = "http://localhost:" + TEST_PORT;
 

--- a/src/test/java/org/mozilla/android/sync/test/TestUtils.java
+++ b/src/test/java/org/mozilla/android/sync/test/TestUtils.java
@@ -5,12 +5,14 @@ package org.mozilla.android.sync.test;
 
 import static org.junit.Assert.assertEquals;
 
+import java.io.UnsupportedEncodingException;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 
 import org.junit.Test;
 import org.mozilla.gecko.sync.Utils;
 
-public class TestUtils {
+public class TestUtils extends Utils {
 
   @Test
   public void testGenerateGUID() {
@@ -30,5 +32,23 @@ public class TestUtils {
     assertEquals("test1, test2", Utils.toCommaSeparatedString(xs));
     xs.add("test3");
     assertEquals("test1, test2, test3", Utils.toCommaSeparatedString(xs));
+  }
+
+  @Test
+  public void testUsernameFromAccount() throws NoSuchAlgorithmException, UnsupportedEncodingException {
+    assertEquals("xee7ffonluzpdp66l6xgpyh2v2w6ojkc", Utils.sha1Base32("foobar@baz.com"));
+    assertEquals("xee7ffonluzpdp66l6xgpyh2v2w6ojkc", Utils.usernameFromAccount("foobar@baz.com"));
+    assertEquals("xee7ffonluzpdp66l6xgpyh2v2w6ojkc", Utils.usernameFromAccount("FooBar@Baz.com"));
+    assertEquals("xee7ffonluzpdp66l6xgpyh2v2w6ojkc", Utils.usernameFromAccount("xee7ffonluzpdp66l6xgpyh2v2w6ojkc"));
+    assertEquals("foobar",                           Utils.usernameFromAccount("foobar"));
+    assertEquals("foobar",                           Utils.usernameFromAccount("FOOBAr"));
+  }
+
+  @Test
+  public void testGetPrefsPath() throws NoSuchAlgorithmException, UnsupportedEncodingException {
+    assertEquals("ore7dlrwqi6xr7honxdtpvmh6tly4r7k", Utils.sha1Base32("test.url.com:xee7ffonluzpdp66l6xgpyh2v2w6ojkc"));
+    assertEquals("sync.prefs.ore7dlrwqi6xr7honxdtpvmh6tly4r7k", Utils.getPrefsPath("foobar@baz.com", "test.url.com"));
+    assertEquals("sync.prefs.ore7dlrwqi6xr7honxdtpvmh6tly4r7k", Utils.getPrefsPath("FooBar@Baz.com", "test.url.com"));
+    assertEquals("sync.prefs.ore7dlrwqi6xr7honxdtpvmh6tly4r7k", Utils.getPrefsPath("xee7ffonluzpdp66l6xgpyh2v2w6ojkc", "test.url.com"));
   }
 }

--- a/src/test/java/org/mozilla/android/sync/test/integration/TestFreshStart.java
+++ b/src/test/java/org/mozilla/android/sync/test/integration/TestFreshStart.java
@@ -34,6 +34,7 @@ import org.mozilla.gecko.sync.MetaGlobal;
 import org.mozilla.gecko.sync.NonObjectJSONException;
 import org.mozilla.gecko.sync.SyncConfiguration;
 import org.mozilla.gecko.sync.SyncConfigurationException;
+import org.mozilla.gecko.sync.Utils;
 import org.mozilla.gecko.sync.crypto.CryptoException;
 import org.mozilla.gecko.sync.crypto.KeyBundle;
 import org.mozilla.gecko.sync.delegates.FreshStartDelegate;
@@ -110,7 +111,7 @@ public class TestFreshStart {
       return;
     }
 
-    assertEquals(TEST_USERNAME, KeyBundle.usernameFromAccount(TEST_ACCOUNT));
+    assertEquals(TEST_USERNAME, Utils.usernameFromAccount(TEST_ACCOUNT));
     session.config.enabledEngineNames = new HashSet<String>();
     session.config.enabledEngineNames.add("bookmarks");
     session.config.enabledEngineNames.add("clients");

--- a/src/test/java/org/mozilla/gecko/sync/crypto/test/TestKeyBundle.java
+++ b/src/test/java/org/mozilla/gecko/sync/crypto/test/TestKeyBundle.java
@@ -9,26 +9,14 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.UnsupportedEncodingException;
-import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 
 import org.junit.Test;
 import org.mozilla.apache.commons.codec.binary.Base64;
-import org.mozilla.gecko.sync.Utils;
 import org.mozilla.gecko.sync.crypto.CryptoException;
 import org.mozilla.gecko.sync.crypto.KeyBundle;
 
 public class TestKeyBundle {
-  @Test
-  public void testUsernameFromAccount() throws NoSuchAlgorithmException, UnsupportedEncodingException {
-    assertEquals("xee7ffonluzpdp66l6xgpyh2v2w6ojkc", Utils.sha1Base32("foobar@baz.com"));
-    assertEquals("xee7ffonluzpdp66l6xgpyh2v2w6ojkc", KeyBundle.usernameFromAccount("foobar@baz.com"));
-    assertEquals("xee7ffonluzpdp66l6xgpyh2v2w6ojkc", KeyBundle.usernameFromAccount("FooBar@Baz.com"));
-    assertEquals("xee7ffonluzpdp66l6xgpyh2v2w6ojkc", KeyBundle.usernameFromAccount("xee7ffonluzpdp66l6xgpyh2v2w6ojkc"));
-    assertEquals("foobar",                           KeyBundle.usernameFromAccount("foobar"));
-    assertEquals("foobar",                           KeyBundle.usernameFromAccount("FOOBAr"));
-  }
-
   @Test
   public void testCreateKeyBundle() throws UnsupportedEncodingException, CryptoException {
     String username              = "smqvooxj664hmrkrv6bw4r4vkegjhkns";

--- a/test/src/org/mozilla/gecko/sync/setup/test/TestSyncAccounts.java
+++ b/test/src/org/mozilla/gecko/sync/setup/test/TestSyncAccounts.java
@@ -271,7 +271,8 @@ public class TestSyncAccounts extends AndroidSyncTestCase {
   }
 
   /**
-   * Verify that creating an account wipes stale settings in Shared Preferences.
+   * Verify that creating an account wipes stale settings in Shared Preferences,
+   * and wipes global prefs.
    */
   public void testCreatingWipesSharedPrefs() throws Exception {
     final String TEST_PREFERENCE = "testPreference";
@@ -281,6 +282,8 @@ public class TestSyncAccounts extends AndroidSyncTestCase {
     prefs.edit().putString(SyncConfiguration.PREF_SYNC_ID, TEST_SYNC_ID).commit();
     prefs.edit().putString(TEST_PREFERENCE, TEST_SYNC_ID).commit();
 
+    SyncAdapter.getGlobalPrefs(context).edit().putString(TEST_PREFERENCE, TEST_SYNC_ID);
+
     syncAccount = new SyncAccountParameters(context, null,
         TEST_USERNAME, TEST_SYNCKEY, TEST_PASSWORD, TEST_SERVERURL);
     account = SyncAccounts.createSyncAccount(syncAccount);
@@ -288,5 +291,7 @@ public class TestSyncAccounts extends AndroidSyncTestCase {
     // All values deleted (known and unknown).
     assertNull(prefs.getString(TEST_PREFERENCE, null));
     assertNull(prefs.getString(TEST_SYNC_ID, null));
+    // And global value gone too.
+    assertNull(SyncAdapter.getGlobalPrefs(context).getString(TEST_PREFERENCE, null));
   }
 }


### PR DESCRIPTION
...han "sync.prefs.global" Shared Preferences.

Long term sync.prefs.globals should go away, and certainly next sync
is Account specific, so this seemed the right thing to do.  I made
next sync an Account datum because we want to access it without
invoking the full Account Manager callback needed to retrieve encoded
username and server URL.
