### PR TITLE
Bug CRYPTO - Add Scrypt and PBKDF2 interfaces.

### DIFF
--- a/android-sync-app/pom.xml
+++ b/android-sync-app/pom.xml
@@ -72,6 +72,12 @@
       <version>4.1.21</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.madgag</groupId>
+      <artifactId>sc-light-jdk15on</artifactId>
+      <version>1.47.0.2</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -151,6 +157,7 @@
           </dependency>
         </dependencies>
         <configuration>
+          <!-- <argLine>-Xmx2048m</argLine> -->
           <runOrder>random</runOrder>
           <excludedGroups>org.mozilla.android.sync.test.integration.IntegrationTestCategory</excludedGroups>
         </configuration>

--- a/example.classpath
+++ b/example.classpath
@@ -15,6 +15,7 @@
 			<attribute name="ignore_optional_problems" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry exported="true" kind="var" path="M2_REPO/com/madgag/sc-light-jdk15on/1.47.0.2/sc-light-jdk15on-1.47.0.2.jar"/>
 	<classpathentry exported="true" kind="var" path="M2_REPO/commons-logging/commons-logging/1.1.1/commons-logging-1.1.1.jar"/>
 	<classpathentry exported="true" kind="var" path="M2_REPO/org/simpleframework/simple/4.1.21/simple-4.1.21.jar"/>
   <!-- Stub/unstub libraries must come before Android libraries for

--- a/src/main/java/org/mozilla/gecko/sync/crypto/PBKDF2.java
+++ b/src/main/java/org/mozilla/gecko/sync/crypto/PBKDF2.java
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.gecko.sync.crypto;
+
+public interface PBKDF2 {
+  public byte[] pbkdf2SHA1(byte[] p, byte[] s, int c, int dkLen);
+  public byte[] pbkdf2SHA256(byte[] p, byte[] s, int c, int dkLen);
+}

--- a/src/main/java/org/mozilla/gecko/sync/crypto/Scrypt.java
+++ b/src/main/java/org/mozilla/gecko/sync/crypto/Scrypt.java
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.gecko.sync.crypto;
+
+public interface Scrypt {
+  public byte[] scrypt(byte[] password, byte[] salt, int N, int r, int p, int dkLen);
+}

--- a/src/test/java/org/mozilla/gecko/sync/crypto/test/SpongyCastlePBKDF2.java
+++ b/src/test/java/org/mozilla/gecko/sync/crypto/test/SpongyCastlePBKDF2.java
@@ -1,0 +1,28 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+package org.mozilla.gecko.sync.crypto.test;
+
+import org.mozilla.gecko.sync.crypto.PBKDF2;
+import org.spongycastle.crypto.digests.SHA1Digest;
+import org.spongycastle.crypto.digests.SHA256Digest;
+import org.spongycastle.crypto.generators.PKCS5S2ParametersGenerator;
+import org.spongycastle.crypto.params.KeyParameter;
+
+public class SpongyCastlePBKDF2 implements PBKDF2 {
+  @Override
+  public byte[] pbkdf2SHA1(byte[] p, byte[] s, int c, int dkLen) {
+    PKCS5S2ParametersGenerator generator = new PKCS5S2ParametersGenerator(new SHA1Digest());
+    generator.init(p, s, c);
+    KeyParameter key = (KeyParameter)generator.generateDerivedMacParameters(8*dkLen);
+    return key.getKey();
+  }
+
+  @Override
+  public byte[] pbkdf2SHA256(byte[] p, byte[] s, int c, int dkLen) {
+    PKCS5S2ParametersGenerator generator = new PKCS5S2ParametersGenerator(new SHA256Digest());
+    generator.init(p, s, c);
+    KeyParameter key = (KeyParameter)generator.generateDerivedMacParameters(8*dkLen);
+    return key.getKey();
+  }
+}

--- a/src/test/java/org/mozilla/gecko/sync/crypto/test/SpongyCastleScrypt.java
+++ b/src/test/java/org/mozilla/gecko/sync/crypto/test/SpongyCastleScrypt.java
@@ -1,0 +1,13 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+package org.mozilla.gecko.sync.crypto.test;
+
+import org.mozilla.gecko.sync.crypto.Scrypt;
+
+public class SpongyCastleScrypt implements Scrypt {
+  @Override
+  public byte[] scrypt(byte[] password, byte[] salt, int N, int r, int p, int dkLen) {
+    return org.spongycastle.crypto.generators.SCrypt.generate(password, salt, N, r, p, dkLen);
+  }
+}

