### PR TITLE
Bug 893910: Reset FHR submission failure count after timeout

### DIFF
--- a/src/main/java/org/mozilla/gecko/background/healthreport/HealthReportConstants.java.in
+++ b/src/main/java/org/mozilla/gecko/background/healthreport/HealthReportConstants.java.in
@@ -49,6 +49,7 @@ public class HealthReportConstants {
   public static final String PREF_FIRST_RUN = "healthreport_first_run";
   public static final String PREF_NEXT_SUBMISSION = "healthreport_next_submission";
   public static final String PREF_CURRENT_DAY_FAILURE_COUNT = "healthreport_current_day_failure_count";
+  public static final String PREF_CURRENT_DAY_RESET_TIME = "healthreport_current_day_reset_time";
 
   // Forensic.
   public static final String PREF_LAST_UPLOAD_REQUESTED = "healthreport_last_upload_requested";

--- a/src/main/java/org/mozilla/gecko/background/healthreport/upload/SubmissionPolicy.java
+++ b/src/main/java/org/mozilla/gecko/background/healthreport/upload/SubmissionPolicy.java
@@ -72,6 +72,13 @@ public class SubmissionPolicy {
    * @return true if a request was spawned; false otherwise.
    */
   public boolean tick(final long localTime) {
+    if (localTime >= getCurrentDayResetTime()) {
+      editor()
+        .setCurrentDayResetTime(localTime + getMinimumTimeBetweenUploads())
+        .setCurrentDayFailureCount(0)
+        .commit();
+    }
+
     final long nextUpload = getNextSubmission();
 
     // If the system clock were ever set to a time in the distant future,
@@ -319,6 +326,11 @@ public class SubmissionPolicy {
     return getSharedPreferences().getInt(HealthReportConstants.PREF_CURRENT_DAY_FAILURE_COUNT, 0);
   }
 
+  // Authoritative.
+  public long getCurrentDayResetTime() {
+    return getSharedPreferences().getLong(HealthReportConstants.PREF_CURRENT_DAY_RESET_TIME, -1);
+  }
+
   /**
    * To avoid writing to disk multiple times, we encapsulate writes in a
    * helper class. Be sure to call <code>commit</code> to flush to disk!
@@ -353,6 +365,12 @@ public class SubmissionPolicy {
     // Authoritative.
     public Editor setCurrentDayFailureCount(int failureCount) {
       editor.putInt(HealthReportConstants.PREF_CURRENT_DAY_FAILURE_COUNT, failureCount);
+      return this;
+    }
+
+    // Authoritative.
+    public Editor setCurrentDayResetTime(long resetTime) {
+      editor.putLong(HealthReportConstants.PREF_CURRENT_DAY_RESET_TIME, resetTime);
       return this;
     }
 

--- a/src/test/java/org/mozilla/gecko/background/healthreport/upload/test/TestSubmissionPolicy.java
+++ b/src/test/java/org/mozilla/gecko/background/healthreport/upload/test/TestSubmissionPolicy.java
@@ -143,30 +143,34 @@ public class TestSubmissionPolicy {
 
   @Test
   public void testUploadSoftFailure() throws Exception {
-    assertTrue(policy.tick(0));
+    final long initialUploadTime = 0;
+    assertTrue(policy.tick(initialUploadTime));
     client.upload = Response.SOFT_FAILURE;
 
-    assertTrue(policy.tick(2*policy.getMinimumTimeBetweenUploads()));
-    assertEquals(2*policy.getMinimumTimeBetweenUploads(), policy.getLastUploadRequested());
-    assertEquals(2*policy.getMinimumTimeBetweenUploads(), policy.getLastUploadFailed());
+    final long secondUploadTime = initialUploadTime + policy.getMinimumTimeBetweenUploads();
+    assertTrue(policy.tick(secondUploadTime));
+    assertEquals(secondUploadTime, policy.getLastUploadRequested());
+    assertEquals(secondUploadTime, policy.getLastUploadFailed());
     assertEquals(1, policy.getCurrentDayFailureCount());
     assertEquals(policy.getLastUploadFailed() + policy.getMinimumTimeAfterFailure(), policy.getNextSubmission());
     assertNotNull(client.lastId);
     assertTrue(tracker.getObsoleteIds().containsKey(client.lastId));
     client.lastId = null;
 
-    assertTrue(policy.tick(3*policy.getMinimumTimeBetweenUploads()));
-    assertEquals(3*policy.getMinimumTimeBetweenUploads(), policy.getLastUploadRequested());
-    assertEquals(3*policy.getMinimumTimeBetweenUploads(), policy.getLastUploadFailed());
+    final long thirdUploadTime = secondUploadTime + policy.getMinimumTimeAfterFailure();
+    assertTrue(policy.tick(thirdUploadTime));
+    assertEquals(thirdUploadTime, policy.getLastUploadRequested());
+    assertEquals(thirdUploadTime, policy.getLastUploadFailed());
     assertEquals(2, policy.getCurrentDayFailureCount());
     assertEquals(policy.getLastUploadFailed() + policy.getMinimumTimeAfterFailure(), policy.getNextSubmission());
     assertNotNull(client.lastId);
     assertTrue(tracker.getObsoleteIds().containsKey(client.lastId));
     client.lastId = null;
 
-    assertTrue(policy.tick(4*policy.getMinimumTimeBetweenUploads()));
-    assertEquals(4*policy.getMinimumTimeBetweenUploads(), policy.getLastUploadRequested());
-    assertEquals(4*policy.getMinimumTimeBetweenUploads(), policy.getLastUploadFailed());
+    final long fourthUploadTime = thirdUploadTime + policy.getMinimumTimeAfterFailure();
+    assertTrue(policy.tick(fourthUploadTime));
+    assertEquals(fourthUploadTime, policy.getLastUploadRequested());
+    assertEquals(fourthUploadTime, policy.getLastUploadFailed());
     assertEquals(0, policy.getCurrentDayFailureCount());
     assertEquals(policy.getLastUploadFailed() + policy.getMinimumTimeBetweenUploads(), policy.getNextSubmission());
     assertNotNull(client.lastId);


### PR DESCRIPTION
Note that this is built off of #325, which needs to be pushed before this.

@rnewman: Please review.
