### PR TITLE
Bug 753878 - engines

### DIFF
--- a/manifests/SyncAndroidManifest_activities.xml.in
+++ b/manifests/SyncAndroidManifest_activities.xml.in
@@ -33,6 +33,9 @@
             android:name="org.mozilla.gecko.sync.setup.activities.RedirectToSetupActivity"
             android:windowSoftInputMode="adjustResize|stateHidden"/>
 
+        <!-- Secondary Sync activities. These depend on other activities for context
+             (display a result, or a next step). Since these don't make sense as stand-alone
+             activities, set excludeFromRecents="true" -->
         <activity
             android:theme="@style/SyncTheme"
             android:noHistory="true"
@@ -64,6 +67,7 @@
 
         <activity
             android:theme="@style/SyncTheme"
+            android:excludeFromRecents="true"
             android:icon="@drawable/icon"
             android:label="@string/sync_app_name"
             android:configChanges="orientation"

--- a/manifests/SyncAndroidManifest_activities.xml.in
+++ b/manifests/SyncAndroidManifest_activities.xml.in
@@ -36,12 +36,24 @@
         <activity
             android:theme="@style/SyncTheme"
             android:noHistory="true"
+            android:excludeFromRecents="true"
             android:name="org.mozilla.gecko.sync.setup.activities.SetupFailureActivity" />
 
         <activity
             android:theme="@style/SyncTheme"
             android:noHistory="true"
+            android:excludeFromRecents="true"
             android:name="org.mozilla.gecko.sync.setup.activities.SetupSuccessActivity" />
+
+        <activity
+            android:excludeFromRecents="true"
+            android:taskAffinity="org.mozilla.gecko.sync.setup"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar"
+            android:name="org.mozilla.gecko.sync.config.activities.ConfigureEnginesActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+            </intent-filter>
+         </activity>
 
         <receiver
             android:name="org.mozilla.gecko.sync.receivers.UpgradeReceiver">

--- a/src/main/java/org/mozilla/gecko/sync/ExtendedJSONObject.java
+++ b/src/main/java/org/mozilla/gecko/sync/ExtendedJSONObject.java
@@ -166,8 +166,19 @@ public class ExtendedJSONObject {
     map.put(key, value);
   }
 
