### PR TITLE
Bug 741986 - sync scheduling

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/syncadapter/SyncAdapter.java
+++ b/src/main/java/org/mozilla/gecko/sync/syncadapter/SyncAdapter.java
@@ -241,8 +241,12 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements GlobalSe
         Log.i(LOG_TAG, "Forced sync: overruling remaining backoff of " + delay + "ms.");
       } else {
         Log.i(LOG_TAG, "Not syncing: must wait another " + delay + "ms.");
+        // We never want to ask Android to wait all that long, though.
         long remainingSeconds = delay / 1000;
-        syncResult.delayUntil = remainingSeconds + BACKOFF_PAD_SECONDS;
+        syncResult.delayUntil = Math.min(remainingSeconds,
+                                         MULTI_DEVICE_INTERVAL_MILLISECONDS / 1000);
+        // Padding ensures we don't "just miss" and wait two cycles.
+        syncResult.delayUntil += BACKOFF_PAD_SECONDS;
         return;
       }
     }

--- a/src/main/java/org/mozilla/gecko/sync/syncadapter/SyncAdapter.java
+++ b/src/main/java/org/mozilla/gecko/sync/syncadapter/SyncAdapter.java
@@ -464,6 +464,8 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements GlobalSe
   @Override
   public void requestBackoff(long backoff) {
     if (backoff > 0) {
+      // Fuzz the backoff time (up to 25% more) to prevent client lock-stepping; agrees with desktop.
+      backoff = backoff + Math.round((double) backoff * 0.25d * Math.random());
       this.extendEarliestNextSync(System.currentTimeMillis() + backoff);
     }
   }


### PR DESCRIPTION
In spirit, this is a follow-on to Bugs 763020 and 763021, although I'm not quite there yet.  I'd mostly like feedback on this approach of separating backoffs from regular sync intervals.

I started to complete Bug 741986, but need to discuss what we want to do there.  What I'd like to do is sync clients only perhaps once an hour, as needed, but that will mean introducing another timer pref, etc, and I got to wondering if we want to introduce a timer for every sync stage... we should talk about this.
