### PR TITLE
Bug 763020 and Bug 763021 - sync subset of engines and do a clients only sync after Send Tab

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
+++ b/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
@@ -162,6 +162,11 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
 
     registerCommands();
     prepareStages();
+    Collection<String> knownStageNames = new HashSet<String>();
+    for (Stage stage : Stage.getNamedStages()) {
+      knownStageNames.add(stage.getRepositoryName());
+    }
+    config.stagesToSync = Utils.getStagesToSyncFromBundle(knownStageNames, extras);
 
     // TODO: data-driven plan for the sync, referring to prepareStages.
   }

--- a/src/main/java/org/mozilla/gecko/sync/SyncConfiguration.java
+++ b/src/main/java/org/mozilla/gecko/sync/SyncConfiguration.java
@@ -204,6 +204,9 @@ public class SyncConfiguration implements CredentialsSource {
    * <p>
    * Generated <it>each sync</it> from extras bundle passed to
    * <code>SyncAdapter.onPerformSync</code> and not persisted.
+   * <p>
+   * Not synchronized! Set this exactly once per global session and don't modify
+   * it -- especially not from multiple threads.
    */
   public Collection<String> stagesToSync;
 

--- a/src/main/java/org/mozilla/gecko/sync/SyncConfiguration.java
+++ b/src/main/java/org/mozilla/gecko/sync/SyncConfiguration.java
@@ -6,6 +6,7 @@ package org.mozilla.gecko.sync;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -195,7 +196,16 @@ public class SyncConfiguration implements CredentialsSource {
    * Copied from latest downloaded meta/global record and used to generate a
    * fresh meta/global record for upload.
    */
-  public Set<String>     enabledEngineNames;
+  public Set<String> enabledEngineNames;
+
+  /**
+   * Names of stages to sync <it>this sync</it>, or <code>null</code> to sync
+   * all known stages.
+   * <p>
+   * Generated <it>each sync</it> from extras bundle passed to
+   * <code>SyncAdapter.onPerformSync</code> and not persisted.
+   */
+  public Collection<String> stagesToSync;
 
   // Fields that maintain a reference to a SharedPreferences instance, used for
   // persistence.

--- a/src/main/java/org/mozilla/gecko/sync/Utils.java
+++ b/src/main/java/org/mozilla/gecko/sync/Utils.java
@@ -14,6 +14,7 @@ import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
@@ -21,9 +22,11 @@ import java.util.TreeMap;
 import org.json.simple.JSONArray;
 import org.mozilla.apache.commons.codec.binary.Base32;
 import org.mozilla.apache.commons.codec.binary.Base64;
+import org.mozilla.gecko.sync.setup.Constants;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Bundle;
 
 public class Utils {
 
@@ -336,5 +339,106 @@ public class Utils {
 
   public static String toCommaSeparatedString(Collection<String> items) {
     return toDelimitedString(", ", items);
+  }
+
+  /**
+   * Names of stages to sync: (ALL intersect SYNC) intersect (ALL minus SKIP).
+   *
+   * @param knownStageNames collection of known stage names (set ALL above).
+   * @param toSync set SYNC above, or <code>null</code> to sync all known stages.
+   * @param toSkip set SKIP above, or <code>null</code> to not skip any stages.
+   * @return stage names.
+   */
+  public static Collection<String> getStagesToSync(final Collection<String> knownStageNames, Collection<String> toSync, Collection<String> toSkip) {
+    if (toSkip == null) {
+      toSkip = new HashSet<String>();
+    } else {
+      toSkip = new HashSet<String>(toSkip);
+    }
+
+    if (toSync == null) {
+      toSync = new HashSet<String>(knownStageNames);
+    } else {
+      toSync = new HashSet<String>(toSync);
+    }
+    toSync.retainAll(knownStageNames);
+    toSync.removeAll(toSkip);
+    return toSync;
+  }
+
+  /**
+   * Get names of stages to sync: (ALL intersect SYNC) intersect (ALL minus SKIP).
+   *
+   * @param knownStageNames collection of known stage names (set ALL above).
+   * @param bundle
+   *          a <code>Bundle</code> instance (possibly null) optionally containing keys
+   *          <code>EXTRAS_KEY_STAGES_TO_SYNC</code> (set SYNC above) and
+   *          <code>EXTRAS_KEY_STAGES_TO_SKIP</code> (set SKIP above).
+   * @return stage names.
+   */
+  public static Collection<String> getStagesToSyncFromBundle(final Collection<String> knownStageNames, final Bundle extras) {
+    if (extras == null) {
+      return knownStageNames;
+    }
+    String s1 = extras.getString(Constants.EXTRAS_KEY_STAGES_TO_SYNC);
+    String s2 = extras.getString(Constants.EXTRAS_KEY_STAGES_TO_SKIP);
+    if (s1 == null && s2 == null) {
+      return knownStageNames;
+    }
+
+    ArrayList<String> toSync = null;
+    ArrayList<String> toSkip = null;
+    if (s1 != null) {
+      try {
+        toSync = new ArrayList<String>(ExtendedJSONObject.parseJSONObject(s1).keySet());
+      } catch (Exception e) {
+        Logger.warn(LOG_TAG, "Got exception parsing stages to sync: '" + s1 + "'.", e);
+      }
+    }
+    if (s2 != null) {
+      try {
+        toSkip = new ArrayList<String>(ExtendedJSONObject.parseJSONObject(s2).keySet());
+      } catch (Exception e) {
+        Logger.warn(LOG_TAG, "Got exception parsing stages to skip: '" + s2 + "'.", e);
+      }
+    }
+
+    Logger.info(LOG_TAG, "Asked to sync '" + Utils.toCommaSeparatedString(toSync) +
+                         "' and to skip '" + Utils.toCommaSeparatedString(toSkip) + "'.");
+    return getStagesToSync(knownStageNames, toSync, toSkip);
+  }
+
+  /**
+   * Put names of stages to sync and to skip into sync extras bundle.
+   *
+   * @param bundle
+   *          a <code>Bundle</code> instance (possibly null).
+   * @param stagesToSync
+   *          collection of stage names to sync: key
+   *          <code>EXTRAS_KEY_STAGES_TO_SYNC</code>; ignored if <code>null</code>.
+   * @param stagesToSkip
+   *          collection of stage names to skip: key
+   *          <code>EXTRAS_KEY_STAGES_TO_SKIP</code>; ignored if <code>null</code>.
+   */
+  public static void putStageNamesToSync(final Bundle bundle, final String[] stagesToSync, final String[] stagesToSkip) {
+    if (bundle == null) {
+      return;
+    }
+
+    if (stagesToSync != null) {
+      ExtendedJSONObject o = new ExtendedJSONObject();
+      for (String stageName : stagesToSync) {
+        o.put(stageName, 0);
+      }
+      bundle.putString(Constants.EXTRAS_KEY_STAGES_TO_SYNC, o.toJSONString());
+    }
+
+    if (stagesToSkip != null) {
+      ExtendedJSONObject o = new ExtendedJSONObject();
+      for (String stageName : stagesToSkip) {
+        o.put(stageName, 0);
+      }
+      bundle.putString(Constants.EXTRAS_KEY_STAGES_TO_SKIP, o.toJSONString());
+    }
   }
 }

--- a/src/main/java/org/mozilla/gecko/sync/Utils.java
+++ b/src/main/java/org/mozilla/gecko/sync/Utils.java
@@ -380,26 +380,26 @@ public class Utils {
     if (extras == null) {
       return knownStageNames;
     }
-    String s1 = extras.getString(Constants.EXTRAS_KEY_STAGES_TO_SYNC);
-    String s2 = extras.getString(Constants.EXTRAS_KEY_STAGES_TO_SKIP);
-    if (s1 == null && s2 == null) {
+    String toSyncString = extras.getString(Constants.EXTRAS_KEY_STAGES_TO_SYNC);
+    String toSkipString = extras.getString(Constants.EXTRAS_KEY_STAGES_TO_SKIP);
+    if (toSyncString == null && toSkipString == null) {
       return knownStageNames;
     }
 
     ArrayList<String> toSync = null;
     ArrayList<String> toSkip = null;
-    if (s1 != null) {
+    if (toSyncString != null) {
       try {
-        toSync = new ArrayList<String>(ExtendedJSONObject.parseJSONObject(s1).keySet());
+        toSync = new ArrayList<String>(ExtendedJSONObject.parseJSONObject(toSyncString).keySet());
       } catch (Exception e) {
-        Logger.warn(LOG_TAG, "Got exception parsing stages to sync: '" + s1 + "'.", e);
+        Logger.warn(LOG_TAG, "Got exception parsing stages to sync: '" + toSyncString + "'.", e);
       }
     }
-    if (s2 != null) {
+    if (toSkipString != null) {
       try {
-        toSkip = new ArrayList<String>(ExtendedJSONObject.parseJSONObject(s2).keySet());
+        toSkip = new ArrayList<String>(ExtendedJSONObject.parseJSONObject(toSkipString).keySet());
       } catch (Exception e) {
-        Logger.warn(LOG_TAG, "Got exception parsing stages to skip: '" + s2 + "'.", e);
+        Logger.warn(LOG_TAG, "Got exception parsing stages to skip: '" + toSkipString + "'.", e);
       }
     }
 

--- a/src/main/java/org/mozilla/gecko/sync/setup/Constants.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/Constants.java
@@ -25,7 +25,7 @@ public class Constants {
    * which are the stage names to sync. For example:
    * <code>"{ \"stageToSync\": 0 }"</code>.
    */
-  public static final String EXTRAS_KEY_STAGES_TO_SYNC = "stagesToSync";
+  public static final String EXTRAS_KEY_STAGES_TO_SYNC = "sync";
 
   /**
    * Key in sync extras bundle specifying stages to skip this sync session.
@@ -34,7 +34,7 @@ public class Constants {
    * which are the stage names to skip. For example:
    * <code>"{ \"stageToSkip\": 0 }"</code>.
    */
-  public static final String EXTRAS_KEY_STAGES_TO_SKIP = "stagesToSkip";
+  public static final String EXTRAS_KEY_STAGES_TO_SKIP = "skip";
 
   // Constants for Activities.
   public static final String INTENT_EXTRA_IS_SETUP = "isSetup";

--- a/src/main/java/org/mozilla/gecko/sync/setup/Constants.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/Constants.java
@@ -18,6 +18,24 @@ public class Constants {
   public static final String NUM_CLIENTS          = "account.numClients";
   public static final String DATA_ENABLE_ON_UPGRADE = "data.enableOnUpgrade";
 
+  /**
+   * Key in sync extras bundle specifying stages to sync this sync session.
+   * <p>
+   * Corresponding value should be a String JSON-encoding an object, the keys of
+   * which are the stage names to sync. For example:
+   * <code>"{ \"stageToSync\": 0 }"</code>.
+   */
+  public static final String EXTRAS_KEY_STAGES_TO_SYNC = "stagesToSync";
+
+  /**
+   * Key in sync extras bundle specifying stages to skip this sync session.
+   * <p>
+   * Corresponding value should be a String JSON-encoding an object, the keys of
+   * which are the stage names to skip. For example:
+   * <code>"{ \"stageToSkip\": 0 }"</code>.
+   */
+  public static final String EXTRAS_KEY_STAGES_TO_SKIP = "stagesToSkip";
+
   // Constants for Activities.
   public static final String INTENT_EXTRA_IS_SETUP = "isSetup";
   public static final String INTENT_EXTRA_IS_PAIR  = "isPair";

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/SendTabActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/SendTabActivity.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.gecko.sync.setup.activities;
 
 import java.util.List;

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/SendTabActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/SendTabActivity.java
@@ -11,6 +11,8 @@ import org.mozilla.gecko.sync.repositories.NullCursorException;
 import org.mozilla.gecko.sync.repositories.android.ClientsDatabaseAccessor;
 import org.mozilla.gecko.sync.repositories.domain.ClientRecord;
 import org.mozilla.gecko.sync.setup.Constants;
+import org.mozilla.gecko.sync.stage.SyncClientsEngineStage;
+import org.mozilla.gecko.sync.syncadapter.SyncAdapter;
 
 import android.accounts.Account;
 import android.accounts.AccountManager;
@@ -105,6 +107,9 @@ public class SendTabActivity extends Activity {
         for (int i = 0; i < guids.length; i++) {
           processor.sendURIToClientForDisplay(uri, guids[i], title, getAccountGUID(), getApplicationContext());
         }
+
+        Logger.info(LOG_TAG, "Requesting immediate clients stage sync.");
+        SyncAdapter.requestImmediateSync(localAccount, new String[] { SyncClientsEngineStage.COLLECTION_NAME });
       }
     }.start();
 

--- a/src/main/java/org/mozilla/gecko/sync/stage/GlobalSyncStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/GlobalSyncStage.java
@@ -23,7 +23,7 @@ public interface GlobalSyncStage {
     ensureSpecialRecords,
     updateEngineTimestamps,
     */
-    syncClientsEngine("clients"),
+    syncClientsEngine(SyncClientsEngineStage.STAGE_NAME),
     /*
     processFirstSyncPref,
     processClientCommands,

--- a/src/main/java/org/mozilla/gecko/sync/stage/SyncClientsEngineStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/SyncClientsEngineStage.java
@@ -44,6 +44,7 @@ public class SyncClientsEngineStage implements GlobalSyncStage {
   private static final String LOG_TAG = "SyncClientsEngineStage";
 
   public static final String COLLECTION_NAME       = "clients";
+  public static final String STAGE_NAME            = COLLECTION_NAME;
   public static final int CLIENTS_TTL_REFRESH      = 604800000;   // 7 days in milliseconds.
   public static final int MAX_UPLOAD_FAILURE_COUNT = 5;
 
@@ -324,6 +325,15 @@ public class SyncClientsEngineStage implements GlobalSyncStage {
 
   @Override
   public void execute() throws NoSuchStageException {
+    // We can be disabled just for this sync.
+    boolean disabledThisSync = session.config.stagesToSync != null &&
+                               !session.config.stagesToSync.contains(STAGE_NAME);
+    if (disabledThisSync) {
+      Logger.debug(LOG_TAG, "Stage " + STAGE_NAME + " disabled just for this sync.");
+      session.advance();
+      return;
+    }
+
     if (shouldDownload()) {
       downloadClientRecords();   // Will kick off upload, too…
     } else {

--- a/src/main/java/org/mozilla/gecko/sync/syncadapter/SyncAdapter.java
+++ b/src/main/java/org/mozilla/gecko/sync/syncadapter/SyncAdapter.java
@@ -263,7 +263,7 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements GlobalSe
                    " with client guid " + getAccountGUID() +
                    " (sync account has " + getClientsCount() + " clients).");
 
-    thisSyncIsForced = (extras != null) && (extras.getBoolean("force", false));
+    thisSyncIsForced = (extras != null) && (extras.getBoolean(ContentResolver.SYNC_EXTRAS_MANUAL, false));
     long delay = delayMilliseconds();
     if (delay > 0) {
       if (thisSyncIsForced) {

--- a/src/main/java/org/mozilla/gecko/sync/syncadapter/SyncAdapter.java
+++ b/src/main/java/org/mozilla/gecko/sync/syncadapter/SyncAdapter.java
@@ -10,6 +10,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.TimeUnit;
 
 import org.json.simple.parser.ParseException;
+import org.mozilla.gecko.db.BrowserContract;
 import org.mozilla.gecko.sync.AlreadySyncingException;
 import org.mozilla.gecko.sync.GlobalConstants;
 import org.mozilla.gecko.sync.GlobalSession;
@@ -36,6 +37,7 @@ import android.accounts.AuthenticatorException;
 import android.accounts.OperationCanceledException;
 import android.content.AbstractThreadedSyncAdapter;
 import android.content.ContentProviderClient;
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
@@ -221,6 +223,29 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements GlobalSe
     return delayMilliseconds() > 0;
   }
 
+  /**
+   * Asynchronously request an immediate sync, optionally syncing only the given
+   * named stages.
+   * <p>
+   * Returns immediately.
+   *
+   * @param account
+   *          the Android <code>Account</code> instance to sync.
+   * @param stageNames
+   *          stage names to sync, or <code>null</code> to sync all known stages.
+   */
+  public static void requestImmediateSync(final Account account, final String[] stageNames) {
+    if (account == null) {
+      Logger.warn(LOG_TAG, "Not requesting immediate sync because Android Account is null.");
+      return;
+    }
+
+    final Bundle extras = new Bundle();
+    Utils.putStageNamesToSync(extras, stageNames, null);
+    extras.putBoolean(ContentResolver.SYNC_EXTRAS_MANUAL, true);
+    ContentResolver.requestSync(account, BrowserContract.AUTHORITY, extras);
+  }
+
   @Override
   public void onPerformSync(final Account account,
                             final Bundle extras,
@@ -233,6 +258,10 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements GlobalSe
     // Set these so that we don't need to thread them through assorted calls and callbacks.
     this.syncResult   = syncResult;
     this.localAccount = account;
+
+    Log.i(LOG_TAG, "Syncing client named " + getClientName() +
+                   " with client guid " + getAccountGUID() +
+                   " (sync account has " + getClientsCount() + " clients).");
 
     thisSyncIsForced = (extras != null) && (extras.getBoolean("force", false));
     long delay = delayMilliseconds();

--- a/test/src/org/mozilla/gecko/sync/test/TestUtils.java
+++ b/test/src/org/mozilla/gecko/sync/test/TestUtils.java
@@ -1,3 +1,6 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
 package org.mozilla.gecko.sync.test;
 
 import java.util.ArrayList;

--- a/test/src/org/mozilla/gecko/sync/test/TestUtils.java
+++ b/test/src/org/mozilla/gecko/sync/test/TestUtils.java
@@ -1,0 +1,77 @@
+package org.mozilla.gecko.sync.test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.mozilla.android.sync.test.AndroidSyncTestCase;
+import org.mozilla.gecko.sync.Utils;
+
+import android.os.Bundle;
+
+public class TestUtils extends AndroidSyncTestCase {
+  protected static void assertStages(String[] all, String[] sync, String[] skip, String[] expected) {
+    final Set<String> sAll = new HashSet<String>();
+    for (String s : all) {
+      sAll.add(s);
+    }
+    List<String> sSync = null;
+    if (sync != null) {
+      sSync = new ArrayList<String>();
+      for (String s : sync) {
+        sSync.add(s);
+      }
+    }
+    List<String> sSkip = null;
+    if (skip != null) {
+      sSkip = new ArrayList<String>();
+      for (String s : skip) {
+        sSkip.add(s);
+      }
+    }
+    List<String> stages = new ArrayList<String>(Utils.getStagesToSync(sAll, sSync, sSkip));
+    Collections.sort(stages);
+    List<String> exp = new ArrayList<String>();
+    for (String e : expected) {
+      exp.add(e);
+    }
+    assertEquals(exp, stages);
+  }
+
+  public void testGetStagesToSync() {
+    final String[] all = new String[] { "other1", "other2", "skip1", "skip2", "sync1", "sync2" };
+    assertStages(all, null, null, all);
+    assertStages(all, new String[] { "sync1" }, null, new String[] { "sync1" });
+    assertStages(all, null, new String[] { "skip1", "skip2" }, new String[] { "other1", "other2", "sync1", "sync2" });
+    assertStages(all, new String[] { "sync1", "sync2" }, new String[] { "skip1", "skip2" }, new String[] { "sync1", "sync2" });
+  }
+
+  protected static void assertStagesFromBundle(String[] all, String[] sync, String[] skip, String[] expected) {
+    final Set<String> sAll = new HashSet<String>();
+    for (String s : all) {
+      sAll.add(s);
+    }
+    final Bundle bundle = new Bundle();
+    Utils.putStageNamesToSync(bundle, sync, skip);
+
+    Collection<String> ss = Utils.getStagesToSyncFromBundle(sAll, bundle);
+    List<String> stages = new ArrayList<String>(ss);
+    Collections.sort(stages);
+    List<String> exp = new ArrayList<String>();
+    for (String e : expected) {
+      exp.add(e);
+    }
+    assertEquals(exp, stages);
+  }
+
+  public void testGetStagesToSyncFromBundle() {
+    final String[] all = new String[] { "other1", "other2", "skip1", "skip2", "sync1", "sync2" };
+    assertStagesFromBundle(all, null, null, all);
+    assertStagesFromBundle(all, new String[] { "sync1" }, null, new String[] { "sync1" });
+    assertStagesFromBundle(all, null, new String[] { "skip1", "skip2" }, new String[] { "other1", "other2", "sync1", "sync2" });
+    assertStagesFromBundle(all, new String[] { "sync1", "sync2" }, new String[] { "skip1", "skip2" }, new String[] { "sync1", "sync2" });
+  }
+}


### PR DESCRIPTION
I spent a few days implementing a data driven sync, computing dependencies with a topological sort, etc, etc, and when I was done I looked at the patch set and decided that it was a lot of churn for not a lot of win.  Our dependency tree is a line with a diamond of ServerSyncStages (with no interdependencies) in the middle. I think the approach of this ticket, which just has each stage check to see if it is disabled (like we already do if the stage is not present in meta/global) supports this dependency graph well.

See 763021 for detailed device testing instructions.
