### PR TITLE
Bug 796187 - Send tab: usability tweaks

### DIFF
--- a/res/layout/sync_list_item.xml
+++ b/res/layout/sync_list_item.xml
@@ -4,10 +4,11 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="horizontal"
+    android:gravity="center_vertical"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
-    android:gravity="center_vertical"
+    android:minHeight="?android:attr/listPreferredItemHeight"
+    android:orientation="horizontal"
     android:padding="5dp" >
 
     <ImageView

--- a/res/layout/sync_send_tab.xml
+++ b/res/layout/sync_send_tab.xml
@@ -10,6 +10,26 @@
       style="@style/SyncTop"
       android:text="@string/sync_title_send_tab" />
 
+  <LinearLayout
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="@dimen/SyncSpace" >
+
+    <TextView
+      android:id="@+id/title"
+      android:layout_width="fill_parent"
+      android:layout_height="wrap_content"
+      android:textAppearance="?android:attr/textAppearanceMedium"
+      android:text="@string/sync_title_send_tab" />
+    <TextView
+      android:id="@+id/uri"
+      android:layout_width="fill_parent"
+      android:layout_height="wrap_content"
+      android:textAppearance="?android:attr/textAppearanceSmall"
+      android:text="@string/sync_title_send_tab" />
+  </LinearLayout>
+
   <ListView
     android:id="@+id/device_list"
     style="@style/SyncMiddle"

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/ClientRecordArrayAdapter.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/ClientRecordArrayAdapter.java
@@ -42,6 +42,17 @@ public class ClientRecordArrayAdapter extends ArrayAdapter<ClientRecord> {
     this.notifyDataSetChanged();
   }
 