-  public void remove(String key) {
-    this.object.remove(key);
+  /**
+   * Remove key-value pair from JSONObject.
+   * @param key
+   * @return true if key exists and was removed, false otherwise.
+   *
+   */
+  public boolean remove(String key) {
+    Object res = this.object.remove(key);
+    if (res == null) {
+      return false;
+    } else {
+      return true;
+    }
   }
 
   public ExtendedJSONObject getObject(String key) throws NonObjectJSONException {

--- a/src/main/java/org/mozilla/gecko/sync/ExtendedJSONObject.java
+++ b/src/main/java/org/mozilla/gecko/sync/ExtendedJSONObject.java
@@ -166,6 +166,10 @@ public class ExtendedJSONObject {
     map.put(key, value);
   }
 
+  public void remove(String key) {
+    this.object.remove(key);
+  }
+
   public ExtendedJSONObject getObject(String key) throws NonObjectJSONException {
     Object o = this.object.get(key);
     if (o == null) {

--- a/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
+++ b/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
@@ -77,6 +77,10 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
    * Map from engine name to new settings for an updated meta/global record.
    */
   public final Map<String, EngineSettings> enginesToUpdate = new HashMap<String, EngineSettings>();
+
+  /**
+   * Track engine names to be removed from an updated meta/global record.
+   */
   public final Set<String> enginesToRemove = new HashSet<String>();
 
   /*
@@ -394,6 +398,10 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
     enginesToUpdate.put(engineName, engineSettings);
   }
 
+  /**
+   * Adds engineName to be removed when updating meta/global to be uploaded.
+   * @param engineName
+   */
   public void removeEngineFromMetaGlobal(String engineName) {
     enginesToRemove.add(engineName);
   }
@@ -405,9 +413,9 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
     }
 
     if (Logger.shouldLogVerbose(LOG_TAG)) {
-      Logger.trace(LOG_TAG, "Uploading updated meta/global record since there are engines requesting upload [" +
-          Utils.toCommaSeparatedString(enginesToUpdate.keySet()) +
-          "] or engines to remove [" + Utils.toCommaSeparatedString(enginesToRemove));
+      Logger.trace(LOG_TAG, "Uploading updated meta/global record since there are engine changes to meta/global.");
+      Logger.trace(LOG_TAG, "Engines requesting upload [" + Utils.toCommaSeparatedString(enginesToUpdate.keySet()) + "]");
+      Logger.trace(LOG_TAG, "Engines to remove [" + Utils.toCommaSeparatedString(enginesToRemove) + "]");
     }
 
     return true;
@@ -964,11 +972,7 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
     if (config.enabledEngineNames != null) {
       return config.enabledEngineNames;
     }
-    Set<String> engineNames = new HashSet<String>();
-    for (Stage stage : Stage.getNamedStages()) {
-      engineNames.add(stage.getRepositoryName());
-    }
-    return engineNames;
+    return SyncConfiguration.validEngineNames();
   }
 
   /**

--- a/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
+++ b/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
@@ -35,6 +35,7 @@ import org.mozilla.gecko.sync.net.SyncStorageRecordRequest;
 import org.mozilla.gecko.sync.net.SyncStorageRequest;
 import org.mozilla.gecko.sync.net.SyncStorageRequestDelegate;
 import org.mozilla.gecko.sync.net.SyncStorageResponse;
+import org.mozilla.gecko.sync.setup.Constants;
 import org.mozilla.gecko.sync.stage.AndroidBrowserBookmarksServerSyncStage;
 import org.mozilla.gecko.sync.stage.AndroidBrowserHistoryServerSyncStage;
 import org.mozilla.gecko.sync.stage.CheckPreconditionsStage;
@@ -76,6 +77,7 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
    * Map from engine name to new settings for an updated meta/global record.
    */
   public final Map<String, EngineSettings> enginesToUpdate = new HashMap<String, EngineSettings>();
+  public final Set<String> enginesToRemove = new HashSet<String>();
 
   /*
    * Key accessors.
@@ -392,15 +394,20 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
     enginesToUpdate.put(engineName, engineSettings);
   }
 
+  public void removeEngineFromMetaGlobal(String engineName) {
+    enginesToRemove.add(engineName);
+  }
+
   public boolean hasUpdatedMetaGlobal() {
-    if (enginesToUpdate.isEmpty()) {
+    if (enginesToUpdate.isEmpty() && enginesToRemove.isEmpty()) {
       Logger.info(LOG_TAG, "Not uploading updated meta/global record since there are no engines requesting upload.");
       return false;
     }
 
     if (Logger.shouldLogVerbose(LOG_TAG)) {
-      Logger.trace(LOG_TAG, "Uploading updated meta/global record since there are engines requesting upload: " +
-          Utils.toCommaSeparatedString(enginesToUpdate.keySet()));
+      Logger.trace(LOG_TAG, "Uploading updated meta/global record since there are engines requesting upload [" +
+          Utils.toCommaSeparatedString(enginesToUpdate.keySet()) +
+          "] or engines to remove [" + Utils.toCommaSeparatedString(enginesToRemove));
     }
 
     return true;
@@ -411,7 +418,17 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
     for (Entry<String, EngineSettings> pair : enginesToUpdate.entrySet()) {
       engines.put(pair.getKey(), pair.getValue().toJSONObject());
     }
+    for (String key : enginesToRemove) {
+      engines.remove(key);
+    }
+    // Persist updated engines of meta/global to SyncConfiguration, so persisted meta/global will match what is uploaded.
+    config.enabledEngineNames = config.metaGlobal.getEnabledEngineNames();
+
+    enginesToRemove.clear();
     enginesToUpdate.clear();
+
+    // Clear SharedPrefs for engine state.
+    context.getSharedPreferences(Constants.PREFS_ENGINE_SELECTION, Utils.SHARED_PREFERENCES_MODE).edit().clear().commit();
   }
 
   /**
@@ -627,6 +644,8 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
    */
   public void processMetaGlobal(MetaGlobal global) {
     config.metaGlobal = global;
+    config.metaGlobal.metaURL = config.metaURL();
+    config.metaGlobal.credentials = this.credentials();
 
     Long storageVersion = global.getStorageVersion();
     if (storageVersion == null) {

--- a/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
+++ b/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
@@ -429,8 +429,6 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
     for (String key : enginesToRemove) {
       engines.remove(key);
     }
-    // Persist updated engines of meta/global to SyncConfiguration, so persisted meta/global will match what is uploaded.
-    config.enabledEngineNames = config.metaGlobal.getEnabledEngineNames();
 
     enginesToRemove.clear();
     enginesToUpdate.clear();

--- a/src/main/java/org/mozilla/gecko/sync/MetaGlobalException.java
+++ b/src/main/java/org/mozilla/gecko/sync/MetaGlobalException.java
@@ -34,4 +34,12 @@ public class MetaGlobalException extends SyncException {
       this.serverSyncID = syncID;
     }
   }
+
+  public static class MetaGlobalEngineStateChangedException extends MetaGlobalException {
+    private static final long serialVersionUID = 1L;
+    public final boolean isEnabled;
+    public MetaGlobalEngineStateChangedException(boolean isEnabled) {
+      this.isEnabled = isEnabled;
+    }
+  }
 }

--- a/src/main/java/org/mozilla/gecko/sync/PersistedMetaGlobal.java
+++ b/src/main/java/org/mozilla/gecko/sync/PersistedMetaGlobal.java
@@ -9,6 +9,10 @@ import org.mozilla.gecko.sync.Logger;
 
 import android.content.SharedPreferences;
 
+/**
+ * Persisted version of meta/global from server. This should be exactly what is downloaded.
+ *
+ */
 public class PersistedMetaGlobal {
   public static final String LOG_TAG = "PersistedMetaGlobal";
 

--- a/src/main/java/org/mozilla/gecko/sync/PersistedMetaGlobal.java
+++ b/src/main/java/org/mozilla/gecko/sync/PersistedMetaGlobal.java
@@ -10,7 +10,7 @@ import org.mozilla.gecko.sync.Logger;
 import android.content.SharedPreferences;
 
 /**
- * Persisted version of meta/global from server. This should be exactly what is downloaded.
+ * Persisted version of meta/global from server. This should match what is downloaded.
  *
  */
 public class PersistedMetaGlobal {

--- a/src/main/java/org/mozilla/gecko/sync/SyncConfiguration.java
+++ b/src/main/java/org/mozilla/gecko/sync/SyncConfiguration.java
@@ -258,6 +258,20 @@ public class SyncConfiguration implements CredentialsSource {
     return new ConfigurationBranch(this, prefix);
   }
 
+  public static Set<String> getEnabledEngineNames(SharedPreferences prefs) {
+    String json = prefs.getString(PREF_ENABLED_ENGINE_NAMES, null);
+    if (json == null) {
+      return null;
+    }
+    try {
+      ExtendedJSONObject o = ExtendedJSONObject.parseJSONObject(json);
+      return new HashSet<String>(o.keySet());
+    } catch (Exception e) {
+      // enabledEngineNames can be null.
+      return null;
+    }
+  }
+
   public void loadFromPrefs(SharedPreferences prefs) {
 
     if (prefs.contains(PREF_CLUSTER_URL)) {
@@ -273,15 +287,7 @@ public class SyncConfiguration implements CredentialsSource {
       syncID = prefs.getString(PREF_SYNC_ID, null);
       Logger.trace(LOG_TAG, "Set syncID from bundle: " + syncID);
     }
-    if (prefs.contains(PREF_ENABLED_ENGINE_NAMES)) {
-      String json = prefs.getString(PREF_ENABLED_ENGINE_NAMES, null);
-      try {
-        ExtendedJSONObject o = ExtendedJSONObject.parseJSONObject(json);
-        enabledEngineNames = new HashSet<String>(o.keySet());
-      } catch (Exception e) {
-        // enabledEngineNames can be null.
-      }
-    }
+    enabledEngineNames = getEnabledEngineNames(prefs);
     // We don't set crypto/keys here because we need the syncKeyBundle to decrypt the JSON
     // and we won't have it on construction.
     // TODO: MetaGlobal, password, infoCollections.

--- a/src/main/java/org/mozilla/gecko/sync/SyncConfiguration.java
+++ b/src/main/java/org/mozilla/gecko/sync/SyncConfiguration.java
@@ -13,6 +13,7 @@ import java.util.Set;
 
 import org.mozilla.gecko.sync.crypto.KeyBundle;
 import org.mozilla.gecko.sync.crypto.PersistedCrypto5Keys;
+import org.mozilla.gecko.sync.stage.GlobalSyncStage.Stage;
 
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
@@ -248,6 +249,16 @@ public class SyncConfiguration implements CredentialsSource {
     return prefsSource.getPrefs(prefsPath, Utils.SHARED_PREFERENCES_MODE);
   }
 
+  /**
+   * @return Set<String> of valid engine names that Android Sync implements.
+   */
+  public static Set<String> validEngineNames() {
+    Set<String> engineNames = new HashSet<String>();
+    for (Stage stage : Stage.getNamedStages()) {
+      engineNames.add(stage.getRepositoryName());
+    }
+    return engineNames;
+  }
   /**
    * Return a convenient accessor for part of prefs.
    * @return

--- a/src/main/java/org/mozilla/gecko/sync/config/activities/AndroidSyncConfigureActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/config/activities/AndroidSyncConfigureActivity.java
@@ -21,7 +21,6 @@ import android.os.Bundle;
 
 /**
  * Activity for configuring Firefox Sync settings, that does work of fetching account information.
- * @author liuche
  *
  */
 public abstract class AndroidSyncConfigureActivity extends Activity {

--- a/src/main/java/org/mozilla/gecko/sync/config/activities/AndroidSyncConfigureActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/config/activities/AndroidSyncConfigureActivity.java
@@ -1,7 +1,6 @@
 package org.mozilla.gecko.sync.config.activities;
 
 
-import org.mozilla.gecko.sync.GlobalConstants;
 import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.ThreadPool;
 import org.mozilla.gecko.sync.setup.SyncAccounts;
@@ -44,7 +43,7 @@ public abstract class AndroidSyncConfigureActivity extends Activity {
     ThreadPool.run(new Runnable() {
       @Override
       public void run() {
-        Account[] accounts = mAccountManager.getAccountsByType(GlobalConstants.ACCOUNTTYPE_SYNC);
+        Account[] accounts = SyncAccounts.syncAccounts(mContext);
         if (accounts.length == 0) {
           Logger.error(LOG_TAG, "Failed to get account!");
           finish();
@@ -53,8 +52,13 @@ public abstract class AndroidSyncConfigureActivity extends Activity {
           // Only supports one account per type.
           Account account = accounts[0];
           try {
-            SharedPreferences prefs = SyncAccounts.getPrefsFromDefaultAccount(mContext, mAccountManager, account);
-            accountConsumer.run(prefs);
+            final SharedPreferences prefs = SyncAccounts.getPrefsFromDefaultAccount(mContext, mAccountManager, account);
+            runOnUiThread(new Runnable() {
+              @Override
+              public void run() {
+                accountConsumer.run(prefs);
+              }
+            });
           } catch (Exception e) {
             Logger.error(LOG_TAG, "Failed to get sync account info or shared preferences.", e);
             finish();

--- a/src/main/java/org/mozilla/gecko/sync/config/activities/AndroidSyncConfigureActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/config/activities/AndroidSyncConfigureActivity.java
@@ -1,19 +1,13 @@
 package org.mozilla.gecko.sync.config.activities;
 
 
-import java.util.concurrent.TimeUnit;
-
 import org.mozilla.gecko.sync.GlobalConstants;
 import org.mozilla.gecko.sync.Logger;
-import org.mozilla.gecko.sync.SyncConfiguration;
 import org.mozilla.gecko.sync.ThreadPool;
-import org.mozilla.gecko.sync.Utils;
-import org.mozilla.gecko.sync.setup.Constants;
+import org.mozilla.gecko.sync.setup.SyncAccounts;
 
 import android.accounts.Account;
 import android.accounts.AccountManager;
-import android.accounts.AccountManagerCallback;
-import android.accounts.AccountManagerFuture;
 import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -39,66 +33,33 @@ public abstract class AndroidSyncConfigureActivity extends Activity {
     mAccountManager = AccountManager.get(mContext);
   }
 
-  private void invalidateAuthToken(Account account) {
-    AccountManagerFuture<Bundle> future = mAccountManager.getAuthToken(account, Constants.AUTHTOKEN_TYPE_PLAIN, true, null, null);
-    String token;
-    try {
-      token = future.getResult().getString(AccountManager.KEY_AUTHTOKEN);
-      mAccountManager.invalidateAuthToken(GlobalConstants.ACCOUNTTYPE_SYNC, token);
-    } catch (Exception e) {
-      Logger.error(LOG_TAG, "Couldn't invalidate auth token: " + e);
-    }
-  }
-
-  protected Account getAccount() {
-    Account[] accounts = mAccountManager.getAccountsByType(GlobalConstants.ACCOUNTTYPE_SYNC);
-    if (accounts.length == 0) {
-      return null;
-    } else {
-      // Only support one account per type.
-      return accounts[0];
-    }
-  }
-
+  /**
+   * Fetches the prefs associated with a Sync account, and passes the prefs to
+   * the PrefsConsumer.
+   *
+   * @param accountConsumer interface for consuming prefs from an Account.
+   */
   public void fetchPrefsAndConsume(final PrefsConsumer accountConsumer) {
-    final Account account = getAccount();
-    if (account == null) {
-      Logger.error(LOG_TAG, "Failed to get account!");
-      finish();
-      return;
-    }
-
-    // Get authToken and pass to AccountConsumer.
+    // Run Account management on separate thread to avoid strict mode policy violations.
     ThreadPool.run(new Runnable() {
-
       @Override
       public void run() {
-        // Hack to fix broken Account creation.
-        invalidateAuthToken(account);
-        mAccountManager.getAuthToken(account, Constants.AUTHTOKEN_TYPE_PLAIN, true, new AccountManagerCallback<Bundle>() {
-
-          @Override
-          public void run(AccountManagerFuture<Bundle> future) {
-            Logger.trace(LOG_TAG, "AccountManagerCallback invoked.");
-            // TODO: N.B.: Future must not be used on the main thread.
-            try {
-              Bundle bundle = future.getResult(60L, TimeUnit.SECONDS);
-              // Ignoring KEY_INTENT check.
-              String username = bundle.getString(Constants.OPTION_USERNAME);
-              String serverURL = bundle.getString(Constants.OPTION_SERVER);
-              Logger.debug(LOG_TAG, "username null? " + (null == username) + ", serverURL null? " + (null == serverURL));
-              // Get SharedPreferences and display configuration editor.
-              // Prefs path args are taken directly from constants right now, because prefs are automatically migrated.
-              String prefsPath = Utils.getPrefsPath(GlobalConstants.BROWSER_INTENT_PACKAGE, username, serverURL, Constants.DEFAULT_PROFILE, SyncConfiguration.CURRENT_PREFS_VERSION);
-              SharedPreferences prefs = mContext.getSharedPreferences(prefsPath, Utils.SHARED_PREFERENCES_MODE);
-              accountConsumer.run(prefs);
-            } catch (Exception e) {
-              Logger.error(LOG_TAG, "Failed to get sync information or shared preferences.", e);
-              finish();
-              return;
-            }
+        Account[] accounts = mAccountManager.getAccountsByType(GlobalConstants.ACCOUNTTYPE_SYNC);
+        if (accounts.length == 0) {
+          Logger.error(LOG_TAG, "Failed to get account!");
+          finish();
+          return;
+        } else {
+          // Only supports one account per type.
+          Account account = accounts[0];
+          try {
+            SharedPreferences prefs = SyncAccounts.getPrefsFromDefaultAccount(mContext, mAccountManager, account);
+            accountConsumer.run(prefs);
+          } catch (Exception e) {
+            Logger.error(LOG_TAG, "Failed to get sync account info or shared preferences.", e);
+            finish();
           }
-        }, null);
+        }
       }
     });
   }

--- a/src/main/java/org/mozilla/gecko/sync/config/activities/AndroidSyncConfigureActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/config/activities/AndroidSyncConfigureActivity.java
@@ -1,0 +1,106 @@
+package org.mozilla.gecko.sync.config.activities;
+
+
+import java.util.concurrent.TimeUnit;
+
+import org.mozilla.gecko.sync.GlobalConstants;
+import org.mozilla.gecko.sync.Logger;
+import org.mozilla.gecko.sync.SyncConfiguration;
+import org.mozilla.gecko.sync.ThreadPool;
+import org.mozilla.gecko.sync.Utils;
+import org.mozilla.gecko.sync.setup.Constants;
+
+import android.accounts.Account;
+import android.accounts.AccountManager;
+import android.accounts.AccountManagerCallback;
+import android.accounts.AccountManagerFuture;
+import android.app.Activity;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+
+/**
+ * Activity for configuring Firefox Sync settings, that does work of fetching account information.
+ * @author liuche
+ *
+ */
+public abstract class AndroidSyncConfigureActivity extends Activity {
+  public final static String LOG_TAG = "AndroidSyncConfigAct";
+  protected AccountManager mAccountManager;
+  protected Context mContext;
+
+  protected interface PrefsConsumer {
+    public void run(SharedPreferences prefs);
+  }
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    mContext = getApplicationContext();
+    mAccountManager = AccountManager.get(mContext);
+  }
+
+  private void invalidateAuthToken(Account account) {
+    AccountManagerFuture<Bundle> future = mAccountManager.getAuthToken(account, Constants.AUTHTOKEN_TYPE_PLAIN, true, null, null);
+    String token;
+    try {
+      token = future.getResult().getString(AccountManager.KEY_AUTHTOKEN);
+      mAccountManager.invalidateAuthToken(GlobalConstants.ACCOUNTTYPE_SYNC, token);
+    } catch (Exception e) {
+      Logger.error(LOG_TAG, "Couldn't invalidate auth token: " + e);
+    }
+  }
+
+  protected Account getAccount() {
+    Account[] accounts = mAccountManager.getAccountsByType(GlobalConstants.ACCOUNTTYPE_SYNC);
+    if (accounts.length == 0) {
+      return null;
+    } else {
+      // Only support one account per type.
+      return accounts[0];
+    }
+  }
+
+  public void fetchPrefsAndConsume(final PrefsConsumer accountConsumer) {
+    final Account account = getAccount();
+    if (account == null) {
+      Logger.error(LOG_TAG, "Failed to get account!");
+      finish();
+      return;
+    }
+
+    // Get authToken and pass to AccountConsumer.
+    ThreadPool.run(new Runnable() {
+
+      @Override
+      public void run() {
+        // Hack to fix broken Account creation.
+        invalidateAuthToken(account);
+        mAccountManager.getAuthToken(account, Constants.AUTHTOKEN_TYPE_PLAIN, true, new AccountManagerCallback<Bundle>() {
+
+          @Override
+          public void run(AccountManagerFuture<Bundle> future) {
+            Logger.trace(LOG_TAG, "AccountManagerCallback invoked.");
+            // TODO: N.B.: Future must not be used on the main thread.
+            try {
+              Bundle bundle = future.getResult(60L, TimeUnit.SECONDS);
+              // Ignoring KEY_INTENT check.
+              String username = bundle.getString(Constants.OPTION_USERNAME);
+              String serverURL = bundle.getString(Constants.OPTION_SERVER);
+              Logger.debug(LOG_TAG, "username null? " + (null == username) + ", serverURL null? " + (null == serverURL));
+              // Get SharedPreferences and display configuration editor.
+              // Prefs path args are taken directly from constants right now, because prefs are automatically migrated.
+              String prefsPath = Utils.getPrefsPath(GlobalConstants.BROWSER_INTENT_PACKAGE, username, serverURL, Constants.DEFAULT_PROFILE, SyncConfiguration.CURRENT_PREFS_VERSION);
+              SharedPreferences prefs = mContext.getSharedPreferences(prefsPath, Utils.SHARED_PREFERENCES_MODE);
+              accountConsumer.run(prefs);
+            } catch (Exception e) {
+              Logger.error(LOG_TAG, "Failed to get sync information or shared preferences.", e);
+              finish();
+              return;
+            }
+          }
+        }, null);
+      }
+    });
+  }
+}

--- a/src/main/java/org/mozilla/gecko/sync/config/activities/ConfigureEnginesActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/config/activities/ConfigureEnginesActivity.java
@@ -35,19 +35,24 @@ public class ConfigureEnginesActivity extends AndroidSyncConfigureActivity
   public final static String LOG_TAG = "ConfigureEnginesAct";
   private ListView selectionsList;
 
-  final String[] _options = new String[] {
-      getString(R.string.sync_configure_engines_title_bookmarks),
-      getString(R.string.sync_configure_engines_title_passwords),
-      getString(R.string.sync_configure_engines_title_history),
-      getString(R.string.sync_configure_engines_title_tabs) };
-  protected boolean[] _selections = new boolean[_options.length];
-  private final boolean[] _origSelections = new boolean[_options.length];
+  private String[] _options;
+  protected boolean[] _selections;
+  private boolean[] _origSelections;
 
   @Override
   public void onResume() {
     super.onResume();
     final ConfigureEnginesActivity self = this;
+    Logger.warn(LOG_TAG, "bookmarks");
+    Logger.warn(LOG_TAG, getString(R.string.sync_configure_engines_title_bookmarks));
+    _options = new String[] {
+        getString(R.string.sync_configure_engines_title_bookmarks),
+        getString(R.string.sync_configure_engines_title_passwords),
+        getString(R.string.sync_configure_engines_title_history),
+        getString(R.string.sync_configure_engines_title_tabs) };
     // Display engine configure UI.
+    _selections = new boolean[_options.length];
+    _origSelections = new boolean[_options.length];
     fetchPrefsAndConsume(new PrefsConsumer() {
 
       @Override
@@ -104,8 +109,8 @@ public class ConfigureEnginesActivity extends AndroidSyncConfigureActivity
   public void setSelections(Set<String> selected) {
     _selections[0] = selected.contains("bookmarks");
     // Omit Forms, because there is no way to enable/disable Forms in desktop UI.
-    _selections[1] = selected.contains("history");
-    _selections[2] = selected.contains("passwords");
+    _selections[1] = selected.contains("passwords");
+    _selections[2] = selected.contains("history");
     _selections[3] = selected.contains("tabs");
 
     // Cache original selections for comparing changes.
@@ -114,7 +119,7 @@ public class ConfigureEnginesActivity extends AndroidSyncConfigureActivity
 
   @Override
   public void onClick(DialogInterface dialog, int which) {
-    if (which == DialogInterface.BUTTON_POSITIVE && _selections.equals(_origSelections)) {
+    if (which == DialogInterface.BUTTON_POSITIVE) {
       Logger.debug(LOG_TAG, "Saving selected engines.");
       saveSelections();
       setResult(RESULT_OK);

--- a/src/main/java/org/mozilla/gecko/sync/config/activities/ConfigureEnginesActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/config/activities/ConfigureEnginesActivity.java
@@ -1,0 +1,141 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.gecko.sync.config.activities;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import org.mozilla.gecko.R;
+import org.mozilla.gecko.sync.Logger;
+import org.mozilla.gecko.sync.SyncConfiguration;
+import org.mozilla.gecko.sync.Utils;
+import org.mozilla.gecko.sync.setup.Constants;
+import org.mozilla.gecko.sync.setup.SyncAccounts.SyncAccountParameters;
+
+import android.app.AlertDialog;
+import android.content.DialogInterface;
+import android.content.SharedPreferences;
+import android.content.SharedPreferences.Editor;
+import android.widget.ListView;
+import android.widget.Toast;
+
+/**
+ * Configure which engines to Sync.
+ */
+public class ConfigureEnginesActivity extends AndroidSyncConfigureActivity
+    implements DialogInterface.OnClickListener, DialogInterface.OnMultiChoiceClickListener {
+  public final static String LOG_TAG = "ConfigureEnginesAct";
+  private ListView selectionsList;
+
+  protected interface AccountConsumer {
+    public void run(SyncAccountParameters syncParams, SharedPreferences prefs);
+  }
+
+  protected String[]  _options = new String[] { "Bookmarks", "History", "Passwords", "Tabs" };
+  protected boolean[] _selections = new boolean[_options.length];
+  private final boolean[] _origSelections = new boolean[_options.length];
+
+  @Override
+  public void onResume() {
+    super.onResume();
+    final ConfigureEnginesActivity self = this;
+    // Display engine configure UI.
+    fetchPrefsAndConsume(new PrefsConsumer() {
+
+      @Override
+      public void run(SharedPreferences prefs) {
+        // Extract enabled-engine state.
+        Set<String> enabledEngineNames = getEnabledEngines(prefs);
+        if (enabledEngineNames == null) {
+          enabledEngineNames = new HashSet<String>();
+        }
+        setSelections(enabledEngineNames);
+
+        new AlertDialog.Builder(self)
+            .setTitle(R.string.sync_configure_engines_sync_my_title)
+            .setMultiChoiceItems(_options, _selections, self)
+            .setIcon(R.drawable.icon)
+            .setPositiveButton(android.R.string.ok, self)
+            .setNegativeButton(android.R.string.cancel, self).show();
+      }
+    });
+  }
+
+  private Set<String> getEnabledEngines(SharedPreferences syncPrefs) {
+    Set<String> engines;
+    // Check engine SharedPrefs first.
+    SharedPreferences engineConfigPrefs = mContext.getSharedPreferences(Constants.PREFS_ENGINE_SELECTION, Utils.SHARED_PREFERENCES_MODE);
+    @SuppressWarnings("unchecked")
+    // We only add booleans to this SharedPreference.
+    Map<String, Boolean> engineMap = (Map<String, Boolean>) engineConfigPrefs.getAll();
+    if (!engineMap.isEmpty()) {
+      engines = new HashSet<String>();
+      for (Entry<String, Boolean> pair : engineMap.entrySet()) {
+        if (pair.getValue()) {
+          engines.add(pair.getKey());
+        }
+      }
+      return engines;
+    }
+    Logger.warn(LOG_TAG, "No previous engine prefs");
+    // No previously stored engine prefs.
+    return SyncConfiguration.getEnabledEngineNames(syncPrefs);
+  }
+
+  // Hardcoded engines.
+  public void setSelections(Set<String> enabled) {
+    _selections[0] = enabled.contains("bookmarks");
+    // Omit Forms, because there is no way to enable/disable Forms in desktop UI.
+    _selections[1] = enabled.contains("history");
+    _selections[2] = enabled.contains("passwords");
+    _selections[3] = enabled.contains("tabs");
+
+    // Cache original selections for comparing changes.
+    System.arraycopy(_selections, 0, _origSelections, 0, _selections.length);
+  }
+
+  @Override
+  public void onClick(DialogInterface dialog, int which) {
+    if (which == DialogInterface.BUTTON_POSITIVE && saveEngines()) {
+      setResult(RESULT_OK);
+      Toast.makeText(this, R.string.sync_notification_savedprefs, Toast.LENGTH_SHORT).show();
+    } else {
+      setResult(RESULT_CANCELED);
+    }
+    finish();
+  }
+
+  @Override
+  public void onClick(DialogInterface dialog, int which, boolean isChecked) {
+    // Display multi-selection clicks in UI.
+    _selections[which] = isChecked;
+    if (selectionsList == null) {
+      selectionsList = ((AlertDialog) dialog).getListView();
+    }
+    selectionsList.setItemChecked(which, isChecked);
+  }
+
+  /**
+   * Persists enabled engines to SharedPreferences if changed.
+   * @return true if changed, false otherwise.
+   */
+  private boolean saveEngines() {
+    if (_selections.equals(_origSelections)) {
+      return false;
+    }
+    // Persist to SharedPreferences.
+    SharedPreferences prefs = mContext.getSharedPreferences(Constants.PREFS_ENGINE_SELECTION, Utils.SHARED_PREFERENCES_MODE);
+    Editor enginePrefsEditor = prefs.edit();
+    for (int i = 0; i < _selections.length; i++) {
+      if (_selections[i] != _origSelections[i]) {
+        enginePrefsEditor.putBoolean(_options[i].toLowerCase(), _selections[i]);
+      }
+    }
+    enginePrefsEditor.commit();
+    return true;
+  }
+}

--- a/src/main/java/org/mozilla/gecko/sync/config/activities/ConfigureEnginesActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/config/activities/ConfigureEnginesActivity.java
@@ -14,7 +14,6 @@ import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.SyncConfiguration;
 import org.mozilla.gecko.sync.Utils;
 import org.mozilla.gecko.sync.setup.Constants;
-import org.mozilla.gecko.sync.setup.SyncAccounts.SyncAccountParameters;
 
 import android.app.AlertDialog;
 import android.content.DialogInterface;
@@ -36,11 +35,11 @@ public class ConfigureEnginesActivity extends AndroidSyncConfigureActivity
   public final static String LOG_TAG = "ConfigureEnginesAct";
   private ListView selectionsList;
 
-  protected interface AccountConsumer {
-    public void run(SyncAccountParameters syncParams, SharedPreferences prefs);
-  }
-
-  protected String[] _options = new String[] { "Bookmarks", "Passwords", "History", "Tabs" };
+  final String[] _options = new String[] {
+      getString(R.string.sync_configure_engines_title_bookmarks),
+      getString(R.string.sync_configure_engines_title_passwords),
+      getString(R.string.sync_configure_engines_title_history),
+      getString(R.string.sync_configure_engines_title_tabs) };
   protected boolean[] _selections = new boolean[_options.length];
   private final boolean[] _origSelections = new boolean[_options.length];
 

--- a/src/main/java/org/mozilla/gecko/sync/config/activities/ConfigureEnginesActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/config/activities/ConfigureEnginesActivity.java
@@ -24,7 +24,12 @@ import android.widget.ListView;
 import android.widget.Toast;
 
 /**
- * Configure which engines to Sync.
+ * Provides a user-facing interface for selecting engines to sync. This activity can be launched
+ * from the Sync Settings preferences screen, and will save the selected engines to a pref.
+ * 
+ * On launch, it loads from either the saved pref of selected engines (if it exists) or from
+ * SyncConfiguration. During a sync, this pref will be read and cleared.
+ * 
  */
 public class ConfigureEnginesActivity extends AndroidSyncConfigureActivity
     implements DialogInterface.OnClickListener, DialogInterface.OnMultiChoiceClickListener {
@@ -35,7 +40,7 @@ public class ConfigureEnginesActivity extends AndroidSyncConfigureActivity
     public void run(SyncAccountParameters syncParams, SharedPreferences prefs);
   }
 
-  protected String[]  _options = new String[] { "Bookmarks", "History", "Passwords", "Tabs" };
+  protected String[] _options = new String[] { "Bookmarks", "Passwords", "History", "Tabs" };
   protected boolean[] _selections = new boolean[_options.length];
   private final boolean[] _origSelections = new boolean[_options.length];
 
@@ -48,12 +53,7 @@ public class ConfigureEnginesActivity extends AndroidSyncConfigureActivity
 
       @Override
       public void run(SharedPreferences prefs) {
-        // Extract enabled-engine state.
-        Set<String> enabledEngineNames = getEnabledEngines(prefs);
-        if (enabledEngineNames == null) {
-          enabledEngineNames = new HashSet<String>();
-        }
-        setSelections(enabledEngineNames);
+        setSelections(getEnginesToSelect(prefs));
 
         new AlertDialog.Builder(self)
             .setTitle(R.string.sync_configure_engines_sync_my_title)
@@ -65,7 +65,17 @@ public class ConfigureEnginesActivity extends AndroidSyncConfigureActivity
     });
   }
 
-  private Set<String> getEnabledEngines(SharedPreferences syncPrefs) {
+  /**
+   * Fetches the engine names that should be displayed as selected for syncing.
+   * Check first for the selection pref set by this activity, then the set of
+   * enabled engines from SyncConfiguration, and finally use the set of valid
+   * engine names for Android Sync.
+   *
+   * @param syncPrefs
+   * @return Set<String> of engine names to display as selected. Should never be
+   *         null.
+   */
+  private Set<String> getEnginesToSelect(SharedPreferences syncPrefs) {
     Set<String> engines;
     // Check engine SharedPrefs first.
     SharedPreferences engineConfigPrefs = mContext.getSharedPreferences(Constants.PREFS_ENGINE_SELECTION, Utils.SHARED_PREFERENCES_MODE);
@@ -82,17 +92,22 @@ public class ConfigureEnginesActivity extends AndroidSyncConfigureActivity
       return engines;
     }
     Logger.warn(LOG_TAG, "No previous engine prefs");
-    // No previously stored engine prefs.
-    return SyncConfiguration.getEnabledEngineNames(syncPrefs);
+    // No previously stored engine prefs. Fetch from config.
+
+    engines = SyncConfiguration.getEnabledEngineNames(syncPrefs);
+    if (engines == null) {
+      engines = SyncConfiguration.validEngineNames();
+    }
+    return engines;
   }
 
   // Hardcoded engines.
-  public void setSelections(Set<String> enabled) {
-    _selections[0] = enabled.contains("bookmarks");
+  public void setSelections(Set<String> selected) {
+    _selections[0] = selected.contains("bookmarks");
     // Omit Forms, because there is no way to enable/disable Forms in desktop UI.
-    _selections[1] = enabled.contains("history");
-    _selections[2] = enabled.contains("passwords");
-    _selections[3] = enabled.contains("tabs");
+    _selections[1] = selected.contains("history");
+    _selections[2] = selected.contains("passwords");
+    _selections[3] = selected.contains("tabs");
 
     // Cache original selections for comparing changes.
     System.arraycopy(_selections, 0, _origSelections, 0, _selections.length);
@@ -100,7 +115,9 @@ public class ConfigureEnginesActivity extends AndroidSyncConfigureActivity
 
   @Override
   public void onClick(DialogInterface dialog, int which) {
-    if (which == DialogInterface.BUTTON_POSITIVE && saveEngines()) {
+    if (which == DialogInterface.BUTTON_POSITIVE && _selections.equals(_origSelections)) {
+      Logger.debug(LOG_TAG, "Saving selected engines.");
+      saveSelections();
       setResult(RESULT_OK);
       Toast.makeText(this, R.string.sync_notification_savedprefs, Toast.LENGTH_SHORT).show();
     } else {
@@ -120,13 +137,10 @@ public class ConfigureEnginesActivity extends AndroidSyncConfigureActivity
   }
 
   /**
-   * Persists enabled engines to SharedPreferences if changed.
+   * Persists selected engines to SharedPreferences if changed.
    * @return true if changed, false otherwise.
    */
-  private boolean saveEngines() {
-    if (_selections.equals(_origSelections)) {
-      return false;
-    }
+  private void saveSelections() {
     // Persist to SharedPreferences.
     SharedPreferences prefs = mContext.getSharedPreferences(Constants.PREFS_ENGINE_SELECTION, Utils.SHARED_PREFERENCES_MODE);
     Editor enginePrefsEditor = prefs.edit();
@@ -136,6 +150,5 @@ public class ConfigureEnginesActivity extends AndroidSyncConfigureActivity
       }
     }
     enginePrefsEditor.commit();
-    return true;
   }
 }

--- a/src/main/java/org/mozilla/gecko/sync/setup/Constants.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/Constants.java
@@ -41,6 +41,9 @@ public class Constants {
    */
   public static final String EXTRAS_KEY_STAGES_TO_SKIP = "skip";
 
+  // SharedPreferences filenames.
+  public static final String PREFS_ENGINE_SELECTION = "sync.prefs.engine-selection";
+
   // Constants for Activities.
   public static final String INTENT_EXTRA_IS_SETUP        = "isSetup";
   public static final String INTENT_EXTRA_IS_PAIR         = "isPair";

--- a/src/main/java/org/mozilla/gecko/sync/setup/SyncAccounts.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/SyncAccounts.java
@@ -610,4 +610,55 @@ public class SyncAccounts {
       throw new CredentialException.MissingAllCredentialsException(e);
     }
   }
+
+  /**
+   * Synchronously fetch SharedPreferences of a profile associated with a Sync
+   * account.
+   *
+   * @param context
+   * @param accountManager
+   *          Android account manager
+   * @param account
+   *          Android Account
+   * @param product
+   *          String of product package
+   * @param profile
+   *          String name of profile of account
+   * @param version
+   * @return SharedPreferences associated with params
+   * @throws CredentialException
+   * @throws NoSuchAlgorithmException
+   * @throws UnsupportedEncodingException
+   */
+  public static SharedPreferences getPrefsFromAccount(final Context context, final AccountManager accountManager, final Account account, final String product, final String profile, final long version) throws CredentialException, NoSuchAlgorithmException, UnsupportedEncodingException {
+    SyncAccountParameters params = SyncAccounts.blockingFromAndroidAccountV0(context, accountManager, account);
+    String prefsPath = Utils.getPrefsPath(product, params.username, params.serverURL, profile, version);
+    SharedPreferences prefs = context.getSharedPreferences(prefsPath, Utils.SHARED_PREFERENCES_MODE);
+    return prefs;
+  }
+
+  /**
+   * Synchronously fetch SharedPreferences of the default profile associated
+   * with a Sync account. Uses the default package, default profile, and current
+   * version associated with this installation.
+   *
+   * @param context
+   * @param accountManager
+   *          Android account manager
+   * @param account
+   *          Android Account
+   * @return
+   * @throws CredentialException
+   * @throws NoSuchAlgorithmException
+   * @throws UnsupportedEncodingException
+   */
+  public static SharedPreferences getPrefsFromDefaultAccount(final Context context, final AccountManager accountManager, final Account account) throws CredentialException, NoSuchAlgorithmException, UnsupportedEncodingException {
+    final String product = GlobalConstants.BROWSER_INTENT_PACKAGE;
+    final String profile = Constants.DEFAULT_PROFILE;
+    final long version = SyncConfiguration.CURRENT_PREFS_VERSION;
+    SyncAccountParameters params = SyncAccounts.blockingFromAndroidAccountV0(context, accountManager, account);
+    String prefsPath = Utils.getPrefsPath(product, params.username, params.serverURL, profile, version);
+    SharedPreferences prefs = context.getSharedPreferences(prefsPath, Utils.SHARED_PREFERENCES_MODE);
+    return prefs;
+  }
 }

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/SendTabActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/SendTabActivity.java
@@ -9,18 +9,15 @@ import java.util.List;
 import org.mozilla.gecko.R;
 import org.mozilla.gecko.sync.CommandProcessor;
 import org.mozilla.gecko.sync.CommandRunner;
-import org.mozilla.gecko.sync.CredentialException;
 import org.mozilla.gecko.sync.GlobalConstants;
 import org.mozilla.gecko.sync.GlobalSession;
 import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.SyncConfiguration;
-import org.mozilla.gecko.sync.Utils;
 import org.mozilla.gecko.sync.repositories.NullCursorException;
 import org.mozilla.gecko.sync.repositories.android.ClientsDatabaseAccessor;
 import org.mozilla.gecko.sync.repositories.domain.ClientRecord;
 import org.mozilla.gecko.sync.setup.Constants;
 import org.mozilla.gecko.sync.setup.SyncAccounts;
-import org.mozilla.gecko.sync.setup.SyncAccounts.SyncAccountParameters;
 import org.mozilla.gecko.sync.stage.SyncClientsEngineStage;
 import org.mozilla.gecko.sync.syncadapter.SyncAdapter;
 
@@ -115,21 +112,9 @@ public class SendTabActivity extends Activity {
       Logger.warn(LOG_TAG, "Null local account; aborting.");
       return null;
     }
-
-    SyncAccountParameters params;
-    try {
-      params = SyncAccounts.blockingFromAndroidAccountV0(this, accountManager, localAccount);
-    } catch (CredentialException e) {
-      Logger.warn(LOG_TAG, "Could not get sync account parameters; aborting.");
-      return null;
-    }
-
     SharedPreferences prefs;
     try {
-      final String product = GlobalConstants.BROWSER_INTENT_PACKAGE;
-      final String profile = Constants.DEFAULT_PROFILE;
-      final long version = SyncConfiguration.CURRENT_PREFS_VERSION;
-      prefs = Utils.getSharedPreferences(getApplicationContext(), product, params.username, params.serverURL, profile, version);
+      prefs = SyncAccounts.getPrefsFromDefaultAccount(this, accountManager, localAccount);
       return prefs.getString(SyncConfiguration.PREF_ACCOUNT_GUID, null);
     } catch (Exception e) {
       return null;

--- a/src/main/java/org/mozilla/gecko/sync/stage/FormHistoryServerSyncStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/FormHistoryServerSyncStage.java
@@ -9,7 +9,6 @@ import java.net.URISyntaxException;
 import org.mozilla.gecko.sync.CryptoRecord;
 import org.mozilla.gecko.sync.GlobalSession;
 import org.mozilla.gecko.sync.MetaGlobalException;
-import org.mozilla.gecko.sync.MetaGlobalException.MetaGlobalEngineStateChangedException;
 import org.mozilla.gecko.sync.Utils;
 import org.mozilla.gecko.sync.repositories.ConstrainedServer11Repository;
 import org.mozilla.gecko.sync.repositories.RecordFactory;
@@ -90,7 +89,7 @@ public class FormHistoryServerSyncStage extends ServerSyncStage {
    * Forms engine state should match History, because there is no manual way to control Forms syncing.
    */
   @Override
-  protected void checkAndUpdateManualEngines(boolean enabledInMetaGlobal) throws MetaGlobalEngineStateChangedException {
+  protected void checkAndUpdateManualEngines(boolean enabledInMetaGlobal) throws MetaGlobalException {
     SharedPreferences selectedEngines = session.getPrefs(Constants.PREFS_ENGINE_SELECTION, Utils.SHARED_PREFERENCES_MODE);
     if (selectedEngines.contains("history")) {
       boolean enabledInSelection = selectedEngines.getBoolean("history", false);

--- a/src/main/java/org/mozilla/gecko/sync/stage/FormHistoryServerSyncStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/FormHistoryServerSyncStage.java
@@ -8,6 +8,9 @@ import java.net.URISyntaxException;
 
 import org.mozilla.gecko.sync.CryptoRecord;
 import org.mozilla.gecko.sync.GlobalSession;
+import org.mozilla.gecko.sync.MetaGlobalException;
+import org.mozilla.gecko.sync.MetaGlobalException.MetaGlobalEngineStateChangedException;
+import org.mozilla.gecko.sync.Utils;
 import org.mozilla.gecko.sync.repositories.ConstrainedServer11Repository;
 import org.mozilla.gecko.sync.repositories.RecordFactory;
 import org.mozilla.gecko.sync.repositories.Repository;
@@ -15,6 +18,9 @@ import org.mozilla.gecko.sync.repositories.android.FormHistoryRepositorySession;
 import org.mozilla.gecko.sync.repositories.domain.FormHistoryRecord;
 import org.mozilla.gecko.sync.repositories.domain.Record;
 import org.mozilla.gecko.sync.repositories.domain.VersionConstants;
+import org.mozilla.gecko.sync.setup.Constants;
+
+import android.content.SharedPreferences;
 
 public class FormHistoryServerSyncStage extends ServerSyncStage {
 
@@ -75,5 +81,23 @@ public class FormHistoryServerSyncStage extends ServerSyncStage {
   @Override
   protected RecordFactory getRecordFactory() {
     return new FormHistoryRecordFactory();
+  }
+
+  /*
+   * (non-Javadoc)
+   * @see org.mozilla.gecko.sync.stage.ServerSyncStage#checkAndUpdateManualEngines(boolean)
+   *
+   * Forms engine state should match History, because there is no manual way to control Forms syncing.
+   */
+  @Override
+  protected void checkAndUpdateManualEngines(boolean enabledInMetaGlobal) throws MetaGlobalEngineStateChangedException {
+    SharedPreferences selectedEngines = session.getPrefs(Constants.PREFS_ENGINE_SELECTION, Utils.SHARED_PREFERENCES_MODE);
+    if (selectedEngines.contains("history")) {
+      boolean enabledInSelection = selectedEngines.getBoolean("history", false);
+      if (enabledInMetaGlobal != enabledInSelection) {
+        // Engine enable state has been changed by the user.
+        throw new MetaGlobalException.MetaGlobalEngineStateChangedException(enabledInSelection);
+      }
+    }
   }
 }

--- a/src/main/java/org/mozilla/gecko/sync/stage/ServerSyncStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/ServerSyncStage.java
@@ -15,7 +15,6 @@ import org.mozilla.gecko.sync.GlobalSession;
 import org.mozilla.gecko.sync.HTTPFailureException;
 import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.MetaGlobalException;
-import org.mozilla.gecko.sync.MetaGlobalException.MetaGlobalEngineStateChangedException;
 import org.mozilla.gecko.sync.NoCollectionKeysSetException;
 import org.mozilla.gecko.sync.NonObjectJSONException;
 import org.mozilla.gecko.sync.SynchronizerConfiguration;
@@ -111,11 +110,17 @@ public abstract class ServerSyncStage implements
   }
 
   /**
-   * Compares meta/global to manually selected engines and throws an exception if they don't match and meta/global needs to be updated.
+   * Compares meta/global engine state to manually selected engines from Sync
+   * Settings and throws an exception if they don't match and meta/global needs
+   * to be updated.
+   *
    * @param enabledInMetaGlobal
-   * @throws MetaGlobalEngineStateChangedException
+   *          boolean of engine sync state in meta/global
+   * @throws MetaGlobalException
+   *           if engine sync state has been changed in Sync Settings, with new
+   *           engine sync state.
    */
-  protected void checkAndUpdateManualEngines(boolean enabledInMetaGlobal) throws MetaGlobalEngineStateChangedException {
+  protected void checkAndUpdateManualEngines(boolean enabledInMetaGlobal) throws MetaGlobalException {
     SharedPreferences selectedEngines = session.getPrefs(Constants.PREFS_ENGINE_SELECTION, Utils.SHARED_PREFERENCES_MODE);
     if (selectedEngines.contains(this.getEngineName())) {
       boolean enabledInSelection = selectedEngines.getBoolean(this.getEngineName(), false);

--- a/strings/strings.xml.in
+++ b/strings/strings.xml.in
@@ -55,6 +55,10 @@
   <string name="sync_configure_engines_title">&sync.configure.engines.title.label;</string>
   <string name="sync_configure_engines_summary">&sync.configure.engines.summary.label;</string>
   <string name="sync_configure_engines_sync_my_title">&sync.configure.engines.sync.my.title.label;</string>
+  <string name="sync_configure_engines_title_bookmarks">&sync.configure.engines.title.bookmarks;</string>
+  <string name="sync_configure_engines_title_passwords">&sync.configure.engines.title.passwords;</string>
+  <string name="sync_configure_engines_title_history">&sync.configure.engines.title.history;</string>
+  <string name="sync_configure_engines_title_tabs">&sync.configure.engines.title.tabs;</string>
 
   <!-- Common text -->
   <string name="sync_button_cancel">&sync.button.cancel.label;</string>

--- a/strings/strings.xml.in
+++ b/strings/strings.xml.in
@@ -50,6 +50,12 @@
   <!-- Firefox SyncAdapter Settings Screen -->
   <string name="sync_settings_options">&sync.settings.options.label;</string>
   <string name="sync_settings_summary_pair">&sync.summary.pair.label;</string>
+
+  <!-- Configure Engines -->
+  <string name="sync_configure_engines_title">&sync.configure.engines.title.label;</string>
+  <string name="sync_configure_engines_summary">&sync.configure.engines.summary.label;</string>
+  <string name="sync_configure_engines_sync_my_title">&sync.configure.engines.sync.my.title.label;</string>
+
   <!-- Common text -->
   <string name="sync_button_cancel">&sync.button.cancel.label;</string>
   <string name="sync_button_connect">&sync.button.connect.label;</string>
@@ -70,6 +76,7 @@
 
   <!-- Notification strings -->
   <string name="sync_notification_oneaccount">&sync.notification.oneaccount.label;</string>
+  <string name="sync_notification_savedprefs">&sync.notification.configure.saved;</string>
 
   <!-- Incorrect settings and changing credentials. -->
   <string name="sync_invalidcreds_label">&sync.invalidcreds.label;</string>

--- a/strings/sync_strings.dtd.in
+++ b/strings/sync_strings.dtd.in
@@ -58,6 +58,11 @@
 <!ENTITY sync.settings.options.label 'Options'>
 <!ENTITY sync.summary.pair.label 'Link another device to your &syncBrand.shortName.label; account'>
 
+<!-- Configure Engines -->
+<!ENTITY sync.configure.engines.title.label 'Configure Engines'>
+<!ENTITY sync.configure.engines.summary.label 'Configure what to sync: Bookmarks, Passwords, History, Tabs…'>
+<!ENTITY sync.configure.engines.sync.my.title.label 'Sync my…'>
+
 <!-- Common text -->
 <!ENTITY sync.button.cancel.label 'Cancel'>
 <!ENTITY sync.button.connect.label 'Connect'>
@@ -78,6 +83,7 @@
 
 <!-- Notification strings -->
 <!ENTITY sync.notification.oneaccount.label 'Only one &syncBrand.fullName.label; account is supported.'>
+<!ENTITY sync.notification.configure.saved 'Your preferences have been saved.'>
 
 <!-- Incorrect settings and changing credentials. -->
 <!ENTITY sync.invalidcreds.label 'Incorrect account name or password.'>

--- a/strings/sync_strings.dtd.in
+++ b/strings/sync_strings.dtd.in
@@ -59,9 +59,14 @@
 <!ENTITY sync.summary.pair.label 'Link another device to your &syncBrand.shortName.label; account'>
 
 <!-- Configure Engines -->
-<!ENTITY sync.configure.engines.title.label 'Configure Engines'>
-<!ENTITY sync.configure.engines.summary.label 'Configure what to sync: Bookmarks, Passwords, History, Tabs…'>
+<!ENTITY sync.configure.engines.title.label 'Syncing Options'>
 <!ENTITY sync.configure.engines.sync.my.title.label 'Sync my…'>
+<!ENTITY sync.configure.engines.title.bookmarks 'Bookmarks'>
+<!ENTITY sync.configure.engines.title.passwords 'Passwords'>
+<!ENTITY sync.configure.engines.title.history 'History'>
+<!ENTITY sync.configure.engines.title.tabs 'Tabs'>
+<!ENTITY sync.configure.engines.summary  'Select what to sync:'>
+<!ENTITY sync.configure.engines.summary.label '&sync.configure.engines.summary; &sync.configure.engines.title.bookmarks;, &sync.configure.engines.title.passwords;, &sync.configure.engines.title.history;, &sync.configure.engines.title.tabs;…'>
 
 <!-- Common text -->
 <!ENTITY sync.button.cancel.label 'Cancel'>

--- a/sync_options.xml.template
+++ b/sync_options.xml.template
@@ -20,4 +20,14 @@
         android:value="false" />
     </intent>
   </PreferenceScreen>
+  <PreferenceScreen
+    android:key="sync_configure_engines"
+    android:title="@string/sync_configure_engines_title"
+    android:summary="@string/sync_configure_engines_summary">
+    <intent
+      android:action="android.intent.action.MAIN"
+      android:targetPackage="@ANDROID_PACKAGE_NAME@"
+      android:targetClass="org.mozilla.gecko.sync.config.activities.ConfigureEnginesActivity">
+    </intent>
+  </PreferenceScreen>
 </PreferenceScreen>


### PR DESCRIPTION
liuche, this branch is a straight re-base of what you pushed (no changes, just sorting out the commit structure).  Overall, this is looking really good!

There is one major architectural issue: as written, this might not play nicely with multiple Fennecs.  The issue is that the config Activity can only write to the SharedPrefs of one App.  If that App syncs, we're golden; the uploaded meta/global record will be downloaded by any other App that syncs to the same account.  But if that App doesn't sync (the user has un-checked it), then we have a problem.

I'll make more specific comments on this pull-req.
