### PR TITLE
Bug 861994 - import Gecko resources and fix theming

### DIFF
--- a/res/color/primary_text.xml
+++ b/res/color/primary_text.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:state_enabled="false" android:color="@color/text_color_primary_disable_only" />
+    <item android:color="@color/text_color_primary"/>
+
+</selector>

--- a/res/color/primary_text_inverse.xml
+++ b/res/color/primary_text_inverse.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:state_enabled="false" android:color="@color/text_color_primary_disable_only" />
+    <item android:color="@color/text_color_primary_inverse"/>
+
+</selector>

--- a/res/color/secondary_text.xml
+++ b/res/color/secondary_text.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:state_enabled="false" android:color="@color/text_color_primary_disable_only" />
+    <item android:color="@color/text_color_secondary"/>
+
+</selector>

--- a/res/color/secondary_text_inverse.xml
+++ b/res/color/secondary_text_inverse.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:state_enabled="false" android:color="@color/text_color_primary_disable_only" />
+    <item android:color="@color/text_color_secondary_inverse"/>
+
+</selector>

--- a/res/color/tertiary_text.xml
+++ b/res/color/tertiary_text.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:state_enabled="false" android:color="@color/text_color_primary_disable_only" />
+    <item android:color="@color/text_color_tertiary"/>
+
+</selector>

--- a/res/color/tertiary_text_inverse.xml
+++ b/res/color/tertiary_text_inverse.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:state_enabled="false" android:color="@color/text_color_primary_disable_only" />
+    <item android:color="@color/text_color_tertiary_inverse"/>
+
+</selector>

--- a/res/values-large-v11/themes.xml
+++ b/res/values-large-v11/themes.xml
@@ -19,11 +19,5 @@
         <item name="android:windowActionBar">false</item>
         <item name="android:windowNoTitle">true</item>
     </style>
-
-    <style name="GeckoDialogBase" parent="@android:style/Theme.Holo.Light.Dialog">
-        <item name="android:windowContentOverlay">@null</item>
-        <item name="android:windowActionBar">false</item>
-        <item name="android:windowNoTitle">true</item>
-    </style>
-
+    
 </resources>

