### PR TITLE
Bug 814750 - execution queue

### DIFF
--- a/src/main/java/org/mozilla/android/sync/test/helpers/MockGlobalSession.java
+++ b/src/main/java/org/mozilla/android/sync/test/helpers/MockGlobalSession.java
@@ -36,7 +36,7 @@ public class MockGlobalSession extends MockPrefsGlobalSession {
   }
 
   @Override
-  protected void prepareStages() {
+  protected void prepareStageFactory() {
     this.stageOverrides = new HashMap<Stage, GlobalSyncStage>();
     this.stageFactory = new GlobalSyncStageFactory() {
       @Override

--- a/src/main/java/org/mozilla/gecko/sync/ExtendedJSONObject.java
+++ b/src/main/java/org/mozilla/gecko/sync/ExtendedJSONObject.java
@@ -115,7 +115,7 @@ public class ExtendedJSONObject {
   /**
    * Helper method to get a JSON object from a stream.
    *
-   * @param jsonString input.
+   * @param in input stream.
    * @throws ParseException
    * @throws IOException
    * @throws NonArrayJSONException if the object is valid JSON, but not an object.

--- a/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
+++ b/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
@@ -241,10 +241,10 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
   }
 
   public GlobalSyncStage getSyncStageByName(String name) throws NoSuchStageException {
-    return getSyncStageByName(Stage.byName(name));
+    return getSyncStageByEnum(Stage.byName(name));
   }
 
-  public GlobalSyncStage getSyncStageByName(Stage next) throws NoSuchStageException {
+  public GlobalSyncStage getSyncStageByEnum(Stage next) throws NoSuchStageException {
     GlobalSyncStage stage = stages.get(next);
     if (stage == null) {
       throw new NoSuchStageException(next);
@@ -256,7 +256,7 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
     ArrayList<GlobalSyncStage> out = new ArrayList<GlobalSyncStage>();
     for (Stage name : enums) {
       try {
-        GlobalSyncStage stage = this.getSyncStageByName(name);
+        GlobalSyncStage stage = this.getSyncStageByEnum(name);
         out.add(stage);
       } catch (NoSuchStageException e) {
         Logger.warn(LOG_TAG, "Unable to find stage with name " + name);
@@ -305,7 +305,7 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
     Stage next = nextStage(this.currentState);
     GlobalSyncStage nextStage;
     try {
-      nextStage = this.getSyncStageByName(next);
+      nextStage = this.getSyncStageByEnum(next);
     } catch (NoSuchStageException e) {
       this.abort(e, "No such stage " + next);
       return;

--- a/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
+++ b/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
@@ -171,7 +171,7 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
     config.syncKeyBundle = syncKeyBundle;
 
     registerCommands();
-    prepareStages();
+    prepareStageFactory();
 
     Collection<String> knownStageNames = SyncConfiguration.validEngineNames();
     config.stagesToSync = Utils.getStagesToSyncFromBundle(knownStageNames, extras);
@@ -227,7 +227,7 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
     });
   }
 
-  protected void prepareStages() {
+  protected void prepareStageFactory() {
     HashMap<Stage, Class<? extends GlobalSyncStage>> klasses = new HashMap<Stage, Class<? extends GlobalSyncStage>>();
 
     klasses.put(Stage.checkPreconditions,      CheckPreconditionsStage.class);

--- a/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
+++ b/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
@@ -357,7 +357,7 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
    * Stop this sync and start again.
    * @throws AlreadySyncingException
    */
-  protected void restart() throws AlreadySyncingException {
+  public void restart() throws AlreadySyncingException {
     this.currentState = GlobalSyncStage.Stage.idle;
     if (callback.shouldBackOff()) {
       this.callback.handleAborted(this, "Told to back off.");

--- a/src/main/java/org/mozilla/gecko/sync/stage/DynamicGlobalSyncStageFactory.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/DynamicGlobalSyncStageFactory.java
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.gecko.sync.stage;
+
+import java.lang.reflect.Constructor;
+import java.util.Map;
+
+import org.mozilla.gecko.sync.Logger;
+import org.mozilla.gecko.sync.stage.GlobalSyncStage.Stage;
+
+/**
+ * A global sync stage factory that
+ * <ul>
+ * <li>maintains a map from sync stage to global sync stage classes;</li>
+ * <li>creates global sync stages dynamically by reflection.</li>
+ * </ul>
+ */
+public class DynamicGlobalSyncStageFactory implements GlobalSyncStageFactory {
+  public static final String LOG_TAG = DynamicGlobalSyncStageFactory.class.getSimpleName();
+
+  public final Map<Stage, Class<? extends GlobalSyncStage>> klasses;
+
+  public DynamicGlobalSyncStageFactory(Map<Stage, Class<? extends GlobalSyncStage>> klasses) {
+    this.klasses = klasses;
+  }
+
+  @Override
+  public GlobalSyncStage createGlobalSyncStage(Stage stage) {
+    Class<? extends GlobalSyncStage> klass = klasses.get(stage);
+    if (klass == null) {
+      return null;
+    }
+
+    try {
+      Constructor<? extends GlobalSyncStage> constructor = klass.getDeclaredConstructor();
+      if (constructor == null) {
+        return null;
+      }
+      return constructor.newInstance();
+    } catch (Exception e) {
+      Logger.warn(LOG_TAG, "Failed to dynamically create instance of " + klass + "; returning null.", e);
+      return null;
+    }
+  }
+}

--- a/src/main/java/org/mozilla/gecko/sync/stage/GlobalSyncStageFactory.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/GlobalSyncStageFactory.java
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.gecko.sync.stage;
+
+import org.mozilla.gecko.sync.stage.GlobalSyncStage.Stage;
+
+public interface GlobalSyncStageFactory {
+  public GlobalSyncStage createGlobalSyncStage(Stage stage);
+}

--- a/src/main/java/org/mozilla/gecko/sync/stage/NoSuchStageException.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/NoSuchStageException.java
@@ -10,4 +10,9 @@ public class NoSuchStageException extends Exception {
   public NoSuchStageException(GlobalSyncStage.Stage stage) {
     this.stage = stage;
   }
+
+  @Override
+  public String toString() {
+    return super.toString() + " (stage=" + this.stage + ")";
+  }
 }

--- a/src/test/java/org/mozilla/android/sync/net/test/TestGlobalSession.java
+++ b/src/test/java/org/mozilla/android/sync/net/test/TestGlobalSession.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -288,8 +289,7 @@ public class TestGlobalSession {
   }
 
   @Test
-  public void testOnSuccessBackoffAdvanced() throws SyncConfigurationException,
-      IllegalArgumentException, NonObjectJSONException, IOException,
+  public void testOnSuccessBackoffAdvanced() throws Exception,
       ParseException, CryptoException {
     MockGlobalSessionCallback callback = doTestSuccess(true, true);
 
@@ -299,8 +299,7 @@ public class TestGlobalSession {
   }
 
   @Test
-  public void testOnSuccessBackoffAborted() throws SyncConfigurationException,
-      IllegalArgumentException, NonObjectJSONException, IOException,
+  public void testOnSuccessBackoffAborted() throws Exception,
       ParseException, CryptoException {
     MockGlobalSessionCallback callback = doTestSuccess(true, false);
 
@@ -310,18 +309,19 @@ public class TestGlobalSession {
   }
 
   @Test
-  public void testOnSuccessNoBackoffAdvanced() throws SyncConfigurationException,
-      IllegalArgumentException, NonObjectJSONException, IOException,
+  public void testOnSuccessNoBackoffAdvanced() throws Exception,
       ParseException, CryptoException {
     MockGlobalSessionCallback callback = doTestSuccess(false, true);
 
     assertTrue(callback.calledSuccess);
     assertFalse(callback.calledRequestBackoff);
+
+    callback.stagesCompleted.add(Stage.completed);
+    assertEquals(Arrays.asList(Stage.values()), callback.stagesCompleted);
   }
 
   @Test
-  public void testOnSuccessNoBackoffAborted() throws SyncConfigurationException,
-      IllegalArgumentException, NonObjectJSONException, IOException,
+  public void testOnSuccessNoBackoffAborted() throws Exception,
       ParseException, CryptoException {
     MockGlobalSessionCallback callback = doTestSuccess(false, false);
 
@@ -425,7 +425,8 @@ public class TestGlobalSession {
     assertEquals(expected, session.config.metaGlobal.getEnabledEngineNames());
   }
 
-  public void testStageAdvance() {
+  @Test
+  public void testNextStage() {
     assertEquals(GlobalSession.nextStage(Stage.idle), Stage.checkPreconditions);
     assertEquals(GlobalSession.nextStage(Stage.completed), Stage.idle);
   }

--- a/src/test/java/org/mozilla/android/sync/net/test/TestGlobalSession.java
+++ b/src/test/java/org/mozilla/android/sync/net/test/TestGlobalSession.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -76,6 +77,14 @@ public class TestGlobalSession {
     return WaitHelper.getTestWaiter();
   }
 
+  protected Set<Class<? extends Object>> getClasses(Collection<? extends Object> set) {
+    Set<Class<? extends Object>> newSet = new HashSet<Class<? extends Object>>();
+    for (Object o : set) {
+      newSet.add(o.getClass());
+    }
+    return newSet;
+  }
+
   @Test
   public void testGetSyncStagesBy() throws SyncConfigurationException, IllegalArgumentException, NonObjectJSONException, IOException, ParseException, CryptoException, NoSuchStageException {
 
@@ -96,6 +105,8 @@ public class TestGlobalSession {
     final Set<GlobalSyncStage> bookmarksAndTabsSyncStages = new HashSet<GlobalSyncStage>();
     GlobalSyncStage bookmarksStage = s.getSyncStageByName("bookmarks");
     GlobalSyncStage tabsStage = s.getSyncStageByEnum(Stage.syncTabs);
+    assertNotNull(bookmarksStage);
+    assertNotNull(tabsStage);
     bookmarksAndTabsSyncStages.add(bookmarksStage);
     bookmarksAndTabsSyncStages.add(tabsStage);
 
@@ -104,8 +115,11 @@ public class TestGlobalSession {
     bookmarksAndTabsEnums.add(Stage.syncTabs);
 
     assertTrue(s.getSyncStagesByName(empty).isEmpty());
-    assertEquals(bookmarksAndTabsSyncStages, new HashSet<GlobalSyncStage>(s.getSyncStagesByName(bookmarksAndTabsNames)));
-    assertEquals(bookmarksAndTabsSyncStages, new HashSet<GlobalSyncStage>(s.getSyncStagesByEnum(bookmarksAndTabsEnums)));
+
+    // This is a little odd: global sessions create stage instances on demand,
+    // so we won't get identical instances.
+    assertEquals(getClasses(bookmarksAndTabsSyncStages), getClasses(s.getSyncStagesByName(bookmarksAndTabsNames)));
+    assertEquals(getClasses(bookmarksAndTabsSyncStages), getClasses(s.getSyncStagesByEnum(bookmarksAndTabsEnums)));
   }
 
   /**

--- a/src/test/java/org/mozilla/android/sync/net/test/TestGlobalSession.java
+++ b/src/test/java/org/mozilla/android/sync/net/test/TestGlobalSession.java
@@ -80,7 +80,7 @@ public class TestGlobalSession {
                                                  new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY),
                                                  callback, /* context */ null, null, null);
 
-    assertTrue(s.getSyncStageByName(Stage.syncBookmarks) instanceof AndroidBrowserBookmarksServerSyncStage);
+    assertTrue(s.getSyncStageByEnum(Stage.syncBookmarks) instanceof AndroidBrowserBookmarksServerSyncStage);
 
     final Set<String> empty = new HashSet<String>();
 
@@ -90,7 +90,7 @@ public class TestGlobalSession {
 
     final Set<GlobalSyncStage> bookmarksAndTabsSyncStages = new HashSet<GlobalSyncStage>();
     GlobalSyncStage bookmarksStage = s.getSyncStageByName("bookmarks");
-    GlobalSyncStage tabsStage = s.getSyncStageByName(Stage.syncTabs);
+    GlobalSyncStage tabsStage = s.getSyncStageByEnum(Stage.syncTabs);
     bookmarksAndTabsSyncStages.add(bookmarksStage);
     bookmarksAndTabsSyncStages.add(tabsStage);
 

--- a/src/test/java/org/mozilla/android/sync/test/TestResetCommands.java
+++ b/src/test/java/org/mozilla/android/sync/test/TestResetCommands.java
@@ -103,8 +103,8 @@ public class TestResetCommands {
       }
 
       @Override
-      public void prepareStages() {
-        super.prepareStages();
+      public void prepareStageFactory() {
+        super.prepareStageFactory();
         this.withStage(Stage.syncBookmarks, stageGetsReset);
         this.withStage(Stage.syncHistory,   stageNotReset);
       }

--- a/src/test/java/org/mozilla/android/sync/test/helpers/MockGlobalSessionCallback.java
+++ b/src/test/java/org/mozilla/android/sync/test/helpers/MockGlobalSessionCallback.java
@@ -3,9 +3,9 @@
 
 package org.mozilla.android.sync.test.helpers;
 
-import static org.junit.Assert.assertEquals;
-
 import java.net.URI;
+import java.util.LinkedList;
+import java.util.List;
 
 import org.mozilla.gecko.sync.GlobalSession;
 import org.mozilla.gecko.sync.delegates.GlobalSessionCallback;
@@ -23,7 +23,7 @@ public class MockGlobalSessionCallback implements GlobalSessionCallback {
     return WaitHelper.getTestWaiter();
   }
 
-  public int stageCounter = Stage.values().length - 1; // Exclude starting state.
+  public List<Stage> stagesCompleted = new LinkedList<Stage>();
   public boolean calledSuccess = false;
   public boolean calledError = false;
   public Exception calledErrorException = null;
@@ -42,7 +42,6 @@ public class MockGlobalSessionCallback implements GlobalSessionCallback {
   @Override
   public void handleSuccess(GlobalSession globalSession) {
     this.calledSuccess = true;
-    assertEquals(0, this.stageCounter);
     this.testWaiter().performNotify();
   }
 
@@ -60,9 +59,8 @@ public class MockGlobalSessionCallback implements GlobalSessionCallback {
   }
 
   @Override
-  public void handleStageCompleted(Stage currentState,
-           GlobalSession globalSession) {
-    stageCounter--;
+  public void handleStageCompleted(Stage currentState, GlobalSession globalSession) {
+    stagesCompleted.add(currentState);
   }
 
   @Override

--- a/src/test/java/org/mozilla/gecko/sync/stage/test/TestEnsureCrypto5KeysStage.java
+++ b/src/test/java/org/mozilla/gecko/sync/stage/test/TestEnsureCrypto5KeysStage.java
@@ -61,8 +61,8 @@ public class TestEnsureCrypto5KeysStage {
     session = new MockGlobalSession(TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD,
       syncKeyBundle, callback) {
       @Override
-      protected void prepareStages() {
-        super.prepareStages();
+      protected void prepareStageFactory() {
+        super.prepareStageFactory();
         withStage(Stage.ensureKeysStage, new EnsureCrypto5KeysStage());
       }
 

--- a/src/test/java/org/mozilla/gecko/sync/stage/test/TestFetchMetaGlobalStage.java
+++ b/src/test/java/org/mozilla/gecko/sync/stage/test/TestFetchMetaGlobalStage.java
@@ -88,8 +88,8 @@ public class TestFetchMetaGlobalStage {
     session = new MockGlobalSession(TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD,
       syncKeyBundle, callback) {
       @Override
-      protected void prepareStages() {
-        super.prepareStages();
+      protected void prepareStageFactory() {
+        super.prepareStageFactory();
         withStage(Stage.fetchMetaGlobal, new FetchMetaGlobalStage());
       }
 


### PR DESCRIPTION
This uses an execution service rather than the existing nested stack for executing global sync stages.

The final two commits are there for comments only -- they show what a stage factory might look like.  We could go this direction, or not -- I'm not particularly tied to it, and made earlier changes (construction flow) that make the factory pattern less appealing.

One reason to use the execution service was to "explicitly release" stages that had been executed so that we could GC them.  Two comments:
- stages can be executed multiple times (reset, wipe, execute), including possibly after a `restart`, so this is hard to do without calling `prepareStages` multiple times, at which point we should just use the factory.
- stages actually use very little memory, so GCing them is mostly for hygiene and clarity of lifecycles; lifecycle seems better conveyed by the factory pattern.

Thoughts?
