### PR TITLE
Bug 791056 - Hide keyboard unless explicitly summoned by user in J-PAKE and pairing.

### DIFF
--- a/manifests/SyncAndroidManifest_activities.xml.in
+++ b/manifests/SyncAndroidManifest_activities.xml.in
@@ -3,7 +3,7 @@
             android:icon="@drawable/icon"
             android:label="@string/sync_app_name"
             android:configChanges="keyboardHidden|orientation|screenSize"
-            android:windowSoftInputMode="adjustResize|stateHidden"
+            android:windowSoftInputMode="adjustResize|stateAlwaysHidden"
             android:taskAffinity="org.mozilla.gecko.sync.setup"
             android:name="org.mozilla.gecko.sync.setup.activities.SetupSyncActivity" >
             <!-- android:configChanges: SetupSyncActivity will handle orientation changes; no longer restarts activity (default) -->


### PR DESCRIPTION
Tiny bug I ran into on the new tablet UI. This fix does not change any keyboard behavior in Pair a Device, but closes the keyboard when going to J-PAKE pairing.