--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<resources>
+  <color name="awesomebar_header_row">#FFD2DAE2</color>
+  <color name="awesomebar_header_row_focused">#FFA2AAB2</color>
+  <color name="background_normal">#FFCED7DE</color>
+  <color name="background_private">#FF292C29</color>
+  <color name="background_tabs">#FF363B40</color>
+  <color name="highlight">#33000000</color>
+  <color name="highlight_focused">#1A000000</color>
+  <color name="highlight_dark">#33FFFFFF</color>
+  <color name="highlight_dark_focused">#1AFFFFFF</color>
+
+  <!-- highlight on shaped button: 20% white over background_tabs -->
+  <color name="highlight_shaped">#FF696D71</color>
+
+  <!-- highlight-focused on shaped button: 10% white over background_tabs -->
+  <color name="highlight_shaped_focused">#FF565B60</color>
+
+  <!-- highlight on nav button: 20% black over background_normal -->
+  <color name="highlight_nav">#FFA5ACB2</color>
+
+  <!-- highlight-focused on nav button: 10% black over background_normal -->
+  <color name="highlight_nav_focused">#FFB9C1C7</color>
+
+  <!-- highlight on private nav button: 20% white over background_private -->
+  <color name="highlight_nav_pb">#FF545654</color>
+
+  <!-- highlight-focused on private nav button: 10% white over background_private -->
+  <color name="highlight_nav_focused_pb">#FF3F423F</color>
+
+  <!--
+      Application theme colors
+  -->
+  <!-- Default colors -->
+  <color name="text_color_primary">#222222</color>
+  <color name="text_color_secondary">#666666</color>
+  <color name="text_color_tertiary">#9198A1</color>
+
+  <!-- Default inverse colors -->
+  <color name="text_color_primary_inverse">#FFFFFF</color>
+  <color name="text_color_secondary_inverse">#DDDDDD</color>
+  <color name="text_color_tertiary_inverse">#A4A7A9</color>
+
+  <!-- Disabled colors -->
+  <color name="text_color_primary_disable_only">#999999</color>
+
+  <!-- Hint colors -->
+  <color name="text_color_hint">#666666</color>
+  <color name="text_color_hint_inverse">#7F828A</color>
+
+  <!-- Highlight colors -->
+  <color name="text_color_highlight">#FF9500</color>
+  <color name="text_color_highlight_inverse">#D06BFF</color>
+
+  <!-- Link colors -->
+  <color name="text_color_link">#22629E</color>
+
+  <color name="splash_background">#000000</color>
+  <color name="splash_msgfont">#ffffff</color>
+  <color name="splash_urlfont">#000000</color>
+  <color name="splash_content">#ffffff</color>
+  <color name="doorhanger_text">#FF222222</color>
+  <color name="doorhanger_link">#ACC4D5</color>
+  <color name="validation_message_text">#ffffff</color>
+  <color name="identity_verified">#FF3298FF</color>
+  <color name="identity_identified">#FF89C450</color>
+  <color name="url_bar_text_highlight">#FFFF9500</color>
+  <color name="url_bar_text_highlight_pb">#FFD06BFF</color>
+  <color name="suggestion_primary">#dddddd</color>
+  <color name="suggestion_pressed">#bbbbbb</color>
+  <color name="abouthome_thumbnail_bg">#5FFF</color>
+  <color name="abouthome_topsite_shadow">#1000</color>
+  <color name="tab_row_pressed">#4D000000</color>
+  <color name="abouthome_topsite_pin">#55000000</color>
+  <color name="dialogtitle_textcolor">#ffffff</color>
+</resources>

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<resources>
+
+    <!--
+        Base application styles. This could be overridden in other res/values-XXX/themes.xml.
+    -->
+    <style name="Widget"/>
+
+    <style name="Widget.BaseButton" parent="android:style/Widget.Button"/>
+
+    <style name="Widget.BaseDropDownItem" parent="android:style/Widget.DropDownItem"/>
+
+    <style name="Widget.BaseEditText" parent="android:style/Widget.EditText"/>
+
+    <style name="Widget.BaseListView" parent="android:style/Widget.ListView"/>
+
+    <style name="Widget.BaseTextView" parent="android:style/Widget.TextView"/>
+
+    <!--
+        Application styles. All customizations that are not specific
+        to a particular API level can go here.
+    -->
+    <style name="Widget.Button" parent="Widget.BaseButton">
+        <item name="android:textAppearance">@style/TextAppearance.Widget.Button</item>
+    </style>
+
+    <style name="Widget.DropDownItem" parent="Widget.BaseDropDownItem">
+        <item name="android:textAppearance">@style/TextAppearance.Widget.DropDownItem</item>
+    </style>
+
+    <style name="Widget.EditText" parent="Widget.BaseEditText">
+        <item name="android:textAppearance">@style/TextAppearance.Widget.EditText</item>
+    </style>
+
+    <style name="Widget.TextView" parent="Widget.BaseTextView">
+        <item name="android:textAppearance">@style/TextAppearance.Widget.TextView</item>
+    </style>
+
+    <style name="Widget.TextView.SpinnerItem">
+        <item name="android:textAppearance">@style/TextAppearance.Widget.TextView</item>
+    </style>
+
+    <style name="Widget.ListView" parent="Widget.BaseListView">
+        <item name="android:divider">#D1D5DA</item>
+        <item name="android:dividerHeight">1dp</item>
+        <item name="android:cacheColorHint">@android:color/transparent</item>
+    </style>
+
+    <style name="Widget.ExpandableListView" parent="Widget.ListView">
+        <item name="android:groupIndicator">@android:color/transparent</item>
+        <item name="android:childDivider">#D1D5DA</item>
+    </style>
+
+    <style name="Widget.ListItem">
+        <item name="android:minHeight">?android:attr/listPreferredItemHeight</item>
+        <item name="android:textAppearance">?android:attr/textAppearanceLargeInverse</item>
+        <item name="android:gravity">center_vertical</item>
+        <item name="android:paddingLeft">12dip</item>
+        <item name="android:paddingRight">7dip</item>
+        <item name="android:checkMark">?android:attr/listChoiceIndicatorMultiple</item>
+        <item name="android:ellipsize">marquee</item>
+    </style>
+
+    <!--
+        TextAppearance
+        Note: Gecko uses light theme as default, while Android uses dark.
+        If Android convention has to be followd, the list of colors specified 
+        in themes.xml would be inverse, and things would get confusing.
+        Hence, Gecko's TextAppearance is based on text over light theme and
+        TextAppearance.Inverse is based on text over dark theme.
+    -->
+    <style name="TextAppearance">
+        <item name="android:textColor">?android:attr/textColorPrimary</item>
+        <item name="android:textColorHighlight">@color/text_color_highlight</item>
+        <item name="android:textColorHint">?android:attr/textColorHint</item>
+        <item name="android:textColorLink">?android:attr/textColorLink</item>
+        <item name="android:textSize">16sp</item>
+        <item name="android:textStyle">normal</item>
+    </style>
+
+    <style name="TextAppearance.Inverse">
+        <item name="android:textColor">?android:attr/textColorPrimaryInverse</item>
+        <item name="android:textColorHint">?android:attr/textColorHintInverse</item>
+        <item name="android:textColorHighlight">@color/text_color_highlight_inverse</item>
+        <item name="android:textColorLink">?android:attr/textColorLinkInverse</item>
+    </style>
+
+    <style name="TextAppearance.Large">
+        <item name="android:textSize">22sp</item>
+    </style>
+
+    <style name="TextAppearance.Large.Inverse">
+        <item name="android:textColor">?android:attr/textColorPrimaryInverse</item>
+        <item name="android:textColorHint">?android:attr/textColorHintInverse</item>
+        <item name="android:textColorHighlight">@color/text_color_highlight_inverse</item>
+        <item name="android:textColorLink">?android:attr/textColorLinkInverse</item>
+    </style>
+
+    <style name="TextAppearance.Medium">
+        <item name="android:textSize">18sp</item>
+    </style>
+
+    <style name="TextAppearance.Medium.Inverse">
+        <item name="android:textColor">?android:attr/textColorPrimaryInverse</item>
+        <item name="android:textColorHint">?android:attr/textColorHintInverse</item>
+        <item name="android:textColorHighlight">@color/text_color_highlight_inverse</item>
+        <item name="android:textColorLink">?android:attr/textColorLinkInverse</item>
+    </style>
+
+    <style name="TextAppearance.Small">
+        <item name="android:textSize">14sp</item>
+        <item name="android:textColor">?android:attr/textColorSecondary</item>
+    </style>
+
+    <style name="TextAppearance.Small.Inverse">
+        <item name="android:textColor">?android:attr/textColorSecondaryInverse</item>
+        <item name="android:textColorHint">?android:attr/textColorHintInverse</item>
+        <item name="android:textColorHighlight">@color/text_color_highlight_inverse</item>
+        <item name="android:textColorLink">?android:attr/textColorLinkInverse</item>
+    </style>
+
+    <style name="TextAppearance.Micro">
+        <item name="android:textSize">12sp</item>
+        <item name="android:textColor">?android:attr/textColorTertiary</item>
+    </style>
+
+    <style name="TextAppearance.Micro.Inverse">
+        <item name="android:textColor">?android:attr/textColorTertiaryInverse</item>
+        <item name="android:textColorHint">?android:attr/textColorHintInverse</item>
+        <item name="android:textColorHighlight">@color/text_color_highlight_inverse</item>
+        <item name="android:textColorLink">?android:attr/textColorLinkInverse</item>
+    </style>
+
+    <style name="TextAppearance.Widget" />
+
+    <style name="TextAppearance.Widget.Button" parent="TextAppearance.Small">
+        <item name="android:textColor">@color/primary_text</item>
+    </style>
+
+    <style name="TextAppearance.Widget.DropDownItem">
+        <item name="android:textColor">@color/primary_text</item>
+    </style>
+
+    <style name="TextAppearance.Widget.EditText">
+        <item name="android:textColor">@color/primary_text</item>
+    </style>
+
+    <style name="TextAppearance.Widget.TextView">
+        <item name="android:textColor">@color/primary_text</item>
+    </style>
+
+</resources>

