### PR TITLE
Bug 775360 - "Show me how" link should not launch Browser Intents page.

### DIFF
--- a/manifests/SyncAndroidManifest_activities.xml.in
+++ b/manifests/SyncAndroidManifest_activities.xml.in
@@ -12,6 +12,9 @@
         </activity>
 
         <activity
+            android:name="org.mozilla.gecko.sync.setup.activities.WebViewActivity" />
+
+        <activity
             android:clearTaskOnLaunch="true"
             android:name="org.mozilla.gecko.sync.setup.activities.AccountActivity"
             android:windowSoftInputMode="adjustPan|stateHidden"/>

--- a/res/layout/sync_setup_webview.xml
+++ b/res/layout/sync_setup_webview.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  style="@style/SyncLayout" >
+  <WebView android:id="@+id/web_engine"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent" />
+</LinearLayout>

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSyncActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSyncActivity.java
@@ -224,7 +224,9 @@ public class SetupSyncActivity extends AccountAuthenticatorActivity {
     } else {
       uri = Uri.parse(Constants.LINK_FIND_ADD_DEVICE);
     }
-    startActivity(new Intent(Intent.ACTION_VIEW, uri));
+    Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+    intent.setClassName(GlobalConstants.BROWSER_INTENT_PACKAGE, GlobalConstants.BROWSER_INTENT_CLASS);
+    startActivity(intent);
   }
 
   /* Controller methods */

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSyncActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/SetupSyncActivity.java
@@ -224,8 +224,8 @@ public class SetupSyncActivity extends AccountAuthenticatorActivity {
     } else {
       uri = Uri.parse(Constants.LINK_FIND_ADD_DEVICE);
     }
-    Intent intent = new Intent(Intent.ACTION_VIEW, uri);
-    intent.setClassName(GlobalConstants.BROWSER_INTENT_PACKAGE, GlobalConstants.BROWSER_INTENT_CLASS);
+    Intent intent = new Intent(this, WebViewActivity.class);
+    intent.setData(uri);
     startActivity(intent);
   }
 

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/WebViewActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/WebViewActivity.java
@@ -10,6 +10,8 @@ import org.mozilla.gecko.sync.Logger;
 import android.app.Activity;
 import android.net.Uri;
 import android.os.Bundle;
+import android.view.Window;
+import android.webkit.WebChromeClient;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
@@ -24,6 +26,7 @@ public class WebViewActivity extends Activity {
   @Override
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
+    getWindow().requestFeature(Window.FEATURE_PROGRESS);
     setContentView(R.layout.sync_setup_webview);
     // Extract URI to launch from Intent.
     Uri uri = this.getIntent().getData();
@@ -33,8 +36,16 @@ public class WebViewActivity extends Activity {
     }
 
     WebView wv = (WebView) findViewById(R.id.web_engine);
+    // Add a progress bar.
+    final Activity activity = this;
+    wv.setWebChromeClient(new WebChromeClient() {
+      public void onProgressChanged(WebView view, int progress) {
+        // Activities and WebViews measure progress with different scales.
+        // The progress meter will automatically disappear when we reach 100%
+        activity.setProgress(progress * 100);
+      }
+    });
     wv.setWebViewClient(new WebViewClient() {
-      
       // Handle url loading in this WebView, instead of asking the ActivityManager.
       @Override
       public boolean shouldOverrideUrlLoading(WebView view, String url) {

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/WebViewActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/WebViewActivity.java
@@ -14,26 +14,21 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
 /**
- * Displays Uri in an embedded WebView. Closes if there no Uri is passed in.
+ * Displays URI in an embedded WebView. Closes if there no URI is passed in.
  * @author liuche
  *
  */
 public class WebViewActivity extends Activity {
-  private final String LOG_TAG = "WebViewActivity";
-
-  public WebViewActivity() {
-    super();
-    Logger.info(LOG_TAG, "WebViewActivty constructor called.");
-  }
+  private final static String LOG_TAG = "WebViewActivity";
 
   @Override
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.sync_setup_webview);
-    // Extract uri to launch from Intent.
+    // Extract URI to launch from Intent.
     Uri uri = this.getIntent().getData();
     if (uri == null) {
-      Logger.debug(LOG_TAG, "No Uri passed to display.");
+      Logger.debug(LOG_TAG, "No URI passed to display.");
       finish();
     }
 

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/WebViewActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/WebViewActivity.java
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.gecko.sync.setup.activities;
+
+import org.mozilla.gecko.R;
+import org.mozilla.gecko.sync.Logger;
+
+import android.app.Activity;
+import android.net.Uri;
+import android.os.Bundle;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+
+/**
+ * Displays Uri in an embedded WebView. Closes if there no Uri is passed in.
+ * @author liuche
+ *
+ */
+public class WebViewActivity extends Activity {
+  private final String LOG_TAG = "WebViewActivity";
+
+  public WebViewActivity() {
+    super();
+    Logger.info(LOG_TAG, "WebViewActivty constructor called.");
+  }
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.sync_setup_webview);
+    // Extract uri to launch from Intent.
+    Uri uri = this.getIntent().getData();
+    if (uri == null) {
+      Logger.debug(LOG_TAG, "No Uri passed to display.");
+      finish();
+    }
+
+    WebView wv = (WebView) findViewById(R.id.web_engine);
+    wv.setWebViewClient(new WebViewClient() {
+      
+      // Handle url loading in this WebView, instead of asking the ActivityManager.
+      @Override
+      public boolean shouldOverrideUrlLoading(WebView view, String url) {
+        view.loadUrl(url);
+        return false;
+      }
+    });
+    wv.loadUrl(uri.toString());
+    
+  }
+}


### PR DESCRIPTION
This now launches Fennec instead of the browser choice window.

However, some "back" behavior is weird. If you launch Sync setup from Fennec, hitting back from the "Show me how" link follows the Fennec activity stack, instead of bringing you back to Sync setup. Tried a few flags, didn't seem to fix anything. May be a Fennec problem, because built-in browser handles "back" action correctly, but investigating further.
