### PR TITLE
Bug 730142 - filling synchronizer

### DIFF
--- a/src/main/java/org/mozilla/android/sync/test/helpers/BaseMockServerSyncStage.java
+++ b/src/main/java/org/mozilla/android/sync/test/helpers/BaseMockServerSyncStage.java
@@ -66,6 +66,11 @@ public abstract class BaseMockServerSyncStage extends ServerSyncStage {
   }
 
   @Override
+  protected int getBatchSize() {
+    return 5000;
+  }
+
+  @Override
   protected Repository wrappedServerRepo()
   throws NoCollectionKeysSetException, URISyntaxException {
     return getRemoteRepository();

--- a/src/main/java/org/mozilla/gecko/sync/repositories/Server11RepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/Server11RepositorySession.java
@@ -9,13 +9,16 @@ import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.json.simple.JSONArray;
+import org.json.simple.parser.ParseException;
 import org.mozilla.gecko.sync.CryptoRecord;
 import org.mozilla.gecko.sync.DelayedWorkTracker;
 import org.mozilla.gecko.sync.ExtendedJSONObject;
@@ -26,6 +29,7 @@ import org.mozilla.gecko.sync.Server11RecordPostFailedException;
 import org.mozilla.gecko.sync.UnexpectedJSONException;
 import org.mozilla.gecko.sync.crypto.KeyBundle;
 import org.mozilla.gecko.sync.net.SyncStorageCollectionRequest;
+import org.mozilla.gecko.sync.net.SyncStorageCollectionRequestDelegate;
 import org.mozilla.gecko.sync.net.SyncStorageRequest;
 import org.mozilla.gecko.sync.net.SyncStorageRequestDelegate;
 import org.mozilla.gecko.sync.net.SyncStorageResponse;
@@ -119,6 +123,8 @@ public class Server11RepositorySession extends RepositorySession {
     // So that we can clean up.
     private SyncStorageCollectionRequest request;
 
+    public AtomicInteger numRecordsProcessed = new AtomicInteger(0);
+
     public void setRequest(SyncStorageCollectionRequest request) {
       this.request = request;
     }
@@ -152,15 +158,40 @@ public class Server11RepositorySession extends RepositorySession {
       final long normalizedTimestamp = getNormalizedTimestamp(response);
       Logger.debug(LOG_TAG, "Fetch completed. Timestamp is " + normalizedTimestamp);
 
+      final AtomicInteger numRecordsExpected = new AtomicInteger(-1);
+      try {
+        numRecordsExpected.set(response.weaveRecords());
+      } catch (NumberFormatException e) {
+        // We just won't verify.
+      }
+
       // When we're done processing other events, finish.
       workTracker.delayWorkItem(new Runnable() {
         @Override
         public void run() {
-          Logger.debug(LOG_TAG, "Delayed onFetchCompleted running.");
-          // TODO: verify number of returned records.
-          delegate.onFetchCompleted(normalizedTimestamp);
+          finish(numRecordsExpected.get(), numRecordsProcessed.get(), normalizedTimestamp);
         }
       });
+    }
+
+    /**
+     * Called after a successful request.
+     *
+     * @param expected The number of records expected, based on the server's response.
+     * @param gotten The number of records received and processed.
+     * @param end The timestamp of the server's response.
+     */
+    public void finish(int expected, int gotten, long end) {
+      if (expected >= 0 && expected != gotten) {
+        Logger.debug(LOG_TAG, "Expected "
+            + expected + " records but got "
+            + gotten + " records, failing.");
+        delegate.onFetchFailed(null, null);
+        return;
+      }
+
+      Logger.debug(LOG_TAG, "Expected and got " + expected + " records; running delayed onFetchCompleted.");
+      delegate.onFetchCompleted(end);
     }
 
     @Override
@@ -188,6 +219,7 @@ public class Server11RepositorySession extends RepositorySession {
       workTracker.incrementOutstanding();
       try {
         delegate.onFetchedRecord(record);
+        numRecordsProcessed.incrementAndGet();
       } catch (Exception ex) {
         Logger.warn(LOG_TAG, "Got exception calling onFetchedRecord with WBO.", ex);
         // TODO: handle this better.
@@ -203,7 +235,6 @@ public class Server11RepositorySession extends RepositorySession {
       return null;
     }
   }
-
 
   Server11Repository serverRepository;
   AtomicLong uploadTimestamp = new AtomicLong(0);
@@ -225,6 +256,25 @@ public class Server11RepositorySession extends RepositorySession {
     serverRepository = (Server11Repository) repository;
   }
 
+  /**
+   * URL-encode the provided string. If the input is null,
+   * the empty string is returned.
+   *
+   * @param in the string to encode.
+   * @return a URL-encoded version of the input.
+   */
+  protected static String encode(String in) {
+    if (in == null) {
+      return "";
+    }
+    try {
+      return URLEncoder.encode(in, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      // Will never occur.
+      return null;
+    }
+  }
+
   private String flattenIDs(String[] guids) {
     // Consider using Utils.toDelimitedString if and when the signature changes
     // to Collection<String> guids.
@@ -236,17 +286,92 @@ public class Server11RepositorySession extends RepositorySession {
     }
     StringBuilder b = new StringBuilder();
     for (String guid : guids) {
-      b.append(guid);
+      b.append(encode(guid));
       b.append(",");
     }
     return b.substring(0, b.length() - 1);
   }
 
+  public class RequestGuidsDelegateAdapter extends SyncStorageCollectionRequestDelegate {
+    public ArrayList<String> guids = new ArrayList<String>();
+
+    public RepositorySessionGuidsSinceDelegate delegate = null;
+
+    public RequestGuidsDelegateAdapter(RepositorySessionGuidsSinceDelegate delegate) {
+      this.delegate = delegate;
+    }
+
+    // So that we can clean up.
+    private SyncStorageCollectionRequest request;
+
+    public void setRequest(SyncStorageCollectionRequest request) {
+      this.request = request;
+    }
+
+    private void removeRequestFromPending() {
+      if (this.request == null) {
+        return;
+      }
+      pending.remove(this.request);
+      this.request = null;
+    }
+
+    @Override
+    public void handleRequestProgress(String progress) {
+      try {
+        guids.add((String) ExtendedJSONObject.parse(progress));
+      } catch (IOException e) {
+      } catch (ParseException e) {
+      }
+    }
+
+    @Override
+    public String credentials() {
+      return serverRepository.credentialsSource.credentials();
+    }
+
+    @Override
+    public String ifUnmodifiedSince() {
+      return null;
+    }
+
+    @Override
+    public void handleRequestSuccess(SyncStorageResponse response) {
+      Logger.debug(LOG_TAG, "guidsSince done.");
+      delegate.onGuidsSinceSucceeded(guids);
+    }
+
+    @Override
+    public void handleRequestFailure(SyncStorageResponse response) {
+      this.handleRequestError(new HTTPFailureException(response));
+    }
+
+    @Override
+    public void handleRequestError(Exception ex) {
+      removeRequestFromPending();
+      Logger.warn(LOG_TAG, "guidsSince got error.", ex);
+      delegate.onGuidsSinceFailed(ex);
+    }
+  }
+
   @Override
   public void guidsSince(long timestamp,
                          RepositorySessionGuidsSinceDelegate delegate) {
-    // TODO Auto-generated method stub
+    URI collectionURI;
+    try {
+      collectionURI = serverRepository.collectionURI(false, timestamp, -1, "oldest", null);
+    } catch (URISyntaxException e) {
+      delegate.onGuidsSinceFailed(e);
+      return;
+    }
 
+    SyncStorageCollectionRequest request = new SyncStorageCollectionRequest(collectionURI);
+    RequestGuidsDelegateAdapter adapter = new RequestGuidsDelegateAdapter(delegate);
+    // So it can clean up.
+    adapter.setRequest(request);
+    request.delegate = adapter;
+    pending.add(request);
+    request.get();
   }
 
   protected void fetchWithParameters(long newer,
@@ -265,14 +390,6 @@ public class Server11RepositorySession extends RepositorySession {
     delegate.setRequest(request);
     pending.add(request);
     request.get();
-  }
-
-  public void fetchSince(long timestamp, long limit, String sort, RepositorySessionFetchRecordsDelegate delegate) {
-    try {
-      this.fetchWithParameters(timestamp, limit, true, sort, null, new RequestFetchDelegateAdapter(delegate));
-    } catch (URISyntaxException e) {
-      delegate.onFetchFailed(e, null);
-    }
   }
 
   @Override
@@ -298,7 +415,9 @@ public class Server11RepositorySession extends RepositorySession {
     // TODO: watch out for URL length limits!
     try {
       String ids = flattenIDs(guids);
-      this.fetchWithParameters(-1, -1, true, "index", ids, new RequestFetchDelegateAdapter(delegate));
+      long limit = -1;
+      String sort = serverRepository.getDefaultSort();
+      this.fetchWithParameters(-1, limit, true, sort, ids, new RequestFetchDelegateAdapter(delegate));
     } catch (URISyntaxException e) {
       delegate.onFetchFailed(e, null);
     }

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/AndroidBrowserRepositorySession.java
@@ -205,11 +205,11 @@ public abstract class AndroidBrowserRepositorySession extends StoreTrackingRepos
 
       ArrayList<String> guids;
       try {
+        guids = new ArrayList<String>();
         if (!cur.moveToFirst()) {
-          delegate.onGuidsSinceSucceeded(new String[] {});
+          delegate.onGuidsSinceSucceeded(guids);
           return;
         }
-        guids = new ArrayList<String>();
         while (!cur.isAfterLast()) {
           guids.add(RepoUtils.getStringFromCursor(cur, "guid"));
           cur.moveToNext();
@@ -218,10 +218,7 @@ public abstract class AndroidBrowserRepositorySession extends StoreTrackingRepos
         Logger.debug(LOG_TAG, "Closing cursor after guidsSince.");
         cur.close();
       }
-
-      String guidsArray[] = new String[guids.size()];
-      guids.toArray(guidsArray);
-      delegate.onGuidsSinceSucceeded(guidsArray);
+      delegate.onGuidsSinceSucceeded(guids);
     }
   }
 

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/FennecTabsRepository.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/FennecTabsRepository.java
@@ -4,6 +4,8 @@
 
 package org.mozilla.gecko.sync.repositories.android;
 
+import java.util.ArrayList;
+
 import org.mozilla.gecko.db.BrowserContract;
 import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.repositories.InactiveSessionException;
@@ -92,7 +94,7 @@ public class FennecTabsRepository extends Repository {
     public void guidsSince(long timestamp,
                            RepositorySessionGuidsSinceDelegate delegate) {
       // Empty until Bug 730039 lands.
-      delegate.onGuidsSinceSucceeded(new String[] {});
+      delegate.onGuidsSinceSucceeded(new ArrayList<String>());
     }
 
     @Override

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/FormHistoryRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/FormHistoryRepositorySession.java
@@ -170,8 +170,7 @@ public class FormHistoryRepositorySession extends
           }
         }
 
-        String guidsArray[] = guids.toArray(new String[0]);
-        delegate.onGuidsSinceSucceeded(guidsArray);
+        delegate.onGuidsSinceSucceeded(guids);
       }
     };
     delegateQueue.execute(command);

--- a/src/main/java/org/mozilla/gecko/sync/repositories/android/PasswordsRepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/android/PasswordsRepositorySession.java
@@ -116,8 +116,7 @@ public class PasswordsRepositorySession extends
           delegate.onGuidsSinceFailed(e);
           return;
         }
-        String[] guidStrings = new String[guids.size()];
-        delegate.onGuidsSinceSucceeded(guids.toArray(guidStrings));
+        delegate.onGuidsSinceSucceeded(guids);
       }
     };
 