--- a/res/values/sync_styles.xml
+++ b/res/values/sync_styles.xml
@@ -16,14 +16,14 @@
   </style>
 
   <!-- TextView Styles -->
-  <style name="SyncTextFrame" parent="@android:style/TextAppearance">
+  <style name="SyncTextFrame" parent="@style/TextAppearance">
     <item name="android:layout_width">fill_parent</item>
     <item name="android:layout_height">fill_parent</item>
     <item name="android:layout_gravity">center</item>
     <item name="android:padding">@dimen/SyncSpace</item>
     <item name="android:orientation">vertical</item>
   </style>
-  <style name="SyncTextItem" parent="@android:style/TextAppearance.Medium">
+  <style name="SyncTextItem" parent="@style/TextAppearance.Medium">
     <item name="android:layout_width">fill_parent</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:textSize">15dp</item>
@@ -43,7 +43,7 @@
     <item name="android:textSize">20dp</item>
   </style>
   <!-- EditView Styles -->
-  <style name="SyncEditItem" parent="@android:style/Widget.EditText">
+  <style name="SyncEditItem" parent="@style/Widget.EditText">
     <item name="android:layout_width">fill_parent</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:singleLine">true</item>
@@ -66,7 +66,7 @@
 
   <!-- Top title bar: a text view with the Sync icon to the left. -->
   <style name="SyncTop">
