### PR TITLE
Bug 773562 - android.content.ActivityNotFoundException opening Sync sett...

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/setup/SyncAccounts.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/SyncAccounts.java
@@ -17,6 +17,7 @@ import org.mozilla.gecko.sync.syncadapter.SyncAdapter;
 
 import android.accounts.Account;
 import android.accounts.AccountManager;
+import android.content.ActivityNotFoundException;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
@@ -364,25 +365,40 @@ public class SyncAccounts {
     ContentResolver.setSyncAutomatically(account, authority, syncAutomatically);
   }
 
+  /**
+   * Start sync settings activity.
+   *
+   * @param context current Android context.
+   * @return the <code>Intent</code> started.
+   */
   public static Intent openSyncSettings(Context context) {
-    Intent intent = null;
-
+    // Bug 721760 - opening Sync settings takes user to Battery & Data Manager
+    // on a variety of Motorola devices. This work around tries to load the
+    // correct Intent by hand. Oh, Android.
     try {
       // Allow Motorola Blur package to be loaded.
       final int contextFlags = Context.CONTEXT_INCLUDE_CODE | Context.CONTEXT_IGNORE_SECURITY;
       Context foreignContext = context.createPackageContext(MOTO_BLUR_PACKAGE, contextFlags);
       Class<?> motorolaAccounts = foreignContext.getClassLoader().loadClass(MOTO_BLUR_SETTINGS_ACTIVITY);
       Logger.info(LOG_TAG, "Blur package found. Launching Moto activity.");
-      intent = new Intent(foreignContext, motorolaAccounts);
+
+      final Intent intent = new Intent(foreignContext, motorolaAccounts);
+      intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+      context.startActivity(intent);
+      return intent;
     } catch (NameNotFoundException e) {
-      Logger.debug(LOG_TAG, "No Blur package. Using default Sync Settings intent.");
-      intent = new Intent(Settings.ACTION_SYNC_SETTINGS);
+      Logger.debug(LOG_TAG, "Blur package not found. Launching Sync Settings normally.");
     } catch (ClassNotFoundException e) {
-      Logger.warn(LOG_TAG, "Blur package found but no class. Launching Sync Settings normally.", e);
-      intent = new Intent(Settings.ACTION_SYNC_SETTINGS);
+      Logger.warn(LOG_TAG, "Blur package found but class not found. Launching Sync Settings normally.", e);
+    } catch (ActivityNotFoundException e) {
+      // Bug 773562 - android.content.ActivityNotFoundException on Motorola devices.
+      Logger.warn(LOG_TAG, "Blur package and class found, but activity not found. Launching Sync Settings normally.", e);
     }
+
+    // Open default Sync settings activity.
+    final Intent intent = new Intent(Settings.ACTION_SYNC_SETTINGS);
     intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-    context.startActivity(intent);
+    context.startActivity(intent); // We should always find this Activity.
     return intent;
   }
 


### PR DESCRIPTION
...ings on Motorola devices.

Oh, Android.  Work around by catching Activity and falling back to
default Sync settings activity.  I re-worked the code because I
couldn't convince myself that intent was always non-null.
