### PR TITLE
Bug 888086 - Use StringBuilder in sync/Utils.java

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/Utils.java
+++ b/src/main/java/org/mozilla/gecko/sync/Utils.java
@@ -83,25 +83,19 @@ public class Utils {
    * Helper to convert a byte array to a hex-encoded string
    */
   public static String byte2hex(byte[] b) {
-    // StringBuffer should be used instead.
-    String hs = "";
+    StringBuilder hs = new StringBuilder(b.length*2);
     String stmp;
 
     for (int n = 0; n < b.length; n++) {
-      stmp = java.lang.Integer.toHexString(b[n] & 0XFF);
+      stmp = Integer.toHexString(b[n] & 0XFF);
 
       if (stmp.length() == 1) {
-        hs = hs + "0" + stmp;
-      } else {
-        hs = hs + stmp;
+        hs.append("0");
       }
-
-      if (n < b.length - 1) {
-        hs = hs + "";
-      }
+      hs.append(stmp);
     }
 
-    return hs;
+    return hs.toString();
   }
 
   public static byte[] concatAll(byte[] first, byte[]... rest) {


### PR DESCRIPTION
Finally upstreaming the patch for 888086 - make byte2hex very slightly faster.

Now with less stupid formatting and a slightly less flawed understanding of GitHub.
