### PR TITLE
Bug 863103 - Add BackgroundService runIntentInService() and WakeLock

### DIFF
--- a/src/main/java/org/mozilla/gecko/background/BackgroundService.java
+++ b/src/main/java/org/mozilla/gecko/background/BackgroundService.java
@@ -15,9 +15,14 @@ import android.content.Intent;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.Build;
+import android.os.PowerManager;
+import android.os.PowerManager.WakeLock;
 
 public abstract class BackgroundService extends IntentService {
   private static final String LOG_TAG = BackgroundService.class.getSimpleName();
+  private static final long WAKE_LOCK_TIMEOUT = 1000; // milliseconds
+
+  private static WakeLock wakeLock;
 
   protected BackgroundService() {
     super(LOG_TAG);
@@ -32,6 +37,15 @@ public abstract class BackgroundService extends IntentService {
     service.setAction(intent.getAction());
     service.putExtras(intent);
     context.startService(service);
+
+    // We need a wake lock to ensure that the device stays awake long enough after the Intent's
+    // BroadcastReceiver returns so our IntentService will actually run. Because BackgroundService
+    // can be invoked without calling runIntentInService() and thus acquiring a wake lock, we
+    // acquire a timed wake lock here so BackgroundService doesn't need to worry about whether a
+    // wake lock needs to be released. If multiple intents are queued for this IntentService, then
+    // each intent (launched from runIntentInService) will have acquired its own timed wake lock.
+    WakeLock wakeLock = getWakeLock(context);
+    wakeLock.acquire(WAKE_LOCK_TIMEOUT);
   }
 
   /**
@@ -76,5 +90,13 @@ public abstract class BackgroundService extends IntentService {
   protected void cancelAlarm(PendingIntent pendingIntent) {
     final AlarmManager alarm = getAlarmManager();
     alarm.cancel(pendingIntent);
+  }
+
+  protected static synchronized WakeLock getWakeLock(Context context) {
+    if (BackgroundService.wakeLock == null) {
+      PowerManager pm = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
+      BackgroundService.wakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, LOG_TAG);
+    }
+    return BackgroundService.wakeLock;
   }
 }


### PR DESCRIPTION
@rnewman r?

After reviewing Google's Cloud Messaging (GCM) implementation, here are two BackgroundService additions that may be useful:
1. Add runIntentInService() utility method to ensure the original Intent's extras are copied to rebroadcast Intent:
   
   https://code.google.com/p/gcm/source/browse/gcm-client/src/com/google/android/gcm/GCMBaseIntentService.java?r=3f8285f108caecf9ee040cdadda3a024b81f7e3e#268
2. Add WakeLock to ensure BackgroundService receives the Intent after the BroadcastReceiver returns.

GCM releases its WakeLock at the end of onHandleIntent():

  https://code.google.com/p/gcm/source/browse/gcm-client/src/com/google/android/gcm/GCMBaseIntentService.java?r=3f8285f108caecf9ee040cdadda3a024b81f7e3e#241

Can we safely assume that Android will always call our onDestroy() method? If not, then we risk leaking a WakeLock.

This change is tricky because it relies on every subclass calling super.onHandleIntent() and super.onDestroy() (if the subclass has overridden those methods). Also, we might be able to remove the ugly EXTRA_RELEASE_WAKE_LOCK extra if we assume BackgroundServices are always launched from runIntentForService() and thus called acquireWakeLock().
