### PR TITLE
Bug 815773 - process local commands

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
+++ b/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
@@ -11,8 +11,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -161,61 +159,12 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
     config.password      = password;
     config.syncKeyBundle = syncKeyBundle;
 
-    registerCommands();
     prepareStages();
 
     Collection<String> knownStageNames = SyncConfiguration.validEngineNames();
     config.stagesToSync = Utils.getStagesToSyncFromBundle(knownStageNames, extras);
 
     // TODO: data-driven plan for the sync, referring to prepareStages.
-  }
-
-  /**
-   * Register commands this global session knows how to process.
-   * <p>
-   * Re-registering a command overwrites any existing registration.
-   */
-  protected static void registerCommands() {
-    final CommandProcessor processor = CommandProcessor.getProcessor();
-
-    processor.registerCommand("resetEngine", new CommandRunner(1) {
-      @Override
-      public void executeCommand(final GlobalSession session, List<String> args) {
-        HashSet<String> names = new HashSet<String>();
-        names.add(args.get(0));
-        session.resetStagesByName(names);
-      }
-    });
-
-    processor.registerCommand("resetAll", new CommandRunner(0) {
-      @Override
-      public void executeCommand(final GlobalSession session, List<String> args) {
-        session.resetAllStages();
-      }
-    });
-
-    processor.registerCommand("wipeEngine", new CommandRunner(1) {
-      @Override
-      public void executeCommand(final GlobalSession session, List<String> args) {
-        HashSet<String> names = new HashSet<String>();
-        names.add(args.get(0));
-        session.wipeStagesByName(names);
-      }
-    });
-
-    processor.registerCommand("wipeAll", new CommandRunner(0) {
-      @Override
-      public void executeCommand(final GlobalSession session, List<String> args) {
-        session.wipeAllStages();
-      }
-    });
-
-    processor.registerCommand("displayURI", new CommandRunner(3) {
-      @Override
-      public void executeCommand(final GlobalSession session, List<String> args) {
-        CommandProcessor.displayURI(args, session.getContext());
-      }
-    });
   }
 
   protected void prepareStages() {

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/SendTabActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/SendTabActivity.java
@@ -8,11 +8,9 @@ import java.util.List;
 
 import org.mozilla.gecko.R;
 import org.mozilla.gecko.sync.CommandProcessor;
-import org.mozilla.gecko.sync.CommandRunner;
-import org.mozilla.gecko.sync.SyncConstants;
-import org.mozilla.gecko.sync.GlobalSession;
 import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.SyncConfiguration;
+import org.mozilla.gecko.sync.SyncConstants;
 import org.mozilla.gecko.sync.repositories.NullCursorException;
 import org.mozilla.gecko.sync.repositories.android.ClientsDatabaseAccessor;
 import org.mozilla.gecko.sync.repositories.domain.ClientRecord;
@@ -51,7 +49,6 @@ public class SendTabActivity extends Activity {
     super.onResume();
 
     redirectIfNoSyncAccount();
-    registerDisplayURICommand();
 
     setContentView(R.layout.sync_send_tab);
     final ListView listview = (ListView) findViewById(R.id.device_list);
@@ -77,16 +74,6 @@ public class SendTabActivity extends Activity {
         listview.setAdapter(arrayAdapter);
       }
     }.execute();
-  }
-
-  private static void registerDisplayURICommand() {
-    final CommandProcessor processor = CommandProcessor.getProcessor();
-    processor.registerCommand("displayURI", new CommandRunner(3) {
-      @Override
-      public void executeCommand(final GlobalSession session, List<String> args) {
-        CommandProcessor.displayURI(args, session.getContext());
-      }
-    });
   }
 
   private void redirectIfNoSyncAccount() {

--- a/src/main/java/org/mozilla/gecko/sync/stage/SyncClientsEngineStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/SyncClientsEngineStage.java
@@ -196,6 +196,11 @@ public class SyncClientsEngineStage implements GlobalSyncStage {
           localAccountGUIDDownloaded = true;
           session.config.persistServerClientRecordTimestamp(r.lastModified);
           processCommands(r.commands);
+
+          // It is possible that there are commands in the database for the
+          // local GUID that did not come from the server, namely locally
+          // triggered "wipeAll", "resetAll", etc.
+          processLocalCommands(r.guid);
         } else {
           // Only need to store record if it isn't our local one.
           wipeAndStore(r);
@@ -430,6 +435,38 @@ public class SyncClientsEngineStage implements GlobalSyncStage {
       record.commands.add(jsonCommand);
     }
     toUpload.add(record);
+  }
+
+  /**
+   * The clients database might have commands for the local client that were not
+   * downloaded from the server, namely locally generated "resetAll", "wipeAll",
+   * etc commands. We fetch them and process them here. They will be deleted
+   * when the clients database is wiped after successful upload.
+   *
+   * @param localGuid of local client.
+   * @throws NullCursorException
+   */
+  @SuppressWarnings("unchecked")
+  protected void processLocalCommands(String localGuid) throws NullCursorException {
+    List<Command> commands = getClientsDatabaseAccessor().fetchCommandsForClient(localGuid);
+
+    if (commands == null || commands.size() == 0) {
+      Logger.info(LOG_TAG, "No local commands to process for GUID " + localGuid + ".");
+      return;
+    }
+
+    Logger.info(LOG_TAG, "Processing " + commands.size() +
+        " local commands for GUID " + localGuid + ".");
+
+    // Convert to JSON array.
+    JSONArray jsonCommands = new JSONArray();
+    for (Command command : commands) {
+      JSONObject jsonCommand = command.asJSONObject();
+      jsonCommands.add(jsonCommand);
+    }
+
+    // And process locally.
+    processCommands(jsonCommands);
   }
 
   @SuppressWarnings("unchecked")

--- a/src/main/java/org/mozilla/gecko/sync/stage/SyncClientsEngineStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/SyncClientsEngineStage.java
@@ -61,6 +61,8 @@ public class SyncClientsEngineStage implements GlobalSyncStage {
   protected final AtomicInteger uploadAttemptsCount = new AtomicInteger();
   protected final List<ClientRecord> toUpload = new ArrayList<ClientRecord>();
 
+  protected CommandProcessor commandProcessor = null;
+
   public SyncClientsEngineStage(GlobalSession session) {
     if (session == null) {
       throw new IllegalArgumentException("session must not be null.");
@@ -85,6 +87,14 @@ public class SyncClientsEngineStage implements GlobalSyncStage {
     }
     db.close();
     db = null;
+  }
+
+  protected synchronized CommandProcessor getCommandProcessor() {
+    if (commandProcessor == null) {
+      commandProcessor = CommandProcessor.getProcessor();
+    }
+
+    return commandProcessor;
   }
 
   /**
@@ -410,7 +420,7 @@ public class SyncClientsEngineStage implements GlobalSyncStage {
     }
 
     commandsProcessedShouldUpload = true;
-    CommandProcessor processor = CommandProcessor.getProcessor();
+    CommandProcessor processor = getCommandProcessor();
 
     for (Object o : commands) {
       processor.processCommand(session, new ExtendedJSONObject((JSONObject) o));


### PR DESCRIPTION
This is just the base stuff to process local commands.  (local commands == commands generated by local actions, such as from Sync > Options).

There's UI work to be done on top of this, but we may as well look over this first.

The key point is that local commands are processed when the clients engine downloads its local GUID; that means there's a race if you haven't yet synced.

Braindump 1: there could be interactions if you reset your local GUID that I haven't considered.
Braindump 2: I should verify that local commands are deleted from the DB after processing.  I think I did this, but I should verify.  This probably needs to wait until UI is in place.
