### PR TITLE
Bug 889749 - ciphersuite.

### DIFF
--- a/bagheera-client-test/example.classpath
+++ b/bagheera-client-test/example.classpath
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry including="**/*.java" kind="src" output="bin/test-classes" path="src/test/java"/>
-	<classpathentry kind="src" path="gen"/>
 
 	<classpathentry combineaccessrules="false" kind="src" path="/android-sync"/>
 	<classpathentry kind="output" path="bin/classes"/>

--- a/src/main/java/org/mozilla/gecko/sync/net/TLSSocketFactory.java
+++ b/src/main/java/org/mozilla/gecko/sync/net/TLSSocketFactory.java
@@ -18,7 +18,9 @@ import ch.boye.httpclientandroidlib.params.HttpParams;
 public class TLSSocketFactory extends SSLSocketFactory {
   private static final String LOG_TAG = "TLSSocketFactory";
   private static final String[] DEFAULT_CIPHER_SUITES = new String[] {
-    "SSL_RSA_WITH_RC4_128_SHA",        // "RC4_SHA"
+    "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
+    "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
+    "SSL_RSA_WITH_RC4_128_SHA", // "RC4_SHA"
   };
   private static final String[] DEFAULT_PROTOCOLS = new String[] {
     "SSLv3",

--- a/src/test/java/org/mozilla/gecko/sync/net/test/TestLiveTLSSocketFactory.java
+++ b/src/test/java/org/mozilla/gecko/sync/net/test/TestLiveTLSSocketFactory.java
@@ -1,0 +1,82 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+package org.mozilla.gecko.sync.net.test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.security.GeneralSecurityException;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mozilla.android.sync.test.integration.IntegrationTestCategory;
+import org.mozilla.gecko.background.testhelpers.WaitHelper;
+import org.mozilla.gecko.sync.net.BaseResource;
+import org.mozilla.gecko.sync.net.BaseResourceDelegate;
+import org.mozilla.gecko.sync.net.SyncResponse;
+
+import ch.boye.httpclientandroidlib.HttpResponse;
+import ch.boye.httpclientandroidlib.client.ClientProtocolException;
+
+/**
+ * Android Services code talks to several different HTTPS endpoints. Some of
+ * these endpoints have different TLS ciphersuites enabled. We test available
+ * ciphersuites by connecting to the Digicert and GeoTrust SSL test servers;
+ * GeoTrust's test server accepts weaker ciphersuites than Digicert's.
+ */
+@Category(IntegrationTestCategory.class)
+public class TestLiveTLSSocketFactory {
+  protected static void testSSLConnection(String uri) throws URISyntaxException {
+    final BaseResource r = new BaseResource(uri);
+    r.delegate = new BaseResourceDelegate(r) {
+      @Override
+      public void handleHttpResponse(HttpResponse response) {
+        try {
+          final SyncResponse res = new SyncResponse(response);
+          Assert.assertEquals(200, res.getStatusCode());
+          WaitHelper.getTestWaiter().performNotify();
+        } catch (Throwable e) {
+          WaitHelper.getTestWaiter().performNotify(e);
+        }
+      }
+
+      @Override
+      public void handleHttpProtocolException(ClientProtocolException e) {
+        WaitHelper.getTestWaiter().performNotify(e);
+      }
+
+      @Override
+      public void handleHttpIOException(IOException e) {
+        WaitHelper.getTestWaiter().performNotify(e);
+      }
+
+      @Override
+      public void handleTransportException(GeneralSecurityException e) {
+        WaitHelper.getTestWaiter().performNotify(e);
+      }
+    };
+
+    WaitHelper.getTestWaiter().performWait(new Runnable() {
+      @Override
+      public void run() {
+        r.getBlocking();
+      }
+    });
+  }
+
+  @Test
+  public void testWeakerCiphersuitesAllowed() throws Exception {
+    testSSLConnection("https://ssltest11.bbtest.net");
+  }
+
+  @Test
+  public void testWeakerCiphersuitesNotAllowed() throws Exception {
+    testSSLConnection("https://global-root.digicert.com");
+  }
+
+  @Test
+  public void testIDPWeakerCiphersuitesNotAllowed() throws Exception {
+    testSSLConnection("https://idp.dev.lcip.org");
+  }
+}


### PR DESCRIPTION
Here's how I'd like to handle this short-term: I want to land this on elm _only_, 'cuz I don't want to pay the testing cost for doing this for Sync just yet.  It's working well for me in practice and will let us move ahead with engineering milestone 0.

The attached (live, sigh) test will fail against develop, but pass with this patch.

@rnewman: r?