--- a/src/test/java/org/mozilla/gecko/sync/crypto/test/TestPBKDF2.java
+++ b/src/test/java/org/mozilla/gecko/sync/crypto/test/TestPBKDF2.java
@@ -1,0 +1,153 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+package org.mozilla.gecko.sync.crypto.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.UnsupportedEncodingException;
+import java.security.GeneralSecurityException;
+
+import org.junit.Test;
+import org.mozilla.gecko.sync.Utils;
+import org.mozilla.gecko.sync.crypto.PBKDF2;
+
+/**
+ * Test PBKDF2 implementations against vectors from
+ * <dl>
+ * <dt>SHA-1</dt>
+ * <dd><a href="http://tools.ietf.org/html/draft-josefsson-pbkdf2-test-vectors-06">http://tools.ietf.org/html/draft-josefsson-pbkdf2-test-vectors-06</a></dd>
+ * <dt>SHA-256</dt>
+ * <dd><a href="https://github.com/ircmaxell/PHP-PasswordLib/blob/master/test/Data/Vectors/pbkdf2-draft-josefsson-sha256.test-vectors">https://github.com/ircmaxell/PHP-PasswordLib/blob/master/test/Data/Vectors/pbkdf2-draft-josefsson-sha256.test-vectors</a></dd>
+ * <dd><a href="https://gitorious.org/scrypt/nettle-scrypt/blobs/37c0d5288e991604fe33dba2f1724986a8dddf56/testsuite/pbkdf2-test.c">https://gitorious.org/scrypt/nettle-scrypt/blobs/37c0d5288e991604fe33dba2f1724986a8dddf56/testsuite/pbkdf2-test.c</a></dd>
+ * </dl>
+ */
+public abstract class TestPBKDF2 {
+  public final PBKDF2 pbkdf2;
+
+  public TestPBKDF2(PBKDF2 pbkdf2) {
+    this.pbkdf2 = pbkdf2;
+  }
+
+  @Test
+  public final void testPBKDF2SHA1A() throws GeneralSecurityException, UnsupportedEncodingException {
+    String  p = "password";
+    String  s = "salt";
+    int dkLen = 20;
+
+    checkPBKDF2SHA1(p, s, 1, dkLen, "0c60c80f961f0e71f3a9b524af6012062fe037a6");
+    checkPBKDF2SHA1(p, s, 2, dkLen, "ea6c014dc72d6f8ccd1ed92ace1d41f0d8de8957");
+    checkPBKDF2SHA1(p, s, 4096, dkLen, "4b007901b765489abead49d926f721d065a429c1");
+  }
+
+  @Test
+  public final void testPBKDF2SHA1B() throws GeneralSecurityException, UnsupportedEncodingException {
+    String  p = "passwordPASSWORDpassword";
+    String  s = "saltSALTsaltSALTsaltSALTsaltSALTsalt";
+    int dkLen = 25;
+
+    checkPBKDF2SHA1(p, s, 4096, dkLen, "3d2eec4fe41c849b80c8d83662c0e44a8b291a964cf2f07038");
+  }
+
+  @Test
+  public final void testPBKDF2SHA256A() throws UnsupportedEncodingException, GeneralSecurityException {
+    String  p = "password";
+    String  s = "salt";
+    int dkLen = 32;
+
+    checkPBKDF2SHA256(p, s, 1, dkLen, "120fb6cffcf8b32c43e7225256c4f837a86548c92ccc35480805987cb70be17b");
+    checkPBKDF2SHA256(p, s, 4096, dkLen, "c5e478d59288c841aa530db6845c4c8d962893a001ce4e11a4963873aa98134a");
+  }
+
+  @Test
+  public final void testPBKDF2SHA256B() throws UnsupportedEncodingException, GeneralSecurityException {
+    String  p = "passwordPASSWORDpassword";
+    String  s = "saltSALTsaltSALTsaltSALTsaltSALTsalt";
+    int dkLen = 40;
+
+    checkPBKDF2SHA256(p, s, 4096, dkLen, "348c89dbcbd32b2f32d814b8116e84cf2b17347ebc1800181c4e2a1fb8dd53e1c635518c7dac47e9");
+  }
+
+  @Test
+  public final void testPBKDF2SHA256scryptA() throws UnsupportedEncodingException, GeneralSecurityException {
+    String  p = "passwd";
+    String  s = "salt";
+    int dkLen = 64;
+
+    checkPBKDF2SHA256(p, s, 1, dkLen, "55ac046e56e3089fec1691c22544b605f94185216dde0465e68b9d57c20dacbc49ca9cccf179b645991664b39d77ef317c71b845b1e30bd509112041d3a19783");
+  }
+
+  @Test
+  public final void testPBKDF2SHA256scryptB() throws UnsupportedEncodingException, GeneralSecurityException {
+    String  p = "Password";
+    String  s = "NaCl";
+    int dkLen = 64;
+
+    checkPBKDF2SHA256(p, s, 80000, dkLen, "4ddcd8f60b98be21830cee5ef22701f9641a4418d04c0414aeff08876b34ab56a1d425a1225833549adb841b51c9b3176a272bdebba1d078478f62b397f33c8d");
+  }
+
+  @Test
+  public final void testPBKDF2SHA256C() throws UnsupportedEncodingException, GeneralSecurityException {
+    String  p = "pass\0word";
+    String  s = "sa\0lt";
+    int dkLen = 16;
+
+    checkPBKDF2SHA256(p, s, 4096, dkLen, "89b69d0516f829893c696226650a8687");
+  }
+
+  /*
+  // This test takes two or three minutes to run, so we don't run it.
+  public final void testPBKDF2SHA256D() throws UnsupportedEncodingException, GeneralSecurityException {
+    String  p = "password";
+    String  s = "salt";
+    int dkLen = 32;
+
+    checkPBKDF2SHA256(p, s, 16777216, dkLen, "cf81c66fe8cfc04d1f31ecb65dab4089f7f179e89b3b0bcb17ad10e3ac6eba46");
+  }
+   */
+
+  @Test
+  public final void testTimePBKDF2SHA256() throws UnsupportedEncodingException, GeneralSecurityException {
+    checkPBKDF2SHA256("password", "salt", 80000, 32, null);
+  }
+
+  private void checkPBKDF2SHA1(String p, String s, int c, int dkLen,
+      final String expectedStr)
+          throws GeneralSecurityException,
+          UnsupportedEncodingException {
+    long start = System.currentTimeMillis();
+    byte[] key = pbkdf2.pbkdf2SHA1(p.getBytes("US-ASCII"), s.getBytes("US-ASCII"), c, dkLen);
+    long end = System.currentTimeMillis();
+    System.err.println("SHA-1 " + c + " took " + (end - start) + "ms");
+    assertExpectedBytes(expectedStr, key);
+  }
+
+  private void checkPBKDF2SHA256(String p, String s, int c, int dkLen,
+      final String expectedStr)
+          throws GeneralSecurityException, UnsupportedEncodingException {
+    long start = System.currentTimeMillis();
+    byte[] key = pbkdf2.pbkdf2SHA256(p.getBytes("US-ASCII"), s.getBytes("US-ASCII"), c, dkLen);
+    assertNotNull(key);
+
+    long end = System.currentTimeMillis();
+
+    System.err.println("SHA-256 " + c + " took " + (end - start) + "ms");
+    if (expectedStr == null) {
+      return;
+    }
+
+    assertEquals(dkLen, Utils.hex2Byte(expectedStr).length);
+    assertExpectedBytes(expectedStr, key);
+  }
+
+  public static void assertExpectedBytes(final String expectedStr, byte[] key) {
+    assertEquals(expectedStr, Utils.byte2hex(key));
+    byte[] expected = Utils.hex2Byte(expectedStr);
+
+    assertEquals(expected.length, key.length);
+    for (int i = 0; i < key.length; i++) {
+      assertEquals(expected[i], key[i]);
+    }
+  }
+}