+  /**
+   * If we have only a single client record in the list, mark it as checked.
+   */
+  public synchronized void checkIfSolitaryClient() {
+    // If there's only one other client, check it by default.
+    if (this.getCount() == 1) {
+      setRowChecked(0, true);
+      this.notifyDataSetChanged();
+    }
+  }
+
   protected synchronized void setRowChecked(int position, boolean checked) {
     checkedItems[position] = checked;
     numCheckedGUIDs += checked ? 1 : -1;

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/ClientRecordArrayAdapter.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/ClientRecordArrayAdapter.java
@@ -5,6 +5,7 @@
 package org.mozilla.gecko.sync.setup.activities;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.mozilla.gecko.R;
@@ -33,9 +34,9 @@ public class ClientRecordArrayAdapter extends ArrayAdapter<ClientRecord> {
     this.sendTabActivity = (SendTabActivity) context;
   }
 
-  public synchronized void setClientRecordList(final ClientRecord[] clientRecordList) {
+  public synchronized void setClientRecordList(final Collection<ClientRecord> clientRecordList) {
     this.clear();
-    this.checkedItems = new boolean[clientRecordList.length];
+    this.checkedItems = new boolean[clientRecordList.size()];
     this.numCheckedGUIDs = 0;
     for (ClientRecord clientRecord : clientRecordList) {
       this.add(clientRecord);

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/ClientRecordArrayAdapter.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/ClientRecordArrayAdapter.java
@@ -47,22 +47,36 @@ public class ClientRecordArrayAdapter extends ArrayAdapter<ClientRecord> {
   /**
    * If we have only a single client record in the list, mark it as checked.
    */
-  public synchronized void checkIfSolitaryClient() {
-    // If there's only one other client, check it by default.
-    if (this.getCount() == 1) {
-      setRowChecked(0, true);
+  public synchronized void checkItem(final int position, boolean checked) throws ArrayIndexOutOfBoundsException {
+    if (position < 0 ||
+        position >= checkedItems.length) {
+      throw new ArrayIndexOutOfBoundsException(position);
+    }
+
+    if (setRowChecked(position, true)) {
       this.notifyDataSetChanged();
     }
   }
 
-  protected synchronized void setRowChecked(int position, boolean checked) {
+  /**
+   * Set the specified row to the specified checked state.
+   * @param position an index.
+   * @param checked whether the checkbox should be checked.
+   * @return <code>true</code> if the state changed, <code>false</code> if the
+   *         box was already in the requested state.
+   */
+  protected synchronized boolean setRowChecked(int position, boolean checked) {
+    boolean current = checkedItems[position];
+    if (current == checked) {
+      return false;
+    }
+
     checkedItems[position] = checked;
     numCheckedGUIDs += checked ? 1 : -1;
     if (numCheckedGUIDs <= 0) {
-      sendTabActivity.enableSend(false);
-      return;
+      sendTabActivity.enableSend(numCheckedGUIDs > 0);
     }
-    sendTabActivity.enableSend(true);
+    return true;
   }
 
   @Override

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/ClientRecordArrayAdapter.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/ClientRecordArrayAdapter.java
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.gecko.sync.setup.activities;
 
 import java.util.ArrayList;

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/ClientRecordArrayAdapter.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/ClientRecordArrayAdapter.java
@@ -34,8 +34,9 @@ public class ClientRecordArrayAdapter extends ArrayAdapter<ClientRecord> {
   }
 
   public synchronized void setClientRecordList(final ClientRecord[] clientRecordList) {
-    this.checkedItems = new boolean[clientRecordList.length];
     this.clear();
+    this.checkedItems = new boolean[clientRecordList.length];
+    this.numCheckedGUIDs = 0;
     for (ClientRecord clientRecord : clientRecordList) {
       this.add(clientRecord);
     }
@@ -102,7 +103,7 @@ public class ClientRecordArrayAdapter extends ArrayAdapter<ClientRecord> {
     return row;
   }
 
-  public List<String> getCheckedGUIDs() {
+  public synchronized List<String> getCheckedGUIDs() {
     final List<String> guids = new ArrayList<String>();
     for (int i = 0; i < checkedItems.length; i++) {
       if (checkedItems[i]) {
@@ -112,7 +113,7 @@ public class ClientRecordArrayAdapter extends ArrayAdapter<ClientRecord> {
     return guids;
   }
 
-  public int getNumCheckedGUIDs() {
+  public synchronized int getNumCheckedGUIDs() {
     return numCheckedGUIDs;
   }
 

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/SendTabActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/SendTabActivity.java
@@ -31,6 +31,7 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.ListView;
+import android.widget.TextView;
 import android.widget.Toast;
 
 public class SendTabActivity extends Activity {
@@ -38,10 +39,42 @@ public class SendTabActivity extends Activity {
   private ClientRecordArrayAdapter arrayAdapter;
   private AccountManager accountManager;
   private Account localAccount;
+  private SendTabData sendTabData;
 
   @Override
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
+
+    Intent intent = getIntent();
+    if (intent == null) {
+      Logger.warn(LOG_TAG, "intent was null; aborting without sending tab.");
+      notifyAndFinish(false);
+      return;
+    }
+
+    Bundle extras = intent.getExtras();
+    if (extras == null) {
+      Logger.warn(LOG_TAG, "extras was null; aborting without sending tab.");
+      notifyAndFinish(false);
+      return;
+    }
+
+    sendTabData = SendTabData.fromBundle(extras);
+    if (sendTabData == null) {
+      Logger.warn(LOG_TAG, "send tab data was null; aborting without sending tab.");
+      notifyAndFinish(false);
+      return;
+    }
+
+    if (sendTabData.uri == null) {
+      Logger.warn(LOG_TAG, "uri was null; aborting without sending tab.");
+      notifyAndFinish(false);
+      return;
+    }
+
+    if (sendTabData.title == null) {
+      Logger.warn(LOG_TAG, "title was null; ignoring and sending tab anyway.");
+    }
   }
 
   /**
@@ -97,6 +130,12 @@ public class SendTabActivity extends Activity {
     enableSend(false);
 
     ensureClientList(this, listview);
+
+    TextView textView = (TextView) findViewById(R.id.title);
+    textView.setText(sendTabData.title);
+
+    textView = (TextView) findViewById(R.id.uri);
+    textView.setText(sendTabData.uri);
   }
 
   private static void registerDisplayURICommand() {
@@ -146,25 +185,6 @@ public class SendTabActivity extends Activity {
 
   public void sendClickHandler(View view) {
     Logger.info(LOG_TAG, "Send was clicked.");
-    Bundle extras = this.getIntent().getExtras();
-    if (extras == null) {
-      Logger.warn(LOG_TAG, "extras was null; aborting without sending tab.");
-      notifyAndFinish(false);
-      return;
-    }
-
-    final SendTabData sendTabData = SendTabData.fromBundle(extras);
-
-    if (sendTabData.title == null) {
-      Logger.warn(LOG_TAG, "title was null; ignoring and sending tab anyway.");
-    }
-
-    if (sendTabData.uri == null) {
-      Logger.warn(LOG_TAG, "uri was null; aborting without sending tab.");
-      notifyAndFinish(false);
-      return;
-    }
-
     final List<String> remoteClientGuids = arrayAdapter.getCheckedGUIDs();
 
     if (remoteClientGuids == null) {

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/SendTabActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/SendTabActivity.java
@@ -4,15 +4,19 @@
 
 package org.mozilla.gecko.sync.setup.activities;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 
 import org.mozilla.gecko.R;
 import org.mozilla.gecko.sync.CommandProcessor;
 import org.mozilla.gecko.sync.CommandRunner;
-import org.mozilla.gecko.sync.SyncConstants;
 import org.mozilla.gecko.sync.GlobalSession;
 import org.mozilla.gecko.sync.Logger;
 import org.mozilla.gecko.sync.SyncConfiguration;
+import org.mozilla.gecko.sync.SyncConstants;
 import org.mozilla.gecko.sync.repositories.NullCursorException;
 import org.mozilla.gecko.sync.repositories.android.ClientsDatabaseAccessor;
 import org.mozilla.gecko.sync.repositories.domain.ClientRecord;
@@ -95,20 +99,22 @@ public class SendTabActivity extends Activity {
 
     // Fetching the client list hits the clients database, so we spin this onto
     // a background task.
-    new AsyncTask<Void, Void, ClientRecord[]>() {
+    new AsyncTask<Void, Void, Collection<ClientRecord>>() {
 
       @Override
-      protected ClientRecord[] doInBackground(Void... params) {
-        return getClientArray();
+      protected Collection<ClientRecord> doInBackground(Void... params) {
+        return getOtherClients();
       }
 
       @Override
-      protected void onPostExecute(final ClientRecord[] clientArray) {
+      protected void onPostExecute(final Collection<ClientRecord> clientArray) {
         // We're allowed to update the UI from here.
 
-        Logger.debug(LOG_TAG, "Got " + clientArray.length + " clients.");
+        Logger.debug(LOG_TAG, "Got " + clientArray.size() + " clients.");
         arrayAdapter.setClientRecordList(clientArray);
-        arrayAdapter.checkIfSolitaryClient();
+        if (clientArray.size() == 1) {
+          arrayAdapter.checkItem(0, true);
+        }
       }
     }.execute();
   }
@@ -254,16 +260,31 @@ public class SendTabActivity extends Activity {
     sendButton.setClickable(shouldEnable);
   }
 
-  protected ClientRecord[] getClientArray() {
+  protected Map<String, ClientRecord> getClients() {
     ClientsDatabaseAccessor db = new ClientsDatabaseAccessor(this.getApplicationContext());
-
     try {
-      return db.fetchAllClients().values().toArray(new ClientRecord[0]);
+      return db.fetchAllClients();
     } catch (NullCursorException e) {
       Logger.warn(LOG_TAG, "NullCursorException while populating device list.", e);
       return null;
     } finally {
       db.close();
     }
+  }
+
+  /**
+   * @return a collection of client records, excluding our own.
+   */
+  protected Collection<ClientRecord> getOtherClients() {
+    final Map<String, ClientRecord> all = getClients();
+    final ArrayList<ClientRecord> out = new ArrayList<ClientRecord>(all.size());
+    final String ourGUID = getAccountGUID();
+    for (Entry<String, ClientRecord> entry : all.entrySet()) {
+      if (ourGUID.equals(entry.getKey())) {
+        continue;
+      }
+      out.add(entry.getValue());
+    }
+    return out;
   }
 }

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/SendTabActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/SendTabActivity.java
@@ -44,6 +44,41 @@ public class SendTabActivity extends Activity {
     super.onCreate(savedInstanceState);
   }
 
+  /**
+   * Ensure that the view's list of clients is backed by a recently populated
+   * array adapter. But only once, so we don't end up blowing away your selections
+   * just because you got a text message.
+   */
+  protected synchronized void ensureClientList(final Context context,
+                                               final ListView listview) {
+    if (arrayAdapter != null) {
+      Logger.debug(LOG_TAG, "Already have an array adapter for client lists.");
+      listview.setAdapter(arrayAdapter);
+      return;
+    }
+
+    arrayAdapter = new ClientRecordArrayAdapter(context, R.layout.sync_list_item);
+    listview.setAdapter(arrayAdapter);
+
+    // Fetching the client list hits the clients database, so we spin this onto
+    // a background task.
+    new AsyncTask<Void, Void, ClientRecord[]>() {
+
+      @Override
+      protected ClientRecord[] doInBackground(Void... params) {
+        return getClientArray();
+      }
+
+      @Override
+      protected void onPostExecute(final ClientRecord[] clientArray) {
+        // We're allowed to update the UI from here.
+
+        Logger.debug(LOG_TAG, "Got " + clientArray.length + " clients.");
+        arrayAdapter.setClientRecordList(clientArray);
+      }
+    }.execute();
+  }
+
   @Override
   public void onResume() {
     ActivityUtils.prepareLogging();
@@ -60,23 +95,7 @@ public class SendTabActivity extends Activity {
     listview.setChoiceMode(ListView.CHOICE_MODE_MULTIPLE);
     enableSend(false);
 
-    // Fetching the client list hits the clients database, so we spin this onto
-    // a background task.
-    final Context context = this;
-    new AsyncTask<Void, Void, ClientRecord[]>() {
-
-      @Override
-      protected ClientRecord[] doInBackground(Void... params) {
-        return getClientArray();
-      }
-
-      @Override
-      protected void onPostExecute(final ClientRecord[] clientArray) {
-        // We're allowed to update the UI from here.
-        arrayAdapter = new ClientRecordArrayAdapter(context, R.layout.sync_list_item, clientArray);
-        listview.setAdapter(arrayAdapter);
-      }
-    }.execute();
+    ensureClientList(this, listview);
   }
 
   private static void registerDisplayURICommand() {

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/SendTabActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/SendTabActivity.java
@@ -75,6 +75,7 @@ public class SendTabActivity extends Activity {
 
         Logger.debug(LOG_TAG, "Got " + clientArray.length + " clients.");
         arrayAdapter.setClientRecordList(clientArray);
+        arrayAdapter.checkIfSolitaryClient();
       }
     }.execute();
   }


### PR DESCRIPTION
I ended up reworking the `ClientRecordArrayAdapter`, because despite being an `ArrayAdapter` it elected to manage its own array!

We now populate and connect it, then fetch client records and update the adapter accordingly.

We only fetch client records once, regardless of how many times you resume the activity. That should stop boxes getting unchecked.

And then the real work: check automatically if there's only one client to which to send, and make the rows slightly fatter.