--- a/src/main/java/org/mozilla/gecko/sync/repositories/delegates/RepositorySessionGuidsSinceDelegate.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/delegates/RepositorySessionGuidsSinceDelegate.java
@@ -4,7 +4,9 @@
 
 package org.mozilla.gecko.sync.repositories.delegates;
 
+import java.util.Collection;
+
 public interface RepositorySessionGuidsSinceDelegate {
   public void onGuidsSinceFailed(Exception ex);
-  public void onGuidsSinceSucceeded(String[] guids);
+  public void onGuidsSinceSucceeded(Collection<String> guids);
 }

--- a/src/main/java/org/mozilla/gecko/sync/stage/AndroidBrowserBookmarksServerSyncStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/AndroidBrowserBookmarksServerSyncStage.java
@@ -64,6 +64,16 @@ public class AndroidBrowserBookmarksServerSyncStage extends ServerSyncStage {
     return new BookmarkRecordFactory();
   }
 
+  /**
+   * We assume that we get the entire bookmark folder tree in a single session
+   * so that we can re-parent correctly. Therefore, we really can't get records
+   * in small batches.
+   */
+  @Override
+  protected int getBatchSize() {
+    return (int) BOOKMARKS_REQUEST_LIMIT;
+  }
+
   @Override
   protected boolean isEnabled() throws MetaGlobalException {
     if (session.getContext() == null) {

--- a/src/main/java/org/mozilla/gecko/sync/stage/AndroidBrowserHistoryServerSyncStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/AndroidBrowserHistoryServerSyncStage.java
@@ -65,6 +65,11 @@ public class AndroidBrowserHistoryServerSyncStage extends ServerSyncStage {
   }
 
   @Override
+  protected int getBatchSize() {
+    return (int) HISTORY_REQUEST_LIMIT;
+  }
+
+  @Override
   protected boolean isEnabled() throws MetaGlobalException {
     if (session == null || session.getContext() == null) {
       return false;

--- a/src/main/java/org/mozilla/gecko/sync/stage/FennecTabsServerSyncStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/FennecTabsServerSyncStage.java
@@ -53,4 +53,9 @@ public class FennecTabsServerSyncStage extends ServerSyncStage {
   protected RecordFactory getRecordFactory() {
     return new FennecTabsRecordFactory();
   }
+
+  @Override
+  protected int getBatchSize() {
+    return 50;
+  }
 }

--- a/src/main/java/org/mozilla/gecko/sync/stage/FormHistoryServerSyncStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/FormHistoryServerSyncStage.java
@@ -21,7 +21,7 @@ public class FormHistoryServerSyncStage extends ServerSyncStage {
   // Eventually this kind of sync stage will be data-driven,
   // and all this hard-coding can go away.
   private static final String FORM_HISTORY_SORT          = "index";
-  private static final long   FORM_HISTORY_REQUEST_LIMIT = 5000;         // Sanity limit.
+  private static final long   FORM_HISTORY_REQUEST_LIMIT = 200;         // Sanity limit.
 
   public FormHistoryServerSyncStage(GlobalSession session) {
     super(session);
@@ -75,5 +75,10 @@ public class FormHistoryServerSyncStage extends ServerSyncStage {
   @Override
   protected RecordFactory getRecordFactory() {
     return new FormHistoryRecordFactory();
+  }
+
+  @Override
+  protected int getBatchSize() {
+    return (int) FORM_HISTORY_REQUEST_LIMIT;
   }
 }

--- a/src/main/java/org/mozilla/gecko/sync/stage/PasswordsServerSyncStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/PasswordsServerSyncStage.java
@@ -52,4 +52,13 @@ public class PasswordsServerSyncStage extends ServerSyncStage {
       return r;
     }
   }
+
+  /**
+   * Password insertion is usually very slow, so we aggressively limit the
+   * number of records fetched per batch.
+   */
+  @Override
+  protected int getBatchSize() {
+    return 50;
+  }
 }

--- a/src/main/java/org/mozilla/gecko/sync/synchronizer/FillingGuidsManager.java
+++ b/src/main/java/org/mozilla/gecko/sync/synchronizer/FillingGuidsManager.java
@@ -1,0 +1,54 @@
+package org.mozilla.gecko.sync.synchronizer;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Persist a collection of GUIDs that need to be fetched in the future.
+ */
+public interface FillingGuidsManager {
+  /**
+   * Persist GUIDs that are fresher than all existing GUIDs.
+   * <p>
+   * If possible, order GUIDs from stalest to freshest.
+   *
+   * @param guids fresh GUIDs.
+   * @throws Exception
+   */
+  public void addFreshGuids(Collection<String> guids) throws Exception;
+
+  /**
+   * Get GUIDs to fetch next.
+   * <p>
+   * If possible, order GUIDs from freshest to stalest.
+   *
+   * @return GUIDs or null if there are none to fetch.
+   * @throws Exception
+   */
+  public List<String> nextGuids() throws Exception;
+
+  /**
+   * Mark GUIDs as no longer needing to be fetched.
+   *
+   * @param guids array of GUIDs.
+   * @throws Exception
+   */
+  public void removeGuids(Collection<String> guids) throws Exception;
+
+  /**
+   * Mark GUIDs as needing to be re-fetched.
+   * <p>
+   * This allows to purge GUIDs that repeatedly fail to be fetched.
+   *
+   * @param guids array of GUIDs.
+   * @throws Exception
+   */
+  public void retryGuids(Collection<String> guids) throws Exception;
+
+  /**
+   * Get the number of GUIDs still to be fetched.
+   *
+   * @returns number of GUIDs.
+   */
+  public int numGuidsRemaining();
+}

--- a/src/main/java/org/mozilla/gecko/sync/synchronizer/FillingGuidsManager.java
+++ b/src/main/java/org/mozilla/gecko/sync/synchronizer/FillingGuidsManager.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.gecko.sync.synchronizer;
 
 import java.util.Collection;

--- a/src/main/java/org/mozilla/gecko/sync/synchronizer/FillingRecordsChannel.java
+++ b/src/main/java/org/mozilla/gecko/sync/synchronizer/FillingRecordsChannel.java
@@ -1,0 +1,146 @@
+package org.mozilla.gecko.sync.synchronizer;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.mozilla.gecko.sync.Logger;
+import org.mozilla.gecko.sync.Utils;
+import org.mozilla.gecko.sync.repositories.InactiveSessionException;
+import org.mozilla.gecko.sync.repositories.RepositorySession;
+import org.mozilla.gecko.sync.repositories.delegates.RepositorySessionGuidsSinceDelegate;
+
+/**
+ * A <code>RecordsChannel</code> that updates a collection of GUIDs using
+ * <code>source.guidsSince</code> before downloading the freshest GUIDs using
+ * <code>source.fetch</code>. GUIDs are only removed from the collection when
+ * they are successfully stored.
+ */
+public class FillingRecordsChannel extends RecordsChannel {
+  public static final String LOG_TAG = "FillingRecsChan";
+
+  protected final FillingGuidsManager guidsManager;
+
+  /**
+   * GUIDs of records that were successfully stored this session and do not need
+   * to be fetched later.
+   */
+  protected final ArrayList<String> fetchedGuids = new ArrayList<String>();
+
+  /**
+   * GUIDs of records that were not successfully fetched and stored this
+   * session, and may need to be fetched again later.
+   */
+  protected final ArrayList<String> failedGuids = new ArrayList<String>();
+
+  /**
+   * GUIDs of records to fetch right now.
+   */
+  protected Collection<String> nextGuids;
+
+  public FillingRecordsChannel(final RepositorySession source, final RepositorySession sink,
+      final RecordsChannelDelegate delegate, final FillingGuidsManager guidsManager) {
+    super(source, sink, delegate);
+    this.guidsManager = guidsManager;
+  }
+
+  @Override
+  protected void fetch() {
+    final RecordsChannel self = this;
+    final RepositorySessionGuidsSinceDelegate delegate = new RepositorySessionGuidsSinceDelegate() {
+      @Override
+      public void onGuidsSinceSucceeded(final Collection<String> guids) {
+        Logger.debug(LOG_TAG, "guidsSince returned " + guids.size() + " fresh GUIDs.");
+
+        nextGuids = null;
+        try {
+          guidsManager.addFreshGuids(guids);
+          nextGuids = guidsManager.nextGuids();
+        } catch (Exception e) {
+          Logger.warn(LOG_TAG, "Got exception prepending or getting GUIDs. Ignoring and trying to fetch retrieved GUIDs.", e);
+        }
+        if (nextGuids == null) {
+          nextGuids = guids;
+        }
+        // Early abort if possible.
+        if (nextGuids == null || nextGuids.isEmpty()) {
+          Logger.debug(LOG_TAG, "No GUIDs to fetch. Succeeding fetch early.");
+          onFetchCompleted(timestamp);
+          return;
+        }
+
+        try {
+          String[] nextGuidsArray = nextGuids.toArray(new String[nextGuids.size()]);
+          Logger.debug(LOG_TAG, "Fetching " + nextGuidsArray.length + " records by GUID.");
+          source.fetch(nextGuidsArray, self);
+        } catch (InactiveSessionException e) {
+          onFetchFailed(e, null);
+        }
+      }
+
+      @Override
+      public void onGuidsSinceFailed(final Exception ex) {
+        // A white lie.
+        onFetchFailed(ex, null);
+      }
+    };
+
+    fetchedGuids.clear();
+    source.guidsSince(timestamp, delegate);
+  }
+
+  @Override
+  public void onStoreCompleted(final long storeEnd) {
+    if (nextGuids.isEmpty()) {
+      Logger.debug(LOG_TAG, "No GUIDs to fetch. Completing store early.");
+      super.onStoreCompleted(storeEnd);
+      return;
+    }
+
+    Logger.debug(LOG_TAG, "Removing " + fetchedGuids.size() + " GUIDs and retrying " + failedGuids.size() + " GUIDs.");
+    try {
+      guidsManager.removeGuids(fetchedGuids);
+    } catch (Exception e) {
+      Logger.warn(LOG_TAG, "Got exception removing fetched GUIDs. Ignoring. We might try to re-fetch records!", e);
+    }
+    try {
+      guidsManager.retryGuids(failedGuids);
+    } catch (Exception e) {
+      Logger.warn(LOG_TAG, "Got exception re-adding failed GUIDs. Ignoring. We might try to re-fetch records!", e);
+    }
+
+    Set<String> orphaned = new HashSet<String>(nextGuids);
+    orphaned.removeAll(fetchedGuids);
+    orphaned.removeAll(failedGuids);
+    fetchedGuids.clear(); // GC as soon as possible.
+    failedGuids.clear();
+    if (!orphaned.isEmpty()) {
+      // Hmm... we asked for a record and didn't get anything back.
+      Logger.warn(LOG_TAG, "No record returned for GUIDs " + Utils.toCommaSeparatedString(orphaned) + ".");
+      Logger.warn(LOG_TAG, "Removing orphaned GUIDs and continuing.");
+      try {
+        guidsManager.removeGuids(orphaned);
+      } catch (Exception e) {
+        Logger.warn(LOG_TAG, "Got exception removing orphaned GUIDs. Ignoring. We might re-fetch records for ever!", e);
+      }
+      orphaned = null; // GC as soon as possible.
+    }
+
+    Logger.debug(LOG_TAG, "" + guidsManager.numGuidsRemaining() + " GUIDs still need to be fetched. Completing store.");
+    super.onStoreCompleted(storeEnd);
+  }
+
+
+  @Override
+  public void onRecordStoreSucceeded(final String guid) {
+    super.onRecordStoreSucceeded(guid);
+    fetchedGuids.add(guid);
+  }
+
+  @Override
+  public void onRecordStoreFailed(final Exception ex, final String guid) {
+    failedGuids.add(guid);
+    super.onRecordStoreSucceeded(guid);
+  }
+}

--- a/src/main/java/org/mozilla/gecko/sync/synchronizer/FillingRecordsChannel.java
+++ b/src/main/java/org/mozilla/gecko/sync/synchronizer/FillingRecordsChannel.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.gecko.sync.synchronizer;
 
 import java.util.ArrayList;

--- a/src/main/java/org/mozilla/gecko/sync/synchronizer/FillingServerLocalSynchronizer.java
+++ b/src/main/java/org/mozilla/gecko/sync/synchronizer/FillingServerLocalSynchronizer.java
@@ -1,0 +1,18 @@
+package org.mozilla.gecko.sync.synchronizer;
+
+/**
+ * A <code>Synchronizer</code> that downloads fresh GUIDs and then downloads
+ * records in batches.
+ */
+public class FillingServerLocalSynchronizer extends ServerLocalSynchronizer {
+  protected final FillingGuidsManager manager;
+
+  public FillingServerLocalSynchronizer(final FillingGuidsManager manager) {
+    super();
+    this.manager = manager;
+  }
+
+  public SynchronizerSession getSynchronizerSession() {
+    return new FillingServerLocalSynchronizerSession(this, this, manager);
+  }
+}

--- a/src/main/java/org/mozilla/gecko/sync/synchronizer/FillingServerLocalSynchronizer.java
+++ b/src/main/java/org/mozilla/gecko/sync/synchronizer/FillingServerLocalSynchronizer.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.gecko.sync.synchronizer;
 
 /**

--- a/src/main/java/org/mozilla/gecko/sync/synchronizer/FillingServerLocalSynchronizerSession.java
+++ b/src/main/java/org/mozilla/gecko/sync/synchronizer/FillingServerLocalSynchronizerSession.java
@@ -1,0 +1,20 @@
+package org.mozilla.gecko.sync.synchronizer;
+
+import org.mozilla.gecko.sync.repositories.RepositorySession;
+
+/**
+ * A synchronizer session that fetches remote records in batches by GUIDs.
+ */
+public class FillingServerLocalSynchronizerSession extends ServerLocalSynchronizerSession {
+  protected final FillingGuidsManager incomingManager;
+
+  public FillingServerLocalSynchronizerSession(final Synchronizer synchronizer, final SynchronizerSessionDelegate delegate, final FillingGuidsManager incomingManager) {
+    super(synchronizer, delegate);
+    this.incomingManager = incomingManager;
+  }
+
+  @Override
+  protected RecordsChannel newFirstRecordsChannel(final RepositorySession source, final RepositorySession sink, final RecordsChannelDelegate delegate) {
+    return new FillingRecordsChannel(source, sink, delegate, incomingManager);
+  }
+}

--- a/src/main/java/org/mozilla/gecko/sync/synchronizer/FillingServerLocalSynchronizerSession.java
+++ b/src/main/java/org/mozilla/gecko/sync/synchronizer/FillingServerLocalSynchronizerSession.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.gecko.sync.synchronizer;
 
 import org.mozilla.gecko.sync.repositories.RepositorySession;

--- a/src/main/java/org/mozilla/gecko/sync/synchronizer/RecordsChannel.java
+++ b/src/main/java/org/mozilla/gecko/sync/synchronizer/RecordsChannel.java
@@ -70,7 +70,7 @@ public class RecordsChannel implements
   public RepositorySession source;
   public RepositorySession sink;
   private RecordsChannelDelegate delegate;
-  private long timestamp;
+  protected long timestamp;
   private long fetchEnd = -1;
 
   private final AtomicInteger numFetchFailed = new AtomicInteger();
@@ -140,6 +140,10 @@ public class RecordsChannel implements
     this.consumer = new ConcurrentRecordConsumer(this);
     ThreadPool.run(this.consumer);
     waitingForQueueDone = true;
+    fetch();
+  }
+
+  protected void fetch() {
     source.fetchSince(timestamp, this);
   }
 

--- a/src/main/java/org/mozilla/gecko/sync/synchronizer/SynchronizerSession.java
+++ b/src/main/java/org/mozilla/gecko/sync/synchronizer/SynchronizerSession.java
@@ -104,6 +104,20 @@ implements RecordsChannelDelegate,
   protected RecordsChannel channelBToA;
 
   /**
+   * Create a new first RecordsChannel (for incoming records).
+   */
+  protected RecordsChannel newFirstRecordsChannel(final RepositorySession source, final RepositorySession sink, final RecordsChannelDelegate delegate) {
+    return new RecordsChannel(source, sink, delegate);
+  }
+
+  /**
+   * Create a new second RecordsChannel (for outgoing records).
+   */
+  protected RecordsChannel newSecondRecordsChannel(final RepositorySession source, final RepositorySession sink, final RecordsChannelDelegate delegate) {
+    return new RecordsChannel(source, sink, delegate);
+  }
+
+  /**
    * Please don't call this until you've been notified with onInitialized.
    */
   public synchronized void synchronize() {
@@ -123,7 +137,7 @@ implements RecordsChannelDelegate,
 
     // This is the *second* record channel to flow.
     // I, SynchronizerSession, am the delegate for the *second* flow.
-    channelBToA = new RecordsChannel(this.sessionB, this.sessionA, this);
+    channelBToA = newSecondRecordsChannel(this.sessionB, this.sessionA, this);
 
     // This is the delegate for the *first* flow.
     RecordsChannelDelegate channelAToBDelegate = new RecordsChannelDelegate() {
@@ -155,7 +169,7 @@ implements RecordsChannelDelegate,
     };
 
     // This is the *first* channel to flow.
-    channelAToB = new RecordsChannel(this.sessionA, this.sessionB, channelAToBDelegate);
+    channelAToB = newFirstRecordsChannel(this.sessionA, this.sessionB, channelAToBDelegate);
 
     Logger.info(LOG_TAG, "Starting A to B flow. Channel is " + channelAToB);
     try {

--- a/src/main/java/org/mozilla/gecko/sync/synchronizer/managers/ArrayListGuidsManager.java
+++ b/src/main/java/org/mozilla/gecko/sync/synchronizer/managers/ArrayListGuidsManager.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.gecko.sync.synchronizer.managers;
 
 import java.util.ArrayList;

--- a/src/main/java/org/mozilla/gecko/sync/synchronizer/managers/ArrayListGuidsManager.java
+++ b/src/main/java/org/mozilla/gecko/sync/synchronizer/managers/ArrayListGuidsManager.java
@@ -1,0 +1,57 @@
+package org.mozilla.gecko.sync.synchronizer.managers;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.mozilla.gecko.sync.synchronizer.FillingGuidsManager;
+
+/**
+ * For testing: maintains a collection of GUIDs to be fetched in memory.
+ */
+public class ArrayListGuidsManager implements FillingGuidsManager {
+  public final ArrayList<String> guids = new ArrayList<String>();
+
+  public int batchSize;
+
+  public ArrayListGuidsManager(int batchSize) {
+    this.batchSize = batchSize;
+  }
+
+  @Override
+  public void addFreshGuids(final Collection<String> guids) throws Exception {
+    this.guids.removeAll(guids);
+    this.guids.addAll(guids);
+  }
+
+  @Override
+  public List<String> nextGuids() throws Exception {
+    if (guids.isEmpty()) {
+      return new ArrayList<String>();
+    }
+    int end = guids.size();
+    int beg = Math.max(0, end - batchSize);
+    final List<String> next = guids.subList(beg, end);
+    final ArrayList<String> ret = new ArrayList<String>(next);
+    next.clear();
+    return ret;
+  }
+
+  @Override
+  public void removeGuids(final Collection<String> guids) throws Exception {
+    for (String guid : guids) {
+      this.guids.remove(guid);
+    }
+  }
+
+  @Override
+  public void retryGuids(final Collection<String> guids) throws Exception {
+    // No effort to remove GUIDs that fail repeatedly.
+    addFreshGuids(guids);
+  }
+
+  @Override
+  public int numGuidsRemaining() {
+    return guids.size();
+  }
+}

--- a/src/main/java/org/mozilla/gecko/sync/synchronizer/managers/SQLiteGuidsManager.java
+++ b/src/main/java/org/mozilla/gecko/sync/synchronizer/managers/SQLiteGuidsManager.java
@@ -1,0 +1,158 @@
+package org.mozilla.gecko.sync.synchronizer.managers;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.mozilla.gecko.sync.repositories.android.CachedSQLiteOpenHelper;
+import org.mozilla.gecko.sync.repositories.android.RepoUtils;
+import org.mozilla.gecko.sync.synchronizer.FillingGuidsManager;
+
+import android.content.ContentValues;
+import android.content.Context;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+
+public class SQLiteGuidsManager extends CachedSQLiteOpenHelper implements FillingGuidsManager {
+
+  public static final String LOG_TAG = "SQLiteGuidsMan";
+
+  // Database Specifications.
+  protected static final String DB_NAME = "filling_database";
+  protected static final int SCHEMA_VERSION = 1;
+
+  // Clients Table.
+  public static final String TBL = "guids";
+  public static final String COL_COLLECTION = "collection";
+  public static final String COL_MODIFIED = "modified";
+  public static final String COL_GUID = "guid";
+  public static final String COL_RETRIES_REMAINING = "retries_remaining";
+
+  public static final String[] TBL_COLUMNS = new String[] { COL_COLLECTION, COL_MODIFIED, COL_GUID, COL_RETRIES_REMAINING };
+
+  protected final String collection;
+  protected final int batchSize;
+  protected final int numRetries;
+
+  public SQLiteGuidsManager(Context context, final String collection, final int batchSize, final int numRetries) {
+    super(context, DB_NAME, null, SCHEMA_VERSION);
+    this.collection = collection;
+    this.batchSize = batchSize;
+    this.numRetries = numRetries;
+  }
+
+  @Override
+  public void onCreate(SQLiteDatabase db) {
+    String createTableSql = "CREATE TABLE " + TBL + " ("
+        + COL_COLLECTION + " TEXT NOT NULL, "
+        + COL_MODIFIED + " INTEGER NOT NULL, "
+        + COL_GUID + " TEXT NOT NULL, "
+        + COL_RETRIES_REMAINING + " INTEGER NOT NULL"
+        + ", PRIMARY KEY (" + COL_COLLECTION + ", " + COL_GUID + ")"
+        + ")";
+    db.execSQL(createTableSql);
+  }
+
+  @Override
+  public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+    // For now we'll just drop and recreate the tables.
+    db.execSQL("DROP TABLE IF EXISTS " + TBL);
+    onCreate(db);
+  }
+
+  public void wipeDB() {
+    SQLiteDatabase db = this.getCachedWritableDatabase();
+    onUpgrade(db, SCHEMA_VERSION, SCHEMA_VERSION);
+  }
+
+  public void wipeTable() {
+    SQLiteDatabase db = this.getCachedWritableDatabase();
+    db.execSQL("DELETE FROM " + TBL);
+  }
+
+  @Override
+  public void addFreshGuids(Collection<String> guids) throws Exception {
+    if (guids.isEmpty()) {
+      return;
+    }
+    SQLiteDatabase db = this.getCachedWritableDatabase();
+    try{
+      db.beginTransaction();
+      ContentValues cv = new ContentValues();
+      cv.put(COL_COLLECTION, this.collection);
+      cv.put(COL_RETRIES_REMAINING, this.numRetries);
+      cv.put(COL_MODIFIED, System.currentTimeMillis());
+      final String where = COL_GUID + " = ? AND " + COL_COLLECTION + " = ?";
+      for (String guid : guids) {
+        cv.put(COL_GUID, guid);
+        if (db.update(TBL, cv, where, new String[] { guid, this.collection }) < 1) {
+          db.insert(TBL, null, cv);
+        }
+      }
+      db.setTransactionSuccessful();
+    } finally {
+      db.endTransaction();
+    }
+  }
+
+  @Override
+  public List<String> nextGuids() throws Exception {
+    SQLiteDatabase db = this.getCachedReadableDatabase();
+    List<String> guids = new ArrayList<String>();
+    Cursor cursor = null;
+    try {
+      cursor = db.rawQuery("SELECT " + COL_GUID + " FROM " + TBL + " WHERE collection = ? ORDER BY " + COL_MODIFIED + " DESC, ROWID DESC LIMIT ? ",
+          new String[] { this.collection, Integer.toString(this.batchSize) });
+      if (!cursor.moveToFirst()) {
+        return guids;
+      }
+      int pos = cursor.getColumnIndexOrThrow(COL_GUID);
+      while (!cursor.isAfterLast()) {
+        guids.add(cursor.getString(pos));
+        cursor.moveToNext();
+      }
+    } finally {
+      if (cursor != null) {
+        cursor.close();
+      }
+    }
+    return guids;
+  }
+
+  @Override
+  public int numGuidsRemaining() {
+    SQLiteDatabase db = this.getCachedReadableDatabase();
+    Cursor cursor = null;
+    try {
+      cursor = db.rawQuery("SELECT COUNT(*) FROM " + TBL + " WHERE collection = ?",
+          new String[] { this.collection });
+      if (!cursor.moveToFirst()) {
+        return 0;
+      }
+      return cursor.getInt(0);
+    } finally {
+      if (cursor != null) {
+        cursor.close();
+      }
+    }
+  }
+
+  @Override
+  public void removeGuids(Collection<String> guids) throws Exception {
+    SQLiteDatabase db = this.getCachedWritableDatabase();
+    final String where = "(" + RepoUtils.computeSQLInClause(guids.size(), COL_GUID) + ") AND " + COL_COLLECTION + " = ?";
+    final String guidsArray[] = guids.toArray(new String[guids.size()+1]);
+    guidsArray[guids.size()] = this.collection;
+    db.delete(TBL, where, guidsArray);
+  }
+
+  @Override
+  public void retryGuids(Collection<String> guids) throws Exception {
+    SQLiteDatabase db = this.getCachedWritableDatabase();
+    final String where = "(" + RepoUtils.computeSQLInClause(guids.size(), COL_GUID) + ") AND " + COL_COLLECTION + " = ?";
+    final String guidsArray[] = guids.toArray(new String[guids.size()+1]);
+    guidsArray[guids.size()] = this.collection;
+    db.execSQL("UPDATE " + TBL + " SET " + COL_RETRIES_REMAINING + " = " + COL_RETRIES_REMAINING + " - 1 WHERE " + where, guidsArray);
+    db.delete(TBL, COL_RETRIES_REMAINING + " <= 0", null);
+  }
+}

--- a/src/main/java/org/mozilla/gecko/sync/synchronizer/managers/SQLiteGuidsManager.java
+++ b/src/main/java/org/mozilla/gecko/sync/synchronizer/managers/SQLiteGuidsManager.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.gecko.sync.synchronizer.managers;
 
 import java.util.ArrayList;

--- a/src/test/java/org/mozilla/android/sync/test/RecordsChannelHelper.java
+++ b/src/test/java/org/mozilla/android/sync/test/RecordsChannelHelper.java
@@ -1,0 +1,136 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+package org.mozilla.android.sync.test;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.mozilla.android.sync.test.helpers.ExpectSuccessRepositorySessionCreationDelegate;
+import org.mozilla.android.sync.test.helpers.ExpectSuccessRepositorySessionFinishDelegate;
+import org.mozilla.android.sync.test.helpers.WBORepository;
+import org.mozilla.android.sync.test.helpers.WaitHelper;
+import org.mozilla.gecko.sync.repositories.InactiveSessionException;
+import org.mozilla.gecko.sync.repositories.InvalidSessionTransitionException;
+import org.mozilla.gecko.sync.repositories.Repository;
+import org.mozilla.gecko.sync.repositories.RepositorySession;
+import org.mozilla.gecko.sync.repositories.RepositorySessionBundle;
+import org.mozilla.gecko.sync.synchronizer.RecordsChannel;
+import org.mozilla.gecko.sync.synchronizer.RecordsChannelDelegate;
+
+public class RecordsChannelHelper {
+
+  protected WBORepository remote;
+  protected WBORepository local;
+
+  protected RepositorySession source;
+  protected RepositorySession sink;
+  protected RecordsChannelDelegate rcDelegate;
+
+  protected AtomicInteger numFlowFetchFailed;
+  protected AtomicInteger numFlowStoreFailed;
+  protected AtomicInteger numFlowCompleted;
+  protected AtomicBoolean flowBeginFailed;
+  protected AtomicBoolean flowFinishFailed;
+
+  protected RecordsChannel newRecordsChannel(final RepositorySession source, final RepositorySession sink, final RecordsChannelDelegate rcDelegate) {
+    return new RecordsChannel(source,  sink, rcDelegate);
+  }
+
+  public void doFlow(final Repository remote, final Repository local) throws Exception {
+    doFlow(0, remote, local);
+  }
+
+  public void doFlow(final long lastSyncTimestamp, final Repository remote, final Repository local) throws Exception {
+    WaitHelper.getTestWaiter().performWait(new Runnable() {
+      @Override
+      public void run() {
+        remote.createSession(new ExpectSuccessRepositorySessionCreationDelegate(WaitHelper.getTestWaiter()) {
+          @Override
+          public void onSessionCreated(RepositorySession session) {
+            source = session;
+            source.lastSyncTimestamp = lastSyncTimestamp;
+            local.createSession(new ExpectSuccessRepositorySessionCreationDelegate(WaitHelper.getTestWaiter()) {
+              @Override
+              public void onSessionCreated(RepositorySession session) {
+                sink = session;
+                WaitHelper.getTestWaiter().performNotify();
+              }
+            }, null);
+          }
+        }, null);
+      }
+    });
+
+    assertNotNull(source);
+    assertNotNull(sink);
+
+    numFlowFetchFailed = new AtomicInteger(0);
+    numFlowStoreFailed = new AtomicInteger(0);
+    numFlowCompleted = new AtomicInteger(0);
+    flowBeginFailed = new AtomicBoolean(false);
+    flowFinishFailed = new AtomicBoolean(false);
+
+    rcDelegate = new RecordsChannelDelegate() {
+      @Override
+      public void onFlowFetchFailed(RecordsChannel recordsChannel, Exception ex) {
+        numFlowFetchFailed.incrementAndGet();
+      }
+
+      @Override
+      public void onFlowStoreFailed(RecordsChannel recordsChannel, Exception ex, String recordGuid) {
+        numFlowStoreFailed.incrementAndGet();
+      }
+
+      @Override
+      public void onFlowFinishFailed(RecordsChannel recordsChannel, Exception ex) {
+        flowFinishFailed.set(true);
+        WaitHelper.getTestWaiter().performNotify();
+      }
+
+      @Override
+      public void onFlowCompleted(RecordsChannel recordsChannel, long fetchEnd, long storeEnd) {
+        numFlowCompleted.incrementAndGet();
+        try {
+          sink.finish(new ExpectSuccessRepositorySessionFinishDelegate(WaitHelper.getTestWaiter()) {
+            @Override
+            public void onFinishSucceeded(RepositorySession session, RepositorySessionBundle bundle) {
+              try {
+                source.finish(new ExpectSuccessRepositorySessionFinishDelegate(WaitHelper.getTestWaiter()) {
+                  @Override
+                  public void onFinishSucceeded(RepositorySession session, RepositorySessionBundle bundle) {
+                    performNotify();
+                  }
+                });
+              } catch (InactiveSessionException e) {
+                WaitHelper.getTestWaiter().performNotify(e);
+              }
+            }
+          });
+        } catch (InactiveSessionException e) {
+          WaitHelper.getTestWaiter().performNotify(e);
+        }
+      }
+
+      @Override
+      public void onFlowBeginFailed(RecordsChannel recordsChannel, Exception ex) {
+        flowBeginFailed.set(true);
+        WaitHelper.getTestWaiter().performNotify();
+      }
+    };
+
+    final RecordsChannel rc = newRecordsChannel(source,  sink, rcDelegate);
+    WaitHelper.getTestWaiter().performWait(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          rc.beginAndFlow();
+        } catch (InvalidSessionTransitionException e) {
+          WaitHelper.getTestWaiter().performNotify(e);
+        }
+      }
+    });
+  }
+}

--- a/src/test/java/org/mozilla/android/sync/test/TestFillingRecordsChannel.java
+++ b/src/test/java/org/mozilla/android/sync/test/TestFillingRecordsChannel.java
@@ -1,3 +1,6 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
 package org.mozilla.android.sync.test;
 
 import static org.junit.Assert.assertArrayEquals;

--- a/src/test/java/org/mozilla/android/sync/test/TestFillingRecordsChannel.java
+++ b/src/test/java/org/mozilla/android/sync/test/TestFillingRecordsChannel.java
@@ -1,0 +1,150 @@
+package org.mozilla.android.sync.test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+import org.mozilla.android.sync.test.helpers.WBORepository;
+import org.mozilla.gecko.sync.repositories.RepositorySession;
+import org.mozilla.gecko.sync.repositories.delegates.RepositorySessionCreationDelegate;
+import org.mozilla.gecko.sync.repositories.delegates.RepositorySessionGuidsSinceDelegate;
+import org.mozilla.gecko.sync.repositories.domain.BookmarkRecord;
+import org.mozilla.gecko.sync.synchronizer.FillingRecordsChannel;
+import org.mozilla.gecko.sync.synchronizer.RecordsChannel;
+import org.mozilla.gecko.sync.synchronizer.RecordsChannelDelegate;
+import org.mozilla.gecko.sync.synchronizer.managers.ArrayListGuidsManager;
+
+import android.content.Context;
+
+public class TestFillingRecordsChannel extends RecordsChannelHelper {
+  protected ArrayListGuidsManager manager;
+
+  protected RecordsChannel newRecordsChannel(final RepositorySession source, final RepositorySession sink, final RecordsChannelDelegate rcDelegate) {
+    return new FillingRecordsChannel(source,  sink, rcDelegate, manager);
+  }
+
+  public static class CountGuidsSinceWBORepository extends WBORepository {
+    final AtomicInteger numGuidsSince = new AtomicInteger(0);
+    final ArrayList<Long> timestamps = new ArrayList<Long>();
+
+    @Override
+    public void createSession(RepositorySessionCreationDelegate delegate,
+                              Context context) {
+      delegate.deferredCreationDelegate().onSessionCreated(new WBORepositorySession(this) {
+        @Override
+        public void guidsSince(long timestamp, final RepositorySessionGuidsSinceDelegate delegate) {
+          numGuidsSince.incrementAndGet();
+          timestamps.add(new Long(timestamp));
+          super.guidsSince(timestamp, delegate);
+        }
+      });
+    }
+  }
+
+  /**
+   * Verify that flow fetches fresh GUIDs using guidsSince and calls fetch
+   * correctly.
+   */
+  @Test
+  public void testFlow() throws Exception {
+    final int FIRST = 2;
+    final int SECOND = 20;
+    final int THIRD = 30;
+
+    CountGuidsSinceWBORepository source = new CountGuidsSinceWBORepository();
+    for (int i = 0; i < 10; i++) {
+      source.wbos.put("test" + i, new BookmarkRecord("test" + i, "test", i, false));
+    }
+    WBORepository sink = new WBORepository();
+
+    manager = new ArrayListGuidsManager(5);
+    doFlow(FIRST, source, sink);
+    assertEquals(1, numFlowCompleted.get());
+
+    Set<String> guids = new HashSet<String>();
+    for (String guid : new String[] { "test5", "test6", "test7", "test8", "test9" }) {
+      guids.add(guid);
+    }
+    assertEquals(guids, sink.wbos.keySet());
+    assertEquals(3, manager.guids.size());
+    assertArrayEquals(new String[] { "test2", "test3", "test4" }, manager.guids.toArray(new String[0]));
+
+    assertEquals(1, source.numGuidsSince.get());
+    assertEquals(FIRST, source.timestamps.get(0).longValue());
+
+    // Now flow again. We should find no new GUIDs, but we should grab the
+    // remaining old ones.
+    sink.wbos.clear();
+    doFlow(SECOND, source, sink);
+    assertEquals(1, numFlowCompleted.get());
+    assertEquals(2, source.numGuidsSince.get());
+    assertEquals(SECOND, source.timestamps.get(1).longValue());
+
+    guids = new HashSet<String>();
+    for (String guid : new String[] { "test2", "test3", "test4"  }) {
+      guids.add(guid);
+    }
+    assertEquals(guids, sink.wbos.keySet());
+    assertEquals(0, manager.guids.size());
+
+    // Final flow.  No new GUIDs, nothing to fetch.
+    sink.wbos.clear();
+    doFlow(THIRD, source, sink);
+    assertEquals(1, numFlowCompleted.get());
+    assertEquals(3, source.numGuidsSince.get());
+    assertEquals(THIRD, source.timestamps.get(2).longValue());
+    assertTrue(sink.wbos.isEmpty());
+  }
+
+  /**
+   * Verify that GUIDs failing to store are retried.
+   */
+  @Test
+  public void testRetry() throws Exception {
+    final int FIRST = 2;
+
+    CountGuidsSinceWBORepository source = new CountGuidsSinceWBORepository();
+    for (int i = 0; i < 10; i++) {
+      source.wbos.put(SynchronizerHelpers.FAIL_SENTINEL + i, new BookmarkRecord(SynchronizerHelpers.FAIL_SENTINEL + i, "test", i, false));
+    }
+    for (int i = 10; i < 12; i++) {
+      source.wbos.put("test" + i, new BookmarkRecord("test" + i, "test", i, false));
+    }
+    WBORepository sink = new SynchronizerHelpers.SerialFailStoreWBORepository();
+
+    final Set<String> retryGuids = new HashSet<String>();
+    manager = new ArrayListGuidsManager(5) {
+      @Override
+      public void retryGuids(final Collection<String> guids) throws Exception {
+        retryGuids.addAll(guids);
+        super.retryGuids(guids);
+      }
+    };
+    doFlow(FIRST, source, sink);
+    assertEquals(1, numFlowCompleted.get());
+
+    // Successes...
+    Set<String> guids = new HashSet<String>();
+    for (String guid : new String[] { "test10", "test11" }) {
+      guids.add(guid);
+      assertFalse(manager.guids.contains(guid));
+    }
+    assertEquals(guids, sink.wbos.keySet());
+
+    // Retries...
+    guids = new HashSet<String>();
+    for (String guid : new String[] { SynchronizerHelpers.FAIL_SENTINEL + 7, SynchronizerHelpers.FAIL_SENTINEL + 8, SynchronizerHelpers.FAIL_SENTINEL + 9 }) {
+      guids.add(guid);
+      assertTrue(manager.guids.contains(guid));
+    }
+    assertEquals(guids, retryGuids);
+  }
+}

--- a/src/test/java/org/mozilla/android/sync/test/TestRecordsChannel.java
+++ b/src/test/java/org/mozilla/android/sync/test/TestRecordsChannel.java
@@ -1,3 +1,6 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
 package org.mozilla.android.sync.test;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/mozilla/android/sync/test/TestRecordsChannel.java
+++ b/src/test/java/org/mozilla/android/sync/test/TestRecordsChannel.java
@@ -1,134 +1,14 @@
-/* Any copyright is dedicated to the Public Domain.
-   http://creativecommons.org/publicdomain/zero/1.0/ */
-
 package org.mozilla.android.sync.test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
 import org.mozilla.android.sync.test.SynchronizerHelpers.FailFetchWBORepository;
-import org.mozilla.android.sync.test.helpers.ExpectSuccessRepositorySessionCreationDelegate;
-import org.mozilla.android.sync.test.helpers.ExpectSuccessRepositorySessionFinishDelegate;
 import org.mozilla.android.sync.test.helpers.WBORepository;
-import org.mozilla.android.sync.test.helpers.WaitHelper;
-import org.mozilla.gecko.sync.repositories.InactiveSessionException;
-import org.mozilla.gecko.sync.repositories.InvalidSessionTransitionException;
-import org.mozilla.gecko.sync.repositories.Repository;
-import org.mozilla.gecko.sync.repositories.RepositorySession;
-import org.mozilla.gecko.sync.repositories.RepositorySessionBundle;
 import org.mozilla.gecko.sync.repositories.domain.BookmarkRecord;
-import org.mozilla.gecko.sync.synchronizer.RecordsChannel;
-import org.mozilla.gecko.sync.synchronizer.RecordsChannelDelegate;
 
-public class TestRecordsChannel {
-
-  protected WBORepository remote;
-  protected WBORepository local;
-
-  protected RepositorySession source;
-  protected RepositorySession sink;
-  protected RecordsChannelDelegate rcDelegate;
-
-  protected AtomicInteger numFlowFetchFailed;
-  protected AtomicInteger numFlowStoreFailed;
-  protected AtomicInteger numFlowCompleted;
-  protected AtomicBoolean flowBeginFailed;
-  protected AtomicBoolean flowFinishFailed;
-
-  public void doFlow(final Repository remote, final Repository local) throws Exception {
-    WaitHelper.getTestWaiter().performWait(new Runnable() {
-      @Override
-      public void run() {
-        remote.createSession(new ExpectSuccessRepositorySessionCreationDelegate(WaitHelper.getTestWaiter()) {
-          @Override
-          public void onSessionCreated(RepositorySession session) {
-            source = session;
-            local.createSession(new ExpectSuccessRepositorySessionCreationDelegate(WaitHelper.getTestWaiter()) {
-              @Override
-              public void onSessionCreated(RepositorySession session) {
-                sink = session;
-                WaitHelper.getTestWaiter().performNotify();
-              }
-            }, null);
-          }
-        }, null);
-      }
-    });
-
-    assertNotNull(source);
-    assertNotNull(sink);
-
-    numFlowFetchFailed = new AtomicInteger(0);
-    numFlowStoreFailed = new AtomicInteger(0);
-    numFlowCompleted = new AtomicInteger(0);
-    flowBeginFailed = new AtomicBoolean(false);
-    flowFinishFailed = new AtomicBoolean(false);
-
-    rcDelegate = new RecordsChannelDelegate() {
-      @Override
-      public void onFlowFetchFailed(RecordsChannel recordsChannel, Exception ex) {
-        numFlowFetchFailed.incrementAndGet();
-      }
-
-      @Override
-      public void onFlowStoreFailed(RecordsChannel recordsChannel, Exception ex, String recordGuid) {
-        numFlowStoreFailed.incrementAndGet();
-      }
-
-      @Override
-      public void onFlowFinishFailed(RecordsChannel recordsChannel, Exception ex) {
-        flowFinishFailed.set(true);
-        WaitHelper.getTestWaiter().performNotify();
-      }
-
-      @Override
-      public void onFlowCompleted(RecordsChannel recordsChannel, long fetchEnd, long storeEnd) {
-        numFlowCompleted.incrementAndGet();
-        try {
-          sink.finish(new ExpectSuccessRepositorySessionFinishDelegate(WaitHelper.getTestWaiter()) {
-            @Override
-            public void onFinishSucceeded(RepositorySession session, RepositorySessionBundle bundle) {
-              try {
-                source.finish(new ExpectSuccessRepositorySessionFinishDelegate(WaitHelper.getTestWaiter()) {
-                  @Override
-                  public void onFinishSucceeded(RepositorySession session, RepositorySessionBundle bundle) {
-                    performNotify();
-                  }
-                });
-              } catch (InactiveSessionException e) {
-                WaitHelper.getTestWaiter().performNotify(e);
-              }
-            }
-          });
-        } catch (InactiveSessionException e) {
-          WaitHelper.getTestWaiter().performNotify(e);
-        }
-      }
-
-      @Override
-      public void onFlowBeginFailed(RecordsChannel recordsChannel, Exception ex) {
-        flowBeginFailed.set(true);
-        WaitHelper.getTestWaiter().performNotify();
-      }
-    };
-
-    final RecordsChannel rc = new RecordsChannel(source,  sink, rcDelegate);
-    WaitHelper.getTestWaiter().performWait(new Runnable() {
-      @Override
-      public void run() {
-        try {
-          rc.beginAndFlow();
-        } catch (InvalidSessionTransitionException e) {
-          WaitHelper.getTestWaiter().performNotify(e);
-        }
-      }
-    });
-  }
+public class TestRecordsChannel extends RecordsChannelHelper {
 
   public static final BookmarkRecord[] inbounds = new BookmarkRecord[] {
     new BookmarkRecord("inboundSucc1", "bookmarks", 1, false),

--- a/src/test/java/org/mozilla/android/sync/test/TestWBORepository.java
+++ b/src/test/java/org/mozilla/android/sync/test/TestWBORepository.java
@@ -1,3 +1,6 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
 package org.mozilla.android.sync.test;
 
 import static org.junit.Assert.assertArrayEquals;

--- a/src/test/java/org/mozilla/android/sync/test/TestWBORepository.java
+++ b/src/test/java/org/mozilla/android/sync/test/TestWBORepository.java
@@ -1,0 +1,95 @@
+package org.mozilla.android.sync.test;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Test;
+import org.mozilla.android.sync.test.helpers.ExpectSuccessRepositorySessionBeginDelegate;
+import org.mozilla.android.sync.test.helpers.ExpectSuccessRepositorySessionCreationDelegate;
+import org.mozilla.android.sync.test.helpers.WBORepository;
+import org.mozilla.android.sync.test.helpers.WaitHelper;
+import org.mozilla.gecko.sync.repositories.InvalidSessionTransitionException;
+import org.mozilla.gecko.sync.repositories.Repository;
+import org.mozilla.gecko.sync.repositories.RepositorySession;
+import org.mozilla.gecko.sync.repositories.delegates.RepositorySessionGuidsSinceDelegate;
+import org.mozilla.gecko.sync.repositories.domain.BookmarkRecord;
+
+public class TestWBORepository {
+  protected RepositorySession source;
+
+  public static class ExpectGuidsSince implements RepositorySessionGuidsSinceDelegate {
+    protected final List<String> expected = new ArrayList<String>();
+
+    public ExpectGuidsSince(final String[] guids) {
+      for (String guid : guids) {
+        expected.add(guid);
+      }
+    }
+
+    @Override
+    public void onGuidsSinceSucceeded(Collection<String> guids) {
+      try {
+        assertArrayEquals(expected.toArray(new String[0]), guids.toArray(new String[0]));
+      } catch (Throwable e) {
+        WaitHelper.getTestWaiter().performNotify(e);
+        return;
+      }
+      WaitHelper.getTestWaiter().performNotify();
+    }
+
+    @Override
+    public void onGuidsSinceFailed(Exception ex) {
+      WaitHelper.getTestWaiter().performNotify(ex);
+    }
+  }
+
+  protected void doGuidsSince(final Repository repo, final int timestamp, final String[] expected) {
+    WaitHelper.getTestWaiter().performWait(new Runnable() {
+      @Override
+      public void run() {
+        repo.createSession(new ExpectSuccessRepositorySessionCreationDelegate(WaitHelper.getTestWaiter()) {
+          @Override
+          public void onSessionCreated(RepositorySession session) {
+            source = session;
+            WaitHelper.getTestWaiter().performNotify();
+          }
+        }, null);
+      }
+    });
+
+    WaitHelper.getTestWaiter().performWait(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          source.begin(new ExpectSuccessRepositorySessionBeginDelegate(WaitHelper.getTestWaiter()) {
+            @Override
+            public void onBeginSucceeded(RepositorySession session) {
+              source.guidsSince(timestamp, new ExpectGuidsSince(expected));
+            }
+          });
+        } catch (InvalidSessionTransitionException e) {
+          WaitHelper.getTestWaiter().performNotify(e);
+        }
+      }
+    });
+  }
+
+  @Test
+  public void testGuidsSince() {
+    final WBORepository local = new WBORepository();
+    local.wbos.put("test1", new BookmarkRecord("test1", "test", 1, false));
+    local.wbos.put("test2", new BookmarkRecord("test2", "test", 2, false));
+    local.wbos.put("test3", new BookmarkRecord("test3", "test", 3, false));
+    local.wbos.put("test4", new BookmarkRecord("test4", "test", 4, false));
+
+    doGuidsSince(local, 0, new String[] { "test1", "test2", "test3", "test4" });
+    doGuidsSince(local, 1, new String[] { "test1", "test2", "test3", "test4" });
+    doGuidsSince(local, 2, new String[] { "test2", "test3", "test4" });
+    doGuidsSince(local, 3, new String[] { "test3", "test4" });
+    doGuidsSince(local, 4, new String[] { "test4" });
+    doGuidsSince(local, 5, new String[] { });
+  }
+}

--- a/src/test/java/org/mozilla/android/sync/test/helpers/ExpectSuccessRepositorySessionFetchRecordsDelegate.java
+++ b/src/test/java/org/mozilla/android/sync/test/helpers/ExpectSuccessRepositorySessionFetchRecordsDelegate.java
@@ -6,8 +6,6 @@ package org.mozilla.android.sync.test.helpers;
 import java.util.ArrayList;
 import java.util.concurrent.ExecutorService;
 
-import junit.framework.AssertionFailedError;
-
 import org.mozilla.gecko.sync.repositories.delegates.RepositorySessionFetchRecordsDelegate;
 import org.mozilla.gecko.sync.repositories.domain.Record;
 
@@ -22,7 +20,7 @@ public class ExpectSuccessRepositorySessionFetchRecordsDelegate extends
   @Override
   public void onFetchFailed(Exception ex, Record record) {
     log("Fetch failed.", ex);
-    performNotify(new AssertionFailedError("onFetchFailed: fetch should not have failed."));
+    performNotify(ex);
   }
 
   @Override

--- a/src/test/java/org/mozilla/gecko/sync/synchronizer/managers/test/TestArrayListGuidsManager.java
+++ b/src/test/java/org/mozilla/gecko/sync/synchronizer/managers/test/TestArrayListGuidsManager.java
@@ -1,0 +1,87 @@
+package org.mozilla.gecko.sync.synchronizer.managers.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.mozilla.gecko.sync.synchronizer.managers.ArrayListGuidsManager;
+
+public class TestArrayListGuidsManager {
+
+  @Test
+  public void testAddFreshGuids() throws Exception {
+    ArrayListGuidsManager manager = new ArrayListGuidsManager(5);
+    ArrayList<String> guids = new ArrayList<String>();
+    for (int i = 0; i < 10; i++) {
+      guids.add("test" + i);
+    }
+    manager.addFreshGuids(guids);
+    assertEquals(10, manager.guids.size());
+    assertEquals("test0", manager.guids.get(0));
+    assertEquals("test9", manager.guids.get(9));
+
+    guids.clear();
+    for (int i = 10; i < 20; i++) {
+      guids.add("test" + i);
+    }
+    manager.addFreshGuids(guids);
+    assertEquals(20, manager.guids.size());
+    assertEquals("test0", manager.guids.get(0));
+    assertEquals("test9", manager.guids.get(9));
+    assertEquals("test10", manager.guids.get(10));
+    assertEquals("test19", manager.guids.get(19));
+  }
+
+  @Test
+  public void testNextGuids() throws Exception {
+    ArrayListGuidsManager manager = new ArrayListGuidsManager(5);
+    ArrayList<String> guids = new ArrayList<String>();
+    for (int i = 0; i < 9; i++) {
+      guids.add("test" + i);
+    }
+    manager.addFreshGuids(guids);
+    assertEquals(9, manager.guids.size());
+    assertEquals("test0", manager.guids.get(0));
+    assertEquals("test8", manager.guids.get(8));
+
+    List<String> next = manager.nextGuids();
+    assertEquals(5, next.size());
+    assertEquals("test4", next.get(0));
+    assertEquals("test8", next.get(4));
+    assertEquals(4, manager.guids.size());
+
+    next = manager.nextGuids();
+    assertEquals(4, next.size());
+    assertEquals("test0", next.get(0));
+    assertEquals("test3", next.get(3));
+    assertEquals(0, manager.guids.size());
+
+    assertNotNull(manager.nextGuids());
+    assertTrue(manager.nextGuids().isEmpty());
+  }
+
+  @Test
+  public void testRemoveGuids() throws Exception {
+    ArrayListGuidsManager manager = new ArrayListGuidsManager(5);
+    ArrayList<String> guids = new ArrayList<String>();
+    for (int i = 0; i < 9; i++) {
+      guids.add("test" + i);
+    }
+    manager.addFreshGuids(guids);
+    assertEquals(9, manager.guids.size());
+
+    guids.clear();
+    guids.add("test1");
+    guids.add("test2");
+    guids.add("missing1");
+    guids.add("missing2");
+    manager.removeGuids(guids);
+    assertEquals(7, manager.guids.size());
+    assertEquals("test0", manager.guids.get(0));
+    assertEquals("test3", manager.guids.get(1));
+  }
+}

--- a/src/test/java/org/mozilla/gecko/sync/synchronizer/managers/test/TestArrayListGuidsManager.java
+++ b/src/test/java/org/mozilla/gecko/sync/synchronizer/managers/test/TestArrayListGuidsManager.java
@@ -1,3 +1,6 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
 package org.mozilla.gecko.sync.synchronizer.managers.test;
 
 import static org.junit.Assert.assertEquals;

--- a/test/src/org/mozilla/android/sync/test/AndroidBrowserRepositoryTest.java
+++ b/test/src/org/mozilla/android/sync/test/AndroidBrowserRepositoryTest.java
@@ -3,6 +3,7 @@
 
 package org.mozilla.android.sync.test;
 
+import java.util.Collection;
 import java.util.concurrent.ExecutorService;
 
 import org.mozilla.android.sync.test.helpers.DefaultBeginDelegate;
@@ -790,7 +791,7 @@ public abstract class AndroidBrowserRepositoryTest extends AndroidSyncTestCase {
       public void run() {
         session.guidsSince(System.currentTimeMillis(),
             new RepositorySessionGuidsSinceDelegate() {
-              public void onGuidsSinceSucceeded(String[] guids) {
+              public void onGuidsSinceSucceeded(Collection<String> guids) {
                 fail("Session inactive, should fail");
                 performNotify();
               }

--- a/test/src/org/mozilla/android/sync/test/helpers/DefaultGuidsSinceDelegate.java
+++ b/test/src/org/mozilla/android/sync/test/helpers/DefaultGuidsSinceDelegate.java
@@ -3,6 +3,8 @@
 
 package org.mozilla.android.sync.test.helpers;
 
+import java.util.Collection;
+
 import org.mozilla.gecko.sync.repositories.delegates.RepositorySessionGuidsSinceDelegate;
 
 public class DefaultGuidsSinceDelegate extends DefaultDelegate implements RepositorySessionGuidsSinceDelegate {
@@ -13,7 +15,7 @@ public class DefaultGuidsSinceDelegate extends DefaultDelegate implements Reposi
   }
 
   @Override
-  public void onGuidsSinceSucceeded(String[] guids) {
+  public void onGuidsSinceSucceeded(Collection<String> guids) {
     performNotify("default guids since delegate called", null);
   }
 }

--- a/test/src/org/mozilla/android/sync/test/helpers/ExpectGuidsSinceDelegate.java
+++ b/test/src/org/mozilla/android/sync/test/helpers/ExpectGuidsSinceDelegate.java
@@ -7,10 +7,12 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
 import junit.framework.AssertionFailedError;
+import android.util.Log;
 
 public class ExpectGuidsSinceDelegate extends DefaultGuidsSinceDelegate {
   private String[] expected;
@@ -22,7 +24,7 @@ public class ExpectGuidsSinceDelegate extends DefaultGuidsSinceDelegate {
   }
 
   @Override
-  public void onGuidsSinceSucceeded(String[] guids) {
+  public void onGuidsSinceSucceeded(Collection<String> guids) {
     AssertionFailedError err = null;
     try {
       int notIgnored = 0;

--- a/test/src/org/mozilla/android/sync/test/helpers/ExpectGuidsSinceDelegate.java
+++ b/test/src/org/mozilla/android/sync/test/helpers/ExpectGuidsSinceDelegate.java
@@ -12,7 +12,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import junit.framework.AssertionFailedError;
-import android.util.Log;
 
 public class ExpectGuidsSinceDelegate extends DefaultGuidsSinceDelegate {
   private String[] expected;

--- a/test/src/org/mozilla/android/sync/test/helpers/ExpectNoGUIDsSinceDelegate.java
+++ b/test/src/org/mozilla/android/sync/test/helpers/ExpectNoGUIDsSinceDelegate.java
@@ -5,22 +5,23 @@ package org.mozilla.android.sync.test.helpers;
 
 import static junit.framework.Assert.assertEquals;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
 import junit.framework.AssertionFailedError;
+import android.util.Log;
 
 public class ExpectNoGUIDsSinceDelegate extends DefaultGuidsSinceDelegate {
-  
   public Set<String> ignore = new HashSet<String>();
 
   @Override
-  public void onGuidsSinceSucceeded(String[] guids) {
+  public void onGuidsSinceSucceeded(Collection<String> guids) {
     AssertionFailedError err = null;
     try {
       int nonIgnored = 0;
-      for (int i = 0; i < guids.length; i++) {
-        if (!ignore.contains(guids[i])) {
+      for (String guid : guids) {
+        if (!ignore.contains(guid)) {
           nonIgnored++;
         }
       }

--- a/test/src/org/mozilla/android/sync/test/helpers/ExpectNoGUIDsSinceDelegate.java
+++ b/test/src/org/mozilla/android/sync/test/helpers/ExpectNoGUIDsSinceDelegate.java
@@ -10,7 +10,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import junit.framework.AssertionFailedError;
-import android.util.Log;
 
 public class ExpectNoGUIDsSinceDelegate extends DefaultGuidsSinceDelegate {
   public Set<String> ignore = new HashSet<String>();

--- a/test/src/org/mozilla/android/sync/test/helpers/RealPrefsMockGlobalSession.java
+++ b/test/src/org/mozilla/android/sync/test/helpers/RealPrefsMockGlobalSession.java
@@ -65,6 +65,11 @@ public class RealPrefsMockGlobalSession extends GlobalSession {
     protected RecordFactory getRecordFactory() {
       return null;
     }
+
+    @Override
+    protected int getBatchSize() {
+      return 5000;
+    }
   }
 
   public class MockStage implements GlobalSyncStage {

--- a/test/src/org/mozilla/gecko/sync/synchronizer/managers/test/TestSQLiteGuidsManager.java
+++ b/test/src/org/mozilla/gecko/sync/synchronizer/managers/test/TestSQLiteGuidsManager.java
@@ -1,0 +1,211 @@
+package org.mozilla.gecko.sync.synchronizer.managers.test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+
+import org.mozilla.android.sync.test.AndroidSyncTestCase;
+import org.mozilla.gecko.sync.synchronizer.managers.SQLiteGuidsManager;
+
+public class TestSQLiteGuidsManager extends AndroidSyncTestCase {
+  protected SQLiteGuidsManager manager = null;
+
+  protected void setUp() throws Exception {
+    super.setUp();
+
+    // Set up a separate collection that should be ignored.
+    manager = new SQLiteGuidsManager(getApplicationContext(), "separate", 5, 2);
+    manager.wipeDB();
+
+    ArrayList<String> guids = new ArrayList<String>();
+    for (int i = 0; i < 10; i++) {
+      guids.add("test" + i);
+    }
+    manager.addFreshGuids(guids);
+    manager.close();
+
+    manager = new SQLiteGuidsManager(getApplicationContext(), "test", 5, 2);
+  }
+
+  protected void tearDown() throws Exception {
+    if (manager != null) {
+      manager.close();
+    }
+
+    // Verify separate collection is untouched.
+    try {
+      manager = new SQLiteGuidsManager(getApplicationContext(), "separate", 5, 2);
+      assertEquals(5, manager.nextGuids().size());
+    } finally {
+      if (manager != null) {
+        manager.close();
+      }
+    }
+    super.tearDown();
+  }
+
+  /**
+   * Verify that adding GUIDs works.
+   */
+  public void testAddFreshGuids() throws Exception {
+    ArrayList<String> guids = new ArrayList<String>();
+    for (int i = 0; i < 10; i++) {
+      guids.add("test" + i);
+    }
+    manager.addFreshGuids(guids);
+
+    guids.clear();
+    for (int i = 5; i < 10; i++) {
+      guids.add("test" + i);
+    }
+    assertEquals(new HashSet<String>(guids), new HashSet<String>(manager.nextGuids()));
+
+    // Now add some new GUIDs and check they come out first.
+    guids.clear();
+    for (int i = 10; i < 20; i++) {
+      guids.add("test" + i);
+    }
+    manager.addFreshGuids(guids);
+
+    guids.clear();
+    for (int i = 15; i < 20; i++) {
+      guids.add("test" + i);
+    }
+    assertEquals(new HashSet<String>(guids), new HashSet<String>(manager.nextGuids()));
+  }
+
+  /**
+   * Verify that adding existing GUIDs works.
+   */
+  public void testFreshenGuids() throws Exception {
+    ArrayList<String> guids = new ArrayList<String>();
+    for (int i = 0; i < 10; i++) {
+      guids.add("test" + i);
+    }
+    manager.addFreshGuids(guids);
+
+    guids.clear();
+    for (int i = 5; i < 10; i++) {
+      guids.add("test" + i);
+    }
+    assertEquals(new HashSet<String>(guids), new HashSet<String>(manager.nextGuids()));
+
+    // Now add some of the existing and re-add some of the deleted GUIDs and see
+    // they come out correctly.
+    guids.clear();
+    for (int i = 3; i < 8; i++) {
+      guids.add("test" + i);
+    }
+    manager.addFreshGuids(guids);
+    assertEquals(new HashSet<String>(guids), new HashSet<String>(manager.nextGuids()));
+  }
+
+  /**
+   * Verify that removing existing GUIDs works.
+   */
+  public void testRemoveGuids() throws Exception {
+    ArrayList<String> guids = new ArrayList<String>();
+    for (int i = 0; i < 10; i++) {
+      guids.add("test" + i);
+    }
+    manager.addFreshGuids(guids);
+
+    // Remove GUIDs.
+    guids.clear();
+    for (int i = 3; i < 9; i++) {
+      guids.add("test" + i);
+    }
+    manager.removeGuids(guids);
+
+    // Check remaining GUIDs.
+    guids.clear();
+    for (int i = 0; i < 3; i++) {
+      guids.add("test" + i);
+    }
+    guids.add("test" + 9);
+    assertEquals(new HashSet<String>(guids), new HashSet<String>(manager.nextGuids()));
+  }
+
+  /**
+   * Verify that refreshing existing GUIDs works.
+   */
+  public void testRefreshGuids() throws Exception {
+    ArrayList<String> guids = new ArrayList<String>();
+    for (int i = 0; i < 10; i++) {
+      guids.add("test" + i);
+    }
+    manager.addFreshGuids(guids);
+
+    // Retry GUIDs.
+    manager.retryGuids(guids);
+
+    guids.clear();
+    for (int i = 5; i < 10; i++) {
+      guids.add("test" + i);
+    }
+    manager.retryGuids(guids);
+
+    // Check that we've expired most GUIDs.
+    guids.clear();
+    for (int i = 0; i < 5; i++) {
+      guids.add("test" + i);
+    }
+    assertEquals(new HashSet<String>(guids), new HashSet<String>(manager.nextGuids()));
+
+    // If we re-add, they should freshen back up.
+    guids.clear();
+    for (int i = 8; i < 10; i++) {
+      guids.add("test" + i);
+    }
+    manager.addFreshGuids(guids);
+
+    // And some old ones are still fresh.
+    guids.add("test2");
+    guids.add("test3");
+    guids.add("test4");
+    assertEquals(new HashSet<String>(guids), new HashSet<String>(manager.nextGuids()));
+
+    // Expire everything; only 8 and 9 should remain, since they were re-freshed.
+    guids.clear();
+    for (int i = 0; i < 10; i++) {
+      guids.add("test" + i);
+    }
+    manager.retryGuids(guids);
+
+    guids.clear();
+    for (int i = 8; i < 10; i++) {
+      guids.add("test" + i);
+    }
+    assertEquals(new HashSet<String>(guids), new HashSet<String>(manager.nextGuids()));
+  }
+
+  public void testNumGuidsRemaining() throws Exception {
+    ArrayList<String> guids = new ArrayList<String>();
+    for (int i = 0; i < 10; i++) {
+      guids.add("test" + i);
+    }
+    manager.addFreshGuids(guids);
+    assertEquals(10, manager.numGuidsRemaining());
+
+    guids.clear();
+    for (int i = 8; i < 10; i++) {
+      guids.add("test" + i);
+    }
+    manager.removeGuids(guids);
+    assertEquals(8, manager.numGuidsRemaining());
+
+    guids.clear();
+    for (int i = 0; i < 3; i++) {
+      guids.add("test" + i);
+    }
+    manager.removeGuids(guids);
+    assertEquals(5, manager.numGuidsRemaining());
+
+    // Add some GUIDs back.
+    guids.clear();
+    for (int i = 2; i < 9; i++) {
+      guids.add("test" + i);
+    }
+    manager.addFreshGuids(guids);
+    assertEquals(7, manager.numGuidsRemaining());
+  }
+}

--- a/test/src/org/mozilla/gecko/sync/synchronizer/managers/test/TestSQLiteGuidsManager.java
+++ b/test/src/org/mozilla/gecko/sync/synchronizer/managers/test/TestSQLiteGuidsManager.java
@@ -1,3 +1,6 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
 package org.mozilla.gecko.sync.synchronizer.managers.test;
 
 import java.util.ArrayList;


### PR DESCRIPTION
Download batching!
- `FillingRecordsChannel` calls `guidsSince` and `fetch` rather than `fetchSince`.
- `FillingGuidsManager` stores GUIDs remaining to be fetched.

Feedback requested about:
- `SQLiteGuidsManager` stores all GUIDs in a single table -- should this be separated into multiple tables?
- reset/wipe currently ignore the GUIDs remaining to be fetched.  Perhaps we should wipe the GUIDs collection?  We might have GUIDs waiting to be fetched that aren't returned by `guidsSince(0)` -- possibly if GUIDs are deleted on the server? 
- I made some assumptions about batch size for certain `ServerSyncStage` sub-classes.