--- a/src/test/java/org/mozilla/gecko/sync/crypto/test/TestScrypt.java
+++ b/src/test/java/org/mozilla/gecko/sync/crypto/test/TestScrypt.java
@@ -1,0 +1,63 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+package org.mozilla.gecko.sync.crypto.test;
+
+import java.io.UnsupportedEncodingException;
+import java.security.GeneralSecurityException;
+
+import org.junit.Test;
+import org.mozilla.gecko.sync.crypto.Scrypt;
+
+public abstract class TestScrypt {
+  public final Scrypt scrypt;
+
+  public TestScrypt(Scrypt scrypt) {
+    this.scrypt = scrypt;
+  }
+
+  private void checkScrypt(String passwd, String salt, int N, int r, int p, int dkLen, final String expectedStr)
+      throws UnsupportedEncodingException, GeneralSecurityException {
+    byte[] bytes = scrypt.scrypt(passwd.getBytes("ASCII"), salt.getBytes("ASCII"), N, r, p, dkLen);
+    TestPBKDF2.assertExpectedBytes(expectedStr, bytes);
+  }
+
+  @Test
+  public void testA() throws Exception {
+    checkScrypt("", "", 16, 1, 1, 64, "" +
+        "77d6576238657b203b19ca42c18a0497" +
+        "f16b4844e3074ae8dfdffa3fede21442" +
+        "fcd0069ded0948f8326a753a0fc81f17" +
+        "e8d3e0fb2e0d3628cf35e20c38d18906");
+  }
+
+  @Test
+  public void testB() throws Exception {
+    checkScrypt("password", "NaCl", 1024, 8, 16, 64, "" +
+        "fdbabe1c9d3472007856e7190d01e9fe" +
+        "7c6ad7cbc8237830e77376634b373162" +
+        "2eaf30d92e22a3886ff109279d9830da" +
+        "c727afb94a83ee6d8360cbdfa2cc0640");
+  }
+
+  @Test
+  public void testC() throws Exception {
+    checkScrypt("pleaseletmein", "SodiumChloride", 16384, 8, 1, 64, "" +
+        "7023bdcb3afd7348461c06cd81fd38eb" +
+        "fda8fbba904f8e3ea9b543f6545da1f2" +
+        "d5432955613f0fcf62d49705242a9af9" +
+        "e61e85dc0d651e40dfcf017b45575887");
+  }
+
+  /*
+  // This test eats about 1.5 gigs of heap space, so we don't run it.
+  @Test
+  public void testD() throws Exception {
+    checkScrypt("pleaseletmein", "SodiumChloride", 1048576, 8, 1, 64, "" +
+        "2101cb9b6a511aaeaddbbe09cf70f881" +
+        "ec568d574a2ffd4dabe5ee9820adaa47" +
+        "8e56fd8f4ba5d09ffa1c6d927c40f4c3" +
+        "37304049e8a952fbcbf45c6fa77a41a4");
+  }
+   */
+}

