### PR TITLE
Bug 903123: Add HawkAuthHeaderProvider.

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/Utils.java
+++ b/src/main/java/org/mozilla/gecko/sync/Utils.java
@@ -178,11 +178,19 @@ public class Utils {
     // Truncates towards 0.
     return (long)(decimal * 1000);
   }
+
   public static long decimalSecondsToMilliseconds(Long decimal) {
     return decimal * 1000;
   }
+
   public static long decimalSecondsToMilliseconds(Integer decimal) {
     return (long)(decimal * 1000);
+  }
+
+  public static byte[] sha256(byte[] in)
+      throws NoSuchAlgorithmException {
+    MessageDigest sha1 = MessageDigest.getInstance("SHA-256");
+    return sha1.digest(in);
   }
 
   protected static byte[] sha1(final String utf8)

--- a/src/main/java/org/mozilla/gecko/sync/net/HawkAuthHeaderProvider.java
+++ b/src/main/java/org/mozilla/gecko/sync/net/HawkAuthHeaderProvider.java
@@ -230,9 +230,8 @@ public class HawkAuthHeaderProvider implements AuthHeaderProvider {
     digest.update(("hawk." + HAWK_HEADER_VERSION + ".payload\n").getBytes("UTF-8"));
     digest.update(getBaseContentType(entity.getContentType()).getBytes("UTF-8"));
     digest.update("\n".getBytes("UTF-8"));
-    InputStream stream = null;
+    InputStream stream = entity.getContent();
     try {
-      stream = entity.getContent();
       int numRead;
       byte[] buffer = new byte[4096];
       while (-1 != (numRead = stream.read(buffer))) {
@@ -243,9 +242,7 @@ public class HawkAuthHeaderProvider implements AuthHeaderProvider {
       digest.update("\n".getBytes("UTF-8")); // Trailing newline is specified by Hawk.
       return digest.digest();
     } finally {
-      if (stream != null) {
-        stream.close();
-      }
+      stream.close();
     }
   }
 

--- a/src/main/java/org/mozilla/gecko/sync/net/HawkAuthHeaderProvider.java
+++ b/src/main/java/org/mozilla/gecko/sync/net/HawkAuthHeaderProvider.java
@@ -129,7 +129,7 @@ public class HawkAuthHeaderProvider implements AuthHeaderProvider {
     String requestString = getRequestString(request, "header", timestamp, nonce, payloadHash, extra, app, dlg);
     String macString = getSignature(requestString.getBytes("UTF-8"), this.key);
 
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     sb.append("Hawk id=\"");
     sb.append(this.id);
     sb.append("\", ");
@@ -254,7 +254,7 @@ public class HawkAuthHeaderProvider implements AuthHeaderProvider {
       throw new IllegalArgumentException("Unsupported URI scheme: " + scheme + ".");
     }
 
-    StringBuffer sb = new StringBuffer();
+    StringBuilder sb = new StringBuilder();
     sb.append("hawk.");
     sb.append(HAWK_HEADER_VERSION);
     sb.append('.');

--- a/src/main/java/org/mozilla/gecko/sync/net/HawkAuthHeaderProvider.java
+++ b/src/main/java/org/mozilla/gecko/sync/net/HawkAuthHeaderProvider.java
@@ -144,7 +144,7 @@ public class HawkAuthHeaderProvider implements AuthHeaderProvider {
       sb.append(payloadHash);
       sb.append("\", ");
     }
-    if (extra != null && !extra.isEmpty()) {
+    if (extra != null && extra.length() > 0) {
       sb.append("ext=\"");
       sb.append(escapeExtraHeaderAttribute(extra));
       sb.append("\", ");
@@ -305,7 +305,7 @@ public class HawkAuthHeaderProvider implements AuthHeaderProvider {
       sb.append(hash);
     }
     sb.append("\n");
-    if (extra != null && !extra.isEmpty()) {
+    if (extra != null && extra.length() > 0) {
       sb.append(escapeExtraString(extra));
     }
     sb.append("\n");

--- a/src/main/java/org/mozilla/gecko/sync/net/HawkAuthHeaderProvider.java
+++ b/src/main/java/org/mozilla/gecko/sync/net/HawkAuthHeaderProvider.java
@@ -1,0 +1,303 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.gecko.sync.net;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.security.GeneralSecurityException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Locale;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.mozilla.apache.commons.codec.binary.Base64;
+import org.mozilla.gecko.sync.Utils;
+
+import ch.boye.httpclientandroidlib.Header;
+import ch.boye.httpclientandroidlib.HttpEntity;
+import ch.boye.httpclientandroidlib.HttpEntityEnclosingRequest;
+import ch.boye.httpclientandroidlib.client.methods.HttpRequestBase;
+import ch.boye.httpclientandroidlib.client.methods.HttpUriRequest;
+import ch.boye.httpclientandroidlib.impl.client.DefaultHttpClient;
+import ch.boye.httpclientandroidlib.message.BasicHeader;
+import ch.boye.httpclientandroidlib.protocol.BasicHttpContext;
+
+/**
+ * An <code>AuthHeaderProvider</code> that returns an Authorization header for
+ * Hawk: <a href="https://github.com/hueniverse/hawk">https://github.com/hueniverse/hawk</a>.
+ *
+ * Hawk is an HTTP authentication scheme using a message authentication code
+ * (MAC) algorithm to provide partial HTTP request cryptographic verification.
+ * Hawk is the successor to the HMAC authentication scheme.
+ */
+public class HawkAuthHeaderProvider implements AuthHeaderProvider {
+  public static final String LOG_TAG = HawkAuthHeaderProvider.class.getSimpleName();
+
+  public static final int HAWK_HEADER_VERSION = 1;
+
+  protected static final int NONCE_LENGTH_IN_BYTES = 8;
+  protected static final String HMAC_SHA256_ALGORITHM = "hmacSHA256";
+
+  protected final String id;
+  protected final byte[] key;
+  protected final boolean includePayloadHash;
+
+  /**
+   * Create a Hawk Authorization header provider.
+   * <p>
+   * Hawk specifies no mechanism by which a client receives an
+   * identifier-and-key pair from the server.
+   *
+   * @param id
+   *          to name requests with.
+   * @param key
+   *          to sign request with.
+   *
+   * @param includePayloadHash
+   *          true if message integrity hash should be included in signed
+   *          request header. See <a href="https://github.com/hueniverse/hawk#payload-validation">https://github.com/hueniverse/hawk#payload-validation</a>.
+   */
+  public HawkAuthHeaderProvider(String id, byte[] key, boolean includePayloadHash) {
+    if (id == null) {
+      throw new IllegalArgumentException("id must not be null");
+    }
+    if (key == null) {
+      throw new IllegalArgumentException("key must not be null");
+    }
+    this.id = id;
+    this.key = key;
+    this.includePayloadHash = includePayloadHash;
+  }
+
+  @Override
+  public Header getAuthHeader(HttpRequestBase request, BasicHttpContext context, DefaultHttpClient client) throws GeneralSecurityException {
+    long timestamp = System.currentTimeMillis() / 1000;
+    String nonce = Base64.encodeBase64String(Utils.generateRandomBytes(NONCE_LENGTH_IN_BYTES));
+    String extra = "";
+
+    try {
+      return getAuthHeader(request, context, client, timestamp, nonce, extra, this.includePayloadHash);
+    } catch (Exception e) {
+      // We lie a little and make every exception a GeneralSecurityException.
+      throw new GeneralSecurityException(e);
+    }
+  }
+
+  /**
+   * Helper function that generates an HTTP Authorization: Hawk header given
+   * additional Hawk specific data.
+   *
+   * @throws NoSuchAlgorithmException
+   * @throws InvalidKeyException
+   * @throws IOException
+   */
+  protected Header getAuthHeader(HttpRequestBase request, BasicHttpContext context, DefaultHttpClient client,
+      long timestamp, String nonce, String extra, boolean includePayloadHash)
+          throws InvalidKeyException, NoSuchAlgorithmException, IOException {
+    if (timestamp < 0) {
+      throw new IllegalArgumentException("timestamp must contain only [0-9].");
+    }
+
+    if (nonce == null) {
+      throw new IllegalArgumentException("nonce must not be null.");
+    }
+    if (nonce.length() == 0) {
+      throw new IllegalArgumentException("nonce must not be empty.");
+    }
+
+    String payloadHash = null;
+    if (includePayloadHash) {
+      if (!(request instanceof HttpEntityEnclosingRequest)) {
+        throw new IllegalArgumentException("cannot specify payload for request without an entity");
+      }
+      HttpEntity entity = ((HttpEntityEnclosingRequest) request).getEntity();
+      if (entity == null) {
+        throw new IllegalArgumentException("cannot specify payload for request with a null entity");
+      }
+      byte[] payloadBytes = getPayloadString(entity);
+      payloadHash = Base64.encodeBase64String(Utils.sha256(payloadBytes));
+    }
+
+    String app = null;
+    String dlg = null;
+    String requestString = getRequestString(request, "header", timestamp, nonce, payloadHash, extra, app, dlg);
+    String macString = getSignature(requestString.getBytes("UTF-8"), this.key);
+
+    StringBuffer sb = new StringBuffer();
+    sb.append("Hawk id=\"");
+    sb.append(this.id);
+    sb.append("\", ");
+    sb.append("ts=\"");
+    sb.append(timestamp);
+    sb.append("\", ");
+    sb.append("nonce=\"");
+    sb.append(nonce);
+    sb.append("\", ");
+    if (payloadHash != null) {
+      sb.append("hash=\"");
+      sb.append(payloadHash);
+      sb.append("\", ");
+    }
+    if (extra != null && !extra.isEmpty()) {
+      String escapedExt = extra.replaceAll("\\\\", "\\\\").replaceAll("\"", "\\\"");
+      sb.append("ext=\"");
+      sb.append(escapedExt);
+      sb.append("\", ");
+    }
+    sb.append("mac=\"");
+    sb.append(macString);
+    sb.append("\"");
+
+    Header header = new BasicHeader("Authorization", sb.toString());
+    return header;
+  }
+
+  /**
+   * Return the content type with no parameters (pieces following ;).
+   *
+   * @param contentTypeHeader to interrogate.
+   * @return base content type.
+   */
+  protected static String getBaseContentType(Header contentTypeHeader) {
+    if (contentTypeHeader == null) {
+      throw new IllegalArgumentException("contentTypeHeader must not be null.");
+    }
+    String contentType = contentTypeHeader.getValue();
+    if (contentType == null) {
+      throw new IllegalArgumentException("contentTypeHeader value must not be null.");
+    }
+    int index = contentType.indexOf(";");
+    if (index < 0) {
+      return contentType.trim();
+    }
+    return contentType.substring(0, index).trim();
+  }
+
+  /**
+   * Generate a normalized Hawk payload byte array. This is under-specified; the
+   * code here was reverse engineered from the code at
+   * <a href="https://github.com/hueniverse/hawk/blob/871cc597973110900467bd3dfb84a3c892f678fb/lib/crypto.js#L81">https://github.com/hueniverse/hawk/blob/871cc597973110900467bd3dfb84a3c892f678fb/lib/crypto.js#L81</a>.
+   * <p>
+   * <b>Warning:</b> this method writes the entity body in order to hash its
+   * content. This could take a long time, use a lot of memory, or interfere
+   * with streaming!
+   */
+  protected static byte[] getPayloadString(HttpEntity entity) throws UnsupportedEncodingException, IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    baos.write(("hawk." + HAWK_HEADER_VERSION + ".payload\n").getBytes("UTF-8"));
+    baos.write(getBaseContentType(entity.getContentType()).getBytes("UTF-8"));
+    baos.write('\n');
+    entity.writeTo(baos);
+    baos.write('\n');
+    return baos.toByteArray();
+  }
+
+  /**
+   * Generate a normalized Hawk request string. This is under-specified; the code here was
+   * reverse engineered from the code at
+   * <a href="https://github.com/hueniverse/hawk/blob/871cc597973110900467bd3dfb84a3c892f678fb/lib/crypto.js#L55">https://github.com/hueniverse/hawk/blob/871cc597973110900467bd3dfb84a3c892f678fb/lib/crypto.js#L55</a>.
+   * <p>
+   * This method trusts its inputs to be valid.
+   */
+  protected static String getRequestString(HttpUriRequest request, String type, long timestamp, String nonce, String hash, String extra, String app, String dlg) {
+    String method = request.getMethod().toUpperCase(Locale.US);
+
+    URI uri = request.getURI();
+    String host = uri.getHost();
+
+    String path = uri.getRawPath();
+    if (uri.getRawQuery() != null) {
+      path += "?";
+      path += uri.getRawQuery();
+    }
+    if (uri.getRawFragment() != null) {
+      path += "#";
+      path += uri.getRawFragment();
+    }
+
+    int port = uri.getPort();
+    String scheme = uri.getScheme();
+    if (port != -1) {
+    } else if ("http".equalsIgnoreCase(scheme)) {
+      port = 80;
+    } else if ("https".equalsIgnoreCase(scheme)) {
+      port = 443;
+    } else {
+      throw new IllegalArgumentException("Unsupported URI scheme: " + scheme + ".");
+    }
+
+    StringBuffer sb = new StringBuffer();
+    sb.append("hawk.");
+    sb.append(HAWK_HEADER_VERSION);
+    sb.append('.');
+    sb.append(type);
+    sb.append('\n');
+    sb.append(timestamp);
+    sb.append('\n');
+    sb.append(nonce);
+    sb.append('\n');
+    sb.append(method);
+    sb.append('\n');
+    sb.append(path);
+    sb.append('\n');
+    sb.append(host);
+    sb.append('\n');
+    sb.append(port);
+    sb.append('\n');
+    if (hash != null) {
+      sb.append(hash);
+    }
+    sb.append("\n");
+    if (extra != null) {
+      sb.append(extra.replaceAll("\\\\", "\\\\").replaceAll("\n", "\\n"));
+    }
+    sb.append("\n");
+    if (app != null) {
+      sb.append(app);
+      sb.append("\n");
+      if (dlg != null) {
+        sb.append(dlg);
+      }
+      sb.append("\n");
+    }
+
+    return sb.toString();
+  }
+
+  protected static byte[] hmacSha256(byte[] message, byte[] key)
+      throws NoSuchAlgorithmException, InvalidKeyException {
+
+    SecretKeySpec keySpec = new SecretKeySpec(key, HMAC_SHA256_ALGORITHM);
+
+    Mac hasher = Mac.getInstance(HMAC_SHA256_ALGORITHM);
+    hasher.init(keySpec);
+    hasher.update(message);
+
+    byte[] hmac = hasher.doFinal();
+
+    return hmac;
+  }
+
+  /**
+   * Sign a Hawk request string.
+   *
+   * @param requestString to sign.
+   * @param key as <code>String</code>.
+   * @return signature as base-64 encoded string.
+   * @throws InvalidKeyException
+   * @throws NoSuchAlgorithmException
+   * @throws UnsupportedEncodingException
+   */
+  protected static String getSignature(byte[] requestString, byte[] key)
+      throws InvalidKeyException, NoSuchAlgorithmException, UnsupportedEncodingException {
+    String macString = Base64.encodeBase64String(hmacSha256(requestString, key));
+
+    return macString;
+  }
+}

--- a/src/main/java/org/mozilla/gecko/sync/net/HawkAuthHeaderProvider.java
+++ b/src/main/java/org/mozilla/gecko/sync/net/HawkAuthHeaderProvider.java
@@ -145,9 +145,8 @@ public class HawkAuthHeaderProvider implements AuthHeaderProvider {
       sb.append("\", ");
     }
     if (extra != null && !extra.isEmpty()) {
-      String escapedExt = extra.replaceAll("\\\\", "\\\\").replaceAll("\"", "\\\"");
       sb.append("ext=\"");
-      sb.append(escapedExt);
+      sb.append(escapeExtraHeaderAttribute(extra));
       sb.append("\", ");
     }
     sb.append("mac=\"");
@@ -155,6 +154,37 @@ public class HawkAuthHeaderProvider implements AuthHeaderProvider {
     sb.append("\"");
 
     return new BasicHeader("Authorization", sb.toString());
+  }
+
+  /**
+   * Escape the user-provided extra string for the ext="" header attribute.
+   * <p>
+   * Hawk escapes the header ext="" attribute differently than it does the extra
+   * line in the normalized request string.
+   * <p>
+   * See <a href="https://github.com/hueniverse/hawk/blob/871cc597973110900467bd3dfb84a3c892f678fb/lib/browser.js#L385">https://github.com/hueniverse/hawk/blob/871cc597973110900467bd3dfb84a3c892f678fb/lib/browser.js#L385</a>.
+   *
+   * @param extra to escape.
+   * @return extra escaped for the ext="" header attribute.
+   */
+  protected static String escapeExtraHeaderAttribute(String extra) {
+    return extra.replaceAll("\\\\", "\\\\").replaceAll("\"", "\\\"");
+  }
+
+  /**
+   * Escape the user-provided extra string for inserting into the normalized
+   * request string.
+   * <p>
+   * Hawk escapes the header ext="" attribute differently than it does the extra
+   * line in the normalized request string.
+   * <p>
+   * See <a href="https://github.com/hueniverse/hawk/blob/871cc597973110900467bd3dfb84a3c892f678fb/lib/crypto.js#L67">https://github.com/hueniverse/hawk/blob/871cc597973110900467bd3dfb84a3c892f678fb/lib/crypto.js#L67</a>.
+   *
+   * @param extra to escape.
+   * @return extra escaped for the normalized request string.
+   */
+  protected static String escapeExtraString(String extra) {
+    return extra.replaceAll("\\\\", "\\\\").replaceAll("\n", "\\n");
   }
 
   /**
@@ -275,8 +305,8 @@ public class HawkAuthHeaderProvider implements AuthHeaderProvider {
       sb.append(hash);
     }
     sb.append("\n");
-    if (extra != null) {
-      sb.append(extra.replaceAll("\\\\", "\\\\").replaceAll("\n", "\\n"));
+    if (extra != null && !extra.isEmpty()) {
+      sb.append(escapeExtraString(extra));
     }
     sb.append("\n");
     if (app != null) {

--- a/src/main/java/org/mozilla/gecko/sync/net/HawkAuthHeaderProvider.java
+++ b/src/main/java/org/mozilla/gecko/sync/net/HawkAuthHeaderProvider.java
@@ -154,8 +154,7 @@ public class HawkAuthHeaderProvider implements AuthHeaderProvider {
     sb.append(macString);
     sb.append("\"");
 
-    Header header = new BasicHeader("Authorization", sb.toString());
-    return header;
+    return new BasicHeader("Authorization", sb.toString());
   }
 
   /**
@@ -301,9 +300,7 @@ public class HawkAuthHeaderProvider implements AuthHeaderProvider {
     hasher.init(keySpec);
     hasher.update(message);
 
-    byte[] hmac = hasher.doFinal();
-
-    return hmac;
+    return hasher.doFinal();
   }
 
   /**
@@ -318,8 +315,6 @@ public class HawkAuthHeaderProvider implements AuthHeaderProvider {
    */
   protected static String getSignature(byte[] requestString, byte[] key)
       throws InvalidKeyException, NoSuchAlgorithmException, UnsupportedEncodingException {
-    String macString = Base64.encodeBase64String(hmacSha256(requestString, key));
-
-    return macString;
+    return Base64.encodeBase64String(hmacSha256(requestString, key));
   }
 }

--- a/src/test/java/org/mozilla/gecko/sync/net/test/TestHawkAuthHeaderProvider.java
+++ b/src/test/java/org/mozilla/gecko/sync/net/test/TestHawkAuthHeaderProvider.java
@@ -1,0 +1,138 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+package org.mozilla.gecko.sync.net.test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+
+import org.junit.Test;
+import org.mozilla.gecko.sync.net.HawkAuthHeaderProvider;
+
+import ch.boye.httpclientandroidlib.Header;
+import ch.boye.httpclientandroidlib.client.methods.HttpGet;
+import ch.boye.httpclientandroidlib.client.methods.HttpPost;
+import ch.boye.httpclientandroidlib.client.methods.HttpRequestBase;
+import ch.boye.httpclientandroidlib.client.methods.HttpUriRequest;
+import ch.boye.httpclientandroidlib.entity.StringEntity;
+import ch.boye.httpclientandroidlib.impl.client.DefaultHttpClient;
+import ch.boye.httpclientandroidlib.message.BasicHeader;
+import ch.boye.httpclientandroidlib.protocol.BasicHttpContext;
+
+/**
+ * These test vectors were taken from
+ * <a href="https://github.com/hueniverse/hawk/blob/871cc597973110900467bd3dfb84a3c892f678fb/README.md">https://github.com/hueniverse/hawk/blob/871cc597973110900467bd3dfb84a3c892f678fb/README.md</a>.
+ */
+public class TestHawkAuthHeaderProvider {
+  // Expose a few protected static member functions as public for testing.
+  protected static class LeakyHawkAuthHeaderProvider extends HawkAuthHeaderProvider {
+    public LeakyHawkAuthHeaderProvider(String tokenId, byte[] reqHMACKey) {
+      // getAuthHeader takes includePayloadHash as a parameter.
+      super(tokenId, reqHMACKey, false);
+    }
+
+    // Public for testing.
+    public static String getRequestString(HttpUriRequest request, String type, long timestamp, String nonce, String hash, String extra, String app, String dlg) {
+      return HawkAuthHeaderProvider.getRequestString(request, type, timestamp, nonce, hash, extra, app, dlg);
+    }
+
+    // Public for testing.
+    public static String getSignature(String requestString, String key)
+        throws InvalidKeyException, NoSuchAlgorithmException, UnsupportedEncodingException {
+      return HawkAuthHeaderProvider.getSignature(requestString.getBytes("UTF-8"), key.getBytes("UTF-8"));
+    }
+
+    // Public for testing.
+    @Override
+    public Header getAuthHeader(HttpRequestBase request, BasicHttpContext context, DefaultHttpClient client,
+        long timestamp, String nonce, String extra, boolean includePayloadHash)
+            throws InvalidKeyException, NoSuchAlgorithmException, IOException {
+      return super.getAuthHeader(request, context, client, timestamp, nonce, extra, includePayloadHash);
+    }
+
+    // Public for testing.
+    public static String getBaseContentType(Header contentTypeHeader) {
+      return HawkAuthHeaderProvider.getBaseContentType(contentTypeHeader);
+    }
+  }
+
+  @Test
+  public void testSpecRequestString() throws Exception {
+    long timestamp = 1353832234;
+    String nonce = "j4h3g2";
+    String extra = "some-app-ext-data";
+    String hash = null;
+    String app = null;
+    String dlg = null;
+
+    URI uri = new URI("http://example.com:8000/resource/1?b=1&a=2");
+    HttpUriRequest req = new HttpGet(uri);
+
+    String expected = "hawk.1.header\n" +
+        "1353832234\n" +
+        "j4h3g2\n" +
+        "GET\n" +
+        "/resource/1?b=1&a=2\n" +
+        "example.com\n" +
+        "8000\n" +
+        "\n" +
+        "some-app-ext-data\n";
+
+    // LeakyHawkAuthHeaderProvider.
+    assertEquals(expected, LeakyHawkAuthHeaderProvider.getRequestString(req, "header", timestamp, nonce, hash, extra, app, dlg));
+  }
+
+  @Test
+  public void testSpecSignatureExample() throws Exception {
+    String input = "hawk.1.header\n" +
+        "1353832234\n" +
+        "j4h3g2\n" +
+        "GET\n" +
+        "/resource/1?b=1&a=2\n" +
+        "example.com\n" +
+        "8000\n" +
+        "\n" +
+        "some-app-ext-data\n";
+
+    assertEquals("6R4rV5iE+NPoym+WwjeHzjAGXUtLNIxmo1vpMofpLAE=", LeakyHawkAuthHeaderProvider.getSignature(input, "werxhqb98rpaxn39848xrunpaw3489ruxnpa98w4rxn"));
+  }
+
+  @Test
+  public void testSpecPayloadExample() throws Exception {
+    LeakyHawkAuthHeaderProvider provider = new LeakyHawkAuthHeaderProvider("dh37fgj492je", "werxhqb98rpaxn39848xrunpaw3489ruxnpa98w4rxn".getBytes("UTF-8"));
+    URI uri = new URI("http://example.com:8000/resource/1?b=1&a=2");
+    HttpPost req = new HttpPost(uri);
+    String body = "Thank you for flying Hawk";
+    req.setEntity(new StringEntity(body));
+    Header header = provider.getAuthHeader(req, null, null, 1353832234L, "j4h3g2", "some-app-ext-data", true);
+    String expected = "Hawk id=\"dh37fgj492je\", ts=\"1353832234\", nonce=\"j4h3g2\", hash=\"Yi9LfIIFRtBEPt74PVmbTF/xVAwPn7ub15ePICfgnuY=\", ext=\"some-app-ext-data\", mac=\"aSe1DERmZuRl3pI36/9BdZmnErTw3sNzOOAUlfeKjVw=\"";
+    assertEquals("Authorization", header.getName());
+    assertEquals(expected, header.getValue());
+  }
+
+  @Test
+  public void testSpecAuthorizationHeader() throws Exception {
+    LeakyHawkAuthHeaderProvider provider = new LeakyHawkAuthHeaderProvider("dh37fgj492je", "werxhqb98rpaxn39848xrunpaw3489ruxnpa98w4rxn".getBytes("UTF-8"));
+    URI uri = new URI("http://example.com:8000/resource/1?b=1&a=2");
+    HttpGet req = new HttpGet(uri);
+    Header header = provider.getAuthHeader(req, null, null, 1353832234L, "j4h3g2", "some-app-ext-data", false);
+    String expected = "Hawk id=\"dh37fgj492je\", ts=\"1353832234\", nonce=\"j4h3g2\", ext=\"some-app-ext-data\", mac=\"6R4rV5iE+NPoym+WwjeHzjAGXUtLNIxmo1vpMofpLAE=\"";
+    assertEquals("Authorization", header.getName());
+    assertEquals(expected, header.getValue());
+  }
+
+  @Test
+  public void testGetBaseContentType() throws Exception {
+    assertEquals("text/plain", LeakyHawkAuthHeaderProvider.getBaseContentType(new BasicHeader("Content-Type", "text/plain")));
+    assertEquals("text/plain", LeakyHawkAuthHeaderProvider.getBaseContentType(new BasicHeader("Content-Type", "text/plain;one")));
+    assertEquals("text/plain", LeakyHawkAuthHeaderProvider.getBaseContentType(new BasicHeader("Content-Type", "text/plain;one;two")));
+    assertEquals("text/html", LeakyHawkAuthHeaderProvider.getBaseContentType(new BasicHeader("Content-Type", "text/html;charset=UTF-8")));
+    assertEquals("text/html", LeakyHawkAuthHeaderProvider.getBaseContentType(new BasicHeader("Content-Type", "text/html; charset=UTF-8")));
+    assertEquals("text/html", LeakyHawkAuthHeaderProvider.getBaseContentType(new BasicHeader("Content-Type", "text/html ;charset=UTF-8")));
+  }
+}

--- a/src/test/java/org/mozilla/gecko/sync/net/test/TestLiveHawkAuth.java
+++ b/src/test/java/org/mozilla/gecko/sync/net/test/TestLiveHawkAuth.java
@@ -32,9 +32,9 @@ import ch.boye.httpclientandroidlib.protocol.BasicHttpContext;
 
 public class TestLiveHawkAuth {
   /**
-   * Hawk comes with an example/usage.js server. Modify it to serve indefinitely
-   * un-comment the following test, and verify that the port and credentials
-   * have not changed; it should pass.
+   * Hawk comes with an example/usage.js server. Modify it to serve indefinitely,
+   * un-comment the following line, and verify that the port and credentials
+   * have not changed; then the following test should pass.
    */
   // @org.junit.Test
   public void testHawkUsage() throws Exception {
@@ -59,6 +59,23 @@ public class TestLiveHawkAuth {
       public void run() {
         try {
           resource.put(new StringEntity("Thank you for flying Hawk"));
+        } catch (UnsupportedEncodingException e) {
+          WaitHelper.getTestWaiter().performNotify(e);
+        }
+      }
+    });
+
+    // PUT with a large (32k or so) body and payload verification.
+    final StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < 16000; i++) {
+      sb.append(Integer.valueOf(i % 100).toString());
+    }
+    resource.delegate = new TestBaseResourceDelegate(resource, new HawkAuthHeaderProvider(id, key, true));
+    WaitHelper.getTestWaiter().performWait(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          resource.put(new StringEntity(sb.toString()));
         } catch (UnsupportedEncodingException e) {
           WaitHelper.getTestWaiter().performNotify(e);
         }

--- a/src/test/java/org/mozilla/gecko/sync/net/test/TestLiveHawkAuth.java
+++ b/src/test/java/org/mozilla/gecko/sync/net/test/TestLiveHawkAuth.java
@@ -1,0 +1,160 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+package org.mozilla.gecko.sync.net.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.security.GeneralSecurityException;
+
+import org.junit.Assert;
+import org.mozilla.android.sync.test.helpers.WaitHelper;
+import org.mozilla.gecko.sync.net.AuthHeaderProvider;
+import org.mozilla.gecko.sync.net.BaseResource;
+import org.mozilla.gecko.sync.net.BaseResourceDelegate;
+import org.mozilla.gecko.sync.net.HawkAuthHeaderProvider;
+import org.mozilla.gecko.sync.net.Resource;
+import org.mozilla.gecko.sync.net.SyncResponse;
+
+import ch.boye.httpclientandroidlib.Header;
+import ch.boye.httpclientandroidlib.HttpResponse;
+import ch.boye.httpclientandroidlib.client.ClientProtocolException;
+import ch.boye.httpclientandroidlib.client.methods.HttpRequestBase;
+import ch.boye.httpclientandroidlib.entity.StringEntity;
+import ch.boye.httpclientandroidlib.impl.client.DefaultHttpClient;
+import ch.boye.httpclientandroidlib.message.BasicHeader;
+import ch.boye.httpclientandroidlib.protocol.BasicHttpContext;
+
+
+public class TestLiveHawkAuth {
+  /**
+   * Hawk comes with an example/usage.js server. Modify it to serve indefinitely
+   * un-comment the following test, and verify that the port and credentials
+   * have not changed; it should pass.
+   */
+  // @org.junit.Test
+  public void testHawkUsage() throws Exception {
+    // Id and credentials are hard-coded in example/usage.js.
+    final String id = "dh37fgj492je";
+    final byte[] key = "werxhqb98rpaxn39848xrunpaw3489ruxnpa98w4rxn".getBytes("UTF-8");
+    final BaseResource resource = new BaseResource("http://localhost:8000/", false);
+
+    // Basic GET.
+    resource.delegate = new TestBaseResourceDelegate(resource, new HawkAuthHeaderProvider(id, key, false));
+    WaitHelper.getTestWaiter().performWait(new Runnable() {
+      @Override
+      public void run() {
+        resource.get();
+      }
+    });
+
+    // PUT with payload verification.
+    resource.delegate = new TestBaseResourceDelegate(resource, new HawkAuthHeaderProvider(id, key, true));
+    WaitHelper.getTestWaiter().performWait(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          resource.put(new StringEntity("Thank you for flying Hawk"));
+        } catch (UnsupportedEncodingException e) {
+          WaitHelper.getTestWaiter().performNotify(e);
+        }
+      }
+    });
+
+    // PUT without payload verification.
+    resource.delegate = new TestBaseResourceDelegate(resource, new HawkAuthHeaderProvider(id, key, false));
+    WaitHelper.getTestWaiter().performWait(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          resource.put(new StringEntity("Thank you for flying Hawk"));
+        } catch (UnsupportedEncodingException e) {
+          WaitHelper.getTestWaiter().performNotify(e);
+        }
+      }
+    });
+
+    // PUT with *bad* payload verification.
+    HawkAuthHeaderProvider provider = new HawkAuthHeaderProvider(id, key, true) {
+      @Override
+      public Header getAuthHeader(HttpRequestBase request, BasicHttpContext context, DefaultHttpClient client) throws GeneralSecurityException {
+        Header header = super.getAuthHeader(request, context, client);
+        // Here's a cheap way of breaking the hash.
+        String newValue = header.getValue().replaceAll("hash=\"....", "hash=\"XXXX");
+        return new BasicHeader(header.getName(), newValue);
+      }
+    };
+
+    resource.delegate = new TestBaseResourceDelegate(resource, provider);
+    try {
+      WaitHelper.getTestWaiter().performWait(new Runnable() {
+        @Override
+        public void run() {
+          try {
+            resource.put(new StringEntity("Thank you for flying Hawk"));
+          } catch (UnsupportedEncodingException e) {
+            WaitHelper.getTestWaiter().performNotify(e);
+          }
+        }
+      });
+      fail("Expected assertion after 401 response.");
+    } catch (WaitHelper.InnerError e) {
+      assertTrue(e.innerError instanceof AssertionError);
+      assertEquals("expected:<200> but was:<401>", ((AssertionError) e.innerError).getMessage());
+    }
+  }
+
+  protected final class TestBaseResourceDelegate extends BaseResourceDelegate {
+    protected final HawkAuthHeaderProvider provider;
+
+    protected TestBaseResourceDelegate(Resource resource, HawkAuthHeaderProvider provider) throws UnsupportedEncodingException {
+      super(resource);
+      this.provider = provider;
+    }
+
+    @Override
+    public AuthHeaderProvider getAuthHeaderProvider() {
+      return provider;
+    }
+
+    @Override
+    public int connectionTimeout() {
+      return 1000;
+    }
+
+    @Override
+    public int socketTimeout() {
+      return 1000;
+    }
+
+    @Override
+    public void handleHttpResponse(HttpResponse response) {
+      SyncResponse res = new SyncResponse(response);
+      try {
+        Assert.assertEquals(200, res.getStatusCode());
+        WaitHelper.getTestWaiter().performNotify();
+      } catch (Throwable e) {
+        WaitHelper.getTestWaiter().performNotify(e);
+      }
+    }
+
+    @Override
+    public void handleTransportException(GeneralSecurityException e) {
+      WaitHelper.getTestWaiter().performNotify(e);
+    }
+
+    @Override
+    public void handleHttpProtocolException(ClientProtocolException e) {
+      WaitHelper.getTestWaiter().performNotify(e);
+    }
+
+    @Override
+    public void handleHttpIOException(IOException e) {
+      WaitHelper.getTestWaiter().performNotify(e);
+    }
+  }
+}


### PR DESCRIPTION
Hawk is an HTTP authentication scheme using a message authentication
code (MAC) algorithm to provide partial HTTP request cryptographic
verification.  Hawk is the successor to the HMAC authentication
scheme.  The Hawk scheme is descripted at
https://github.com/hueniverse/hawk

Hawk is under-specified; this implementation interoperates with the
git hash at
https://github.com/hueniverse/hawk/blob/871cc597973110900467bd3dfb84a3c892f678fb
