### PR TITLE
Inconsistency between javadoc param and method arg.

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/SyncConfiguration.java
+++ b/src/main/java/org/mozilla/gecko/sync/SyncConfiguration.java
@@ -363,7 +363,7 @@ public class SyncConfiguration implements CredentialsSource {
    *
    * @param prefs
    *          SharedPreferences that the engines are associated with.
-   * @param userSelectedEngines
+   * @param selectedEngines
    *          Map<String, Boolean> of engine name to sync state
    */
   public static void storeSelectedEnginesToPrefs(SharedPreferences prefs, Map<String, Boolean> selectedEngines) {


### PR DESCRIPTION
Missed a javadoc param while refactoring. (engine selection for bug 753878)