--- a/src/test/java/org/mozilla/gecko/sync/crypto/test/TestSpongyCastlePBKDF2.java
+++ b/src/test/java/org/mozilla/gecko/sync/crypto/test/TestSpongyCastlePBKDF2.java
@@ -1,0 +1,10 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+package org.mozilla.gecko.sync.crypto.test;
+
+public class TestSpongyCastlePBKDF2 extends TestPBKDF2 {
+  public TestSpongyCastlePBKDF2() {
+    super(new SpongyCastlePBKDF2());
+  }
+}

--- a/src/test/java/org/mozilla/gecko/sync/crypto/test/TestSpongyCastleScrypt.java
+++ b/src/test/java/org/mozilla/gecko/sync/crypto/test/TestSpongyCastleScrypt.java
@@ -1,0 +1,10 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+package org.mozilla.gecko.sync.crypto.test;
+
+public class TestSpongyCastleScrypt extends TestScrypt {
+  public TestSpongyCastleScrypt() {
+    super(new SpongyCastleScrypt());
+  }
+}


### PR DESCRIPTION
This also adds testing only implementations backed by SpongyCastle.

@rnewman, this is an alternate path toward landing some sort of native crypto that will be performant on actual devices.  This unblocks me so that I can implement against the auth server, while allowing a reasonable upgrade path as we experiment with better implementations.  What say you?