-    <item name="android:textAppearance">@android:style/TextAppearance.Large</item>
+    <item name="android:textAppearance">@style/TextAppearance.Large</item>
     <item name="android:layout_width">fill_parent</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:gravity">center_vertical|left</item>
@@ -103,14 +103,14 @@
     <item name="android:orientation">vertical</item>
   </style>
 
-  <style name="SyncButton" parent="@android:style/Widget.Button">
+  <style name="SyncButton" parent="@style/Widget.Button">
     <item name="android:layout_width">fill_parent</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:layout_weight">1</item>
   </style>
 
   <!-- Text Display Styles -->
-  <style name="SyncPinText" parent="@android:style/Widget.TextView">
+  <style name="SyncPinText" parent="@style/Widget.TextView">
     <item name="android:layout_width">130sp</item>
     <item name="android:layout_height">wrap_content</item>
     <item name="android:layout_gravity">center</item>

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -10,14 +10,71 @@
 
 <resources>
 
-    <style name="Gecko" parent="@android:style/Theme.Light">
+    <!--
+        Base application theme. This could be overridden by GeckoBaseTheme
+        in other res/values-XXX/themes.xml.
+    -->
+    <style name="GeckoBase" parent="@android:style/Theme.Light">
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowContentOverlay">@null</item>
     </style>
 
-    <style name="Gecko.Dialog" parent="@android:style/Theme.Dialog">
+    <style name="GeckoDialogBase" parent="@android:style/Theme.Dialog">
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowContentOverlay">@null</item>
     </style>
+
+    <style name="GeckoAwesomeBarBase" parent="GeckoBase">
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowBackground">@null</item>
+    </style>
+
+    <style name="GeckoPreferencesBase" parent="GeckoBase">
+        <item name="android:windowNoTitle">false</item>
+        <item name="android:windowBackground">@color/background_normal</item>
+    </style>
+
+    <!--
+        Application Theme. All customizations that are not specific
+        to a particular API level can go here.
+    -->
+    <style name="Gecko" parent="GeckoBase">
+        <!-- Default colors -->
+        <item name="android:textColorPrimary">@color/primary_text</item>
+        <item name="android:textColorSecondary">@color/secondary_text</item>
+        <item name="android:textColorTertiary">@color/tertiary_text</item>
+
+        <!-- Default inverse colors -->
+        <item name="android:textColorPrimaryInverse">@color/primary_text</item>
+        <item name="android:textColorSecondaryInverse">@color/secondary_text</item>
+        <item name="android:textColorTertiaryInverse">@color/tertiary_text</item>
+
+        <!-- Disabled colors -->
+        <item name="android:textColorPrimaryDisableOnly">@color/text_color_primary_disable_only</item>
+
+        <!-- Hint colors -->
+        <item name="android:textColorHint">@color/text_color_hint</item>
+        <item name="android:textColorHintInverse">@color/text_color_hint_inverse</item>
+
+        <!-- Highlight colors -->
+        <item name="android:textColorHighlight">@color/text_color_highlight</item>
+        <item name="android:textColorHighlightInverse">@color/text_color_highlight_inverse</item>
+
+        <!-- Link colors -->
+        <item name="android:textColorLink">@color/text_color_link</item>
+
+        <!-- TextAppearances -->
+        <item name="android:textAppearance">@style/TextAppearance</item>
+        <item name="android:textAppearanceInverse">@style/TextAppearance.Inverse</item>
+        <item name="android:textAppearanceLarge">@style/TextAppearance.Large</item>
+        <item name="android:textAppearanceMedium">@style/TextAppearance.Medium</item>
+        <item name="android:textAppearanceSmall">@style/TextAppearance.Small</item>
+        <item name="android:textAppearanceLargeInverse">@style/TextAppearance.Large.Inverse</item>
+        <item name="android:textAppearanceMediumInverse">@style/TextAppearance.Medium.Inverse</item>
+        <item name="android:textAppearanceSmallInverse">@style/TextAppearance.Small.Inverse</item>
+    </style>
+
+    <style name="Gecko.Dialog" parent="GeckoDialogBase"/>
 
 </resources>


### PR DESCRIPTION
This effects minimal changes to be able to apply Sriram's patch.  I cherry-picked just enough pieces of Gecko's styles (and removed some pieces) in order to get things running.  I considered importing all of `mobile/android/base/resources` and updating our scripts, but I decided to leave that until "next time".  (If we do that, there are issues with Fennec putting `.xml.in` files in the `xml/` directory that will need sorting out.)  Just wanted to keep everyone in the loop about these changes before committing.

@rnewman, comments?  I intend to merge this by tomorrow EOD unless I get strong negative feedback.
