### PR TITLE
Bug 922147 - no password.

### DIFF
--- a/src/main/java/org/mozilla/gecko/background/testhelpers/MockGlobalSession.java
+++ b/src/main/java/org/mozilla/gecko/background/testhelpers/MockGlobalSession.java
@@ -9,7 +9,6 @@ import java.util.HashMap;
 import org.json.simple.parser.ParseException;
 import org.mozilla.gecko.sync.EngineSettings;
 import org.mozilla.gecko.sync.NonObjectJSONException;
-import org.mozilla.gecko.sync.SyncConfiguration;
 import org.mozilla.gecko.sync.SyncConfigurationException;
 import org.mozilla.gecko.sync.crypto.KeyBundle;
 import org.mozilla.gecko.sync.delegates.GlobalSessionCallback;
@@ -23,7 +22,7 @@ public class MockGlobalSession extends MockPrefsGlobalSession {
   public MockGlobalSession(String clusterURL, String username, String password,
       KeyBundle syncKeyBundle, GlobalSessionCallback callback)
           throws SyncConfigurationException, IllegalArgumentException, IOException, ParseException, NonObjectJSONException {
-    super(SyncConfiguration.DEFAULT_USER_API, clusterURL, username, password, null, syncKeyBundle, callback, /* context */ null, null, null);
+    super(clusterURL, username, password, null, syncKeyBundle, callback, /* context */ null, null, null);
   }
 
   @Override

--- a/src/main/java/org/mozilla/gecko/background/testhelpers/MockPrefsGlobalSession.java
+++ b/src/main/java/org/mozilla/gecko/background/testhelpers/MockPrefsGlobalSession.java
@@ -12,6 +12,8 @@ import org.mozilla.gecko.sync.SyncConfigurationException;
 import org.mozilla.gecko.sync.crypto.KeyBundle;
 import org.mozilla.gecko.sync.delegates.ClientsDataDelegate;
 import org.mozilla.gecko.sync.delegates.GlobalSessionCallback;
+import org.mozilla.gecko.sync.net.AuthHeaderProvider;
+import org.mozilla.gecko.sync.net.BasicAuthHeaderProvider;
 
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -30,7 +32,16 @@ public class MockPrefsGlobalSession extends GlobalSession {
       Bundle extras, ClientsDataDelegate clientsDelegate)
       throws SyncConfigurationException, IllegalArgumentException, IOException,
       ParseException, NonObjectJSONException {
-    super(userAPI, serverURL, username, password, prefsPath, syncKeyBundle,
+    this(userAPI, serverURL, username, new BasicAuthHeaderProvider(username, password), prefsPath, syncKeyBundle, callback, context, extras, clientsDelegate);
+  }
+
+  public MockPrefsGlobalSession(String userAPI, String serverURL,
+      String username, AuthHeaderProvider authHeaderProvider, String prefsPath,
+      KeyBundle syncKeyBundle, GlobalSessionCallback callback, Context context,
+      Bundle extras, ClientsDataDelegate clientsDelegate)
+      throws SyncConfigurationException, IllegalArgumentException, IOException,
+      ParseException, NonObjectJSONException {
+    super(userAPI, serverURL, username, authHeaderProvider, prefsPath, syncKeyBundle,
         callback, context, extras, clientsDelegate);
   }
 

--- a/src/main/java/org/mozilla/gecko/background/testhelpers/MockPrefsGlobalSession.java
+++ b/src/main/java/org/mozilla/gecko/background/testhelpers/MockPrefsGlobalSession.java
@@ -26,22 +26,22 @@ public class MockPrefsGlobalSession extends GlobalSession {
 
   public MockSharedPreferences prefs;
 
-  public MockPrefsGlobalSession(String userAPI, String serverURL,
+  public MockPrefsGlobalSession(String serverURL,
       String username, String password, String prefsPath,
       KeyBundle syncKeyBundle, GlobalSessionCallback callback, Context context,
       Bundle extras, ClientsDataDelegate clientsDelegate)
       throws SyncConfigurationException, IllegalArgumentException, IOException,
       ParseException, NonObjectJSONException {
-    this(userAPI, serverURL, username, new BasicAuthHeaderProvider(username, password), prefsPath, syncKeyBundle, callback, context, extras, clientsDelegate);
+    this(serverURL, username, new BasicAuthHeaderProvider(username, password), prefsPath, syncKeyBundle, callback, context, extras, clientsDelegate);
   }
 
-  public MockPrefsGlobalSession(String userAPI, String serverURL,
+  public MockPrefsGlobalSession(String serverURL,
       String username, AuthHeaderProvider authHeaderProvider, String prefsPath,
       KeyBundle syncKeyBundle, GlobalSessionCallback callback, Context context,
       Bundle extras, ClientsDataDelegate clientsDelegate)
       throws SyncConfigurationException, IllegalArgumentException, IOException,
       ParseException, NonObjectJSONException {
-    super(userAPI, serverURL, username, authHeaderProvider, prefsPath, syncKeyBundle,
+    super(serverURL, username, authHeaderProvider, prefsPath, syncKeyBundle,
         callback, context, extras, clientsDelegate);
   }
 

--- a/src/main/java/org/mozilla/gecko/sync/CredentialsSource.java
+++ b/src/main/java/org/mozilla/gecko/sync/CredentialsSource.java
@@ -1,9 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-package org.mozilla.gecko.sync;
-
-public interface CredentialsSource {
-  public abstract String credentials();
-}

--- a/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
+++ b/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
@@ -31,7 +31,6 @@ import org.mozilla.gecko.sync.delegates.MetaGlobalDelegate;
 import org.mozilla.gecko.sync.delegates.WipeServerDelegate;
 import org.mozilla.gecko.sync.net.AuthHeaderProvider;
 import org.mozilla.gecko.sync.net.BaseResource;
-import org.mozilla.gecko.sync.net.BasicAuthHeaderProvider;
 import org.mozilla.gecko.sync.net.HttpResponseObserver;
 import org.mozilla.gecko.sync.net.SyncResponse;
 import org.mozilla.gecko.sync.net.SyncStorageRecordRequest;
@@ -102,7 +101,7 @@ public class GlobalSession implements PrefsSource, HttpResponseObserver {
   public GlobalSession(String userAPI,
                        String serverURL,
                        String username,
-                       String password,
+                       AuthHeaderProvider authHeaderProvider,
                        String prefsPath,
                        KeyBundle syncKeyBundle,
                        GlobalSessionCallback callback,
@@ -135,7 +134,6 @@ public class GlobalSession implements PrefsSource, HttpResponseObserver {
     this.context         = context;
     this.clientsDelegate = clientsDelegate;
 
-    final AuthHeaderProvider authHeaderProvider = new BasicAuthHeaderProvider(username, password);
     config = new SyncConfiguration(username, authHeaderProvider, prefsPath, this);
 
     config.userAPI       = userAPI;

--- a/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
+++ b/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
@@ -828,7 +828,7 @@ public class GlobalSession implements PrefsSource, HttpResponseObserver {
     final GlobalSession self = this;
 
     try {
-      request = new SyncStorageRequest(config.storageURL(false));
+      request = new SyncStorageRequest(config.storageURL());
     } catch (URISyntaxException ex) {
       Logger.warn(LOG_TAG, "Invalid URI in wipeServer.");
       wipeDelegate.onWipeFailed(ex);

--- a/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
+++ b/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
@@ -98,8 +98,7 @@ public class GlobalSession implements PrefsSource, HttpResponseObserver {
     return config.wboURI(collection, id);
   }
 
-  public GlobalSession(String userAPI,
-                       String serverURL,
+  public GlobalSession(String serverURL,
                        String username,
                        AuthHeaderProvider authHeaderProvider,
                        String prefsPath,
@@ -136,7 +135,6 @@ public class GlobalSession implements PrefsSource, HttpResponseObserver {
 
     config = new SyncConfiguration(username, authHeaderProvider, prefsPath, this);
 
-    config.userAPI       = userAPI;
     config.serverURL     = serverURI;
     config.syncKeyBundle = syncKeyBundle;
 

--- a/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
+++ b/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
@@ -98,26 +98,6 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
     return config.wboURI(collection, id);
   }
 
-  /*
-   * Validators.
-   */
-  private static boolean isInvalidString(String s) {
-    return s == null ||
-           s.trim().length() == 0;
-  }
-
-  private static boolean anyInvalidStrings(String s, String...strings) {
-    if (isInvalidString(s)) {
-      return true;
-    }
-    for (String str : strings) {
-      if (isInvalidString(str)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   public GlobalSession(String userAPI,
                        String serverURL,
                        String username,
@@ -129,12 +109,11 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
                        Bundle extras,
                        ClientsDataDelegate clientsDelegate)
                            throws SyncConfigurationException, IllegalArgumentException, IOException, ParseException, NonObjectJSONException {
+    if (username == null) {
+      throw new IllegalArgumentException("username must not be null.");
+    }
     if (callback == null) {
       throw new IllegalArgumentException("Must provide a callback to GlobalSession constructor.");
-    }
-
-    if (anyInvalidStrings(username, password)) {
-      throw new SyncConfigurationException();
     }
 
     Logger.debug(LOG_TAG, "GlobalSession initialized with bundle " + extras);

--- a/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
+++ b/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
@@ -31,6 +31,7 @@ import org.mozilla.gecko.sync.delegates.MetaGlobalDelegate;
 import org.mozilla.gecko.sync.delegates.WipeServerDelegate;
 import org.mozilla.gecko.sync.net.AuthHeaderProvider;
 import org.mozilla.gecko.sync.net.BaseResource;
+import org.mozilla.gecko.sync.net.BasicAuthHeaderProvider;
 import org.mozilla.gecko.sync.net.HttpResponseObserver;
 import org.mozilla.gecko.sync.net.SyncResponse;
 import org.mozilla.gecko.sync.net.SyncStorageRecordRequest;
@@ -134,11 +135,11 @@ public class GlobalSession implements PrefsSource, HttpResponseObserver {
     this.context         = context;
     this.clientsDelegate = clientsDelegate;
 
-    config = new SyncConfiguration(prefsPath, this);
+    final AuthHeaderProvider authHeaderProvider = new BasicAuthHeaderProvider(username, password);
+    config = new SyncConfiguration(username, authHeaderProvider, prefsPath, this);
+
     config.userAPI       = userAPI;
     config.serverURL     = serverURI;
-    config.username      = username;
-    config.password      = password;
     config.syncKeyBundle = syncKeyBundle;
 
     registerCommands();

--- a/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
+++ b/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
@@ -29,6 +29,7 @@ import org.mozilla.gecko.sync.delegates.JSONRecordFetchDelegate;
 import org.mozilla.gecko.sync.delegates.KeyUploadDelegate;
 import org.mozilla.gecko.sync.delegates.MetaGlobalDelegate;
 import org.mozilla.gecko.sync.delegates.WipeServerDelegate;
+import org.mozilla.gecko.sync.net.AuthHeaderProvider;
 import org.mozilla.gecko.sync.net.BaseResource;
 import org.mozilla.gecko.sync.net.HttpResponseObserver;
 import org.mozilla.gecko.sync.net.SyncResponse;
@@ -58,7 +59,7 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 import ch.boye.httpclientandroidlib.HttpResponse;
 
-public class GlobalSession implements CredentialsSource, PrefsSource, HttpResponseObserver {
+public class GlobalSession implements PrefsSource, HttpResponseObserver {
   private static final String LOG_TAG = "GlobalSession";
 
   public static final String API_VERSION   = "1.1";
@@ -89,9 +90,8 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
   /*
    * Config passthrough for convenience.
    */
-  @Override
-  public String credentials() {
-    return config.credentials();
+  public AuthHeaderProvider getAuthHeaderProvider() {
+    return config.getAuthHeaderProvider();
   }
 
   public URI wboURI(String collection, String id) throws URISyntaxException {
@@ -548,7 +548,7 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
   }
 
   public void fetchInfoCollections(JSONRecordFetchDelegate callback) throws URISyntaxException {
-    final JSONRecordFetcher fetcher = new JSONRecordFetcher(config.infoCollectionsURL(), credentials());
+    final JSONRecordFetcher fetcher = new JSONRecordFetcher(config.infoCollectionsURL(), getAuthHeaderProvider());
     fetcher.fetch(callback);
   }
 
@@ -563,7 +563,6 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
   public void uploadKeys(final CollectionKeys keys,
                          final KeyUploadDelegate keyUploadDelegate) {
     SyncStorageRecordRequest request;
-    final GlobalSession self = this;
     try {
       request = new SyncStorageRecordRequest(this.config.keysURI());
     } catch (URISyntaxException e) {
@@ -588,7 +587,7 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
       @Override
       public void handleRequestFailure(SyncStorageResponse response) {
         Logger.debug(LOG_TAG, "Failed to upload keys.");
-        self.interpretHTTPFailure(response.httpResponse());
+        GlobalSession.this.interpretHTTPFailure(response.httpResponse());
         BaseResource.consumeEntity(response); // The exception thrown should not need the body of the response.
         keyUploadDelegate.onKeyUploadFailed(new HTTPFailureException(response));
       }
@@ -600,8 +599,8 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
       }
 
       @Override
-      public String credentials() {
-        return self.credentials();
+      public AuthHeaderProvider getAuthHeaderProvider() {
+        return GlobalSession.this.getAuthHeaderProvider();
       }
     };
 
@@ -727,7 +726,7 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
 
     final MetaGlobal mg = session.generateNewMetaGlobal();
 
-    session.wipeServer(session, new WipeServerDelegate() {
+    session.wipeServer(session.getAuthHeaderProvider(), new WipeServerDelegate() {
 
       @Override
       public void onWiped(long timestamp) {
@@ -827,7 +826,7 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
   // reset client to prompt reupload.
   // If sync ID mismatch: take that syncID and reset client.
 
-  protected void wipeServer(final CredentialsSource credentials, final WipeServerDelegate wipeDelegate) {
+  protected void wipeServer(final AuthHeaderProvider authHeaderProvider, final WipeServerDelegate wipeDelegate) {
     SyncStorageRequest request;
     final GlobalSession self = this;
 
@@ -868,8 +867,8 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
       }
 
       @Override
-      public String credentials() {
-        return credentials.credentials();
+      public AuthHeaderProvider getAuthHeaderProvider() {
+        return GlobalSession.this.getAuthHeaderProvider();
       }
     };
     request.delete();
@@ -961,7 +960,6 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
   public MetaGlobal generateNewMetaGlobal() {
     final String newSyncID   = Utils.generateGuid();
     final String metaURL     = this.config.metaURL();
-    final String credentials = this.credentials();
 
     ExtendedJSONObject engines = new ExtendedJSONObject();
     for (String engineName : enabledEngineNames()) {
@@ -981,7 +979,7 @@ public class GlobalSession implements CredentialsSource, PrefsSource, HttpRespon
       engines.put(engineName, engineSettings.toJSONObject());
     }
 
-    MetaGlobal metaGlobal = new MetaGlobal(metaURL, credentials);
+    MetaGlobal metaGlobal = new MetaGlobal(metaURL, this.getAuthHeaderProvider());
     metaGlobal.setSyncID(newSyncID);
     metaGlobal.setStorageVersion(STORAGE_VERSION);
     metaGlobal.setEngines(engines);

--- a/src/main/java/org/mozilla/gecko/sync/JSONRecordFetcher.java
+++ b/src/main/java/org/mozilla/gecko/sync/JSONRecordFetcher.java
@@ -9,6 +9,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.mozilla.gecko.background.common.log.Logger;
 import org.mozilla.gecko.sync.delegates.JSONRecordFetchDelegate;
+import org.mozilla.gecko.sync.net.AuthHeaderProvider;
 import org.mozilla.gecko.sync.net.SyncStorageRecordRequest;
 import org.mozilla.gecko.sync.net.SyncStorageRequestDelegate;
 import org.mozilla.gecko.sync.net.SyncStorageResponse;
@@ -21,13 +22,13 @@ public class JSONRecordFetcher {
   private static final long DEFAULT_AWAIT_TIMEOUT_MSEC = 2 * 60 * 1000;   // Two minutes.
   private static final String LOG_TAG = "JSONRecordFetcher";
 
-  protected final String credentials;
+  protected final AuthHeaderProvider authHeaderProvider;
   protected final String uri;
   protected JSONRecordFetchDelegate delegate;
 
-  public JSONRecordFetcher(final String uri, final String credentials) {
+  public JSONRecordFetcher(final String uri, final AuthHeaderProvider authHeaderProvider) {
     this.uri = uri;
-    this.credentials = credentials;
+    this.authHeaderProvider = authHeaderProvider;
   }
 
   protected String getURI() {
@@ -37,8 +38,9 @@ public class JSONRecordFetcher {
   private class JSONFetchHandler implements SyncStorageRequestDelegate {
 
     // SyncStorageRequestDelegate methods for fetching.
-    public String credentials() {
-      return credentials;
+    @Override
+    public AuthHeaderProvider getAuthHeaderProvider() {
+      return authHeaderProvider;
     }
 
     public String ifUnmodifiedSince() {

--- a/src/main/java/org/mozilla/gecko/sync/MetaGlobal.java
+++ b/src/main/java/org/mozilla/gecko/sync/MetaGlobal.java
@@ -16,6 +16,7 @@ import org.mozilla.gecko.background.common.log.Logger;
 import org.mozilla.gecko.sync.MetaGlobalException.MetaGlobalMalformedSyncIDException;
 import org.mozilla.gecko.sync.MetaGlobalException.MetaGlobalMalformedVersionException;
 import org.mozilla.gecko.sync.delegates.MetaGlobalDelegate;
+import org.mozilla.gecko.sync.net.AuthHeaderProvider;
 import org.mozilla.gecko.sync.net.SyncStorageRecordRequest;
 import org.mozilla.gecko.sync.net.SyncStorageRequestDelegate;
 import org.mozilla.gecko.sync.net.SyncStorageResponse;
@@ -23,7 +24,6 @@ import org.mozilla.gecko.sync.net.SyncStorageResponse;
 public class MetaGlobal implements SyncStorageRequestDelegate {
   private static final String LOG_TAG = "MetaGlobal";
   protected String metaURL;
-  protected String credentials;
 
   // Fields.
   protected ExtendedJSONObject  engines;
@@ -40,10 +40,11 @@ public class MetaGlobal implements SyncStorageRequestDelegate {
 
   // A little hack so we can use the same delegate implementation for upload and download.
   private boolean isUploading;
+  protected final AuthHeaderProvider authHeaderProvider;
 
-  public MetaGlobal(String metaURL, String credentials) {
-    this.metaURL     = metaURL;
-    this.credentials = credentials;
+  public MetaGlobal(String metaURL, AuthHeaderProvider authHeaderProvider) {
+    this.metaURL = metaURL;
+    this.authHeaderProvider = authHeaderProvider;
   }
 
   public void fetch(MetaGlobalDelegate delegate) {
@@ -247,7 +248,12 @@ public class MetaGlobal implements SyncStorageRequestDelegate {
 
   // SyncStorageRequestDelegate methods for fetching.
   public String credentials() {
-    return this.credentials;
+    return null;
+  }
+
+  @Override
+  public AuthHeaderProvider getAuthHeaderProvider() {
+    return authHeaderProvider;
   }
 
   public String ifUnmodifiedSince() {

--- a/src/main/java/org/mozilla/gecko/sync/PersistedMetaGlobal.java
+++ b/src/main/java/org/mozilla/gecko/sync/PersistedMetaGlobal.java
@@ -5,7 +5,7 @@
 package org.mozilla.gecko.sync;
 
 import org.mozilla.gecko.background.common.log.Logger;
-import org.mozilla.gecko.sync.CryptoRecord;
+import org.mozilla.gecko.sync.net.AuthHeaderProvider;
 
 import android.content.SharedPreferences;
 
@@ -32,7 +32,7 @@ public class PersistedMetaGlobal {
    * @return <MetaGlobal> set from previously fetched meta/global record from
    *         server
    */
-  public MetaGlobal metaGlobal(String metaUrl, String credentials) {
+  public MetaGlobal metaGlobal(String metaUrl, AuthHeaderProvider authHeaderProvider) {
     String json = prefs.getString(META_GLOBAL_SERVER_RESPONSE_BODY, null);
     if (json == null) {
       return null;
@@ -40,7 +40,7 @@ public class PersistedMetaGlobal {
     MetaGlobal metaGlobal = null;
     try {
       CryptoRecord cryptoRecord = CryptoRecord.fromJSONRecord(json);
-      MetaGlobal mg = new MetaGlobal(metaUrl, credentials);
+      MetaGlobal mg = new MetaGlobal(metaUrl, authHeaderProvider);
       mg.setFromRecord(cryptoRecord);
       metaGlobal = mg;
     } catch (Exception e) {

--- a/src/main/java/org/mozilla/gecko/sync/SyncConfiguration.java
+++ b/src/main/java/org/mozilla/gecko/sync/SyncConfiguration.java
@@ -17,7 +17,6 @@ import org.mozilla.gecko.background.common.log.Logger;
 import org.mozilla.gecko.sync.crypto.KeyBundle;
 import org.mozilla.gecko.sync.crypto.PersistedCrypto5Keys;
 import org.mozilla.gecko.sync.net.AuthHeaderProvider;
-import org.mozilla.gecko.sync.net.BasicAuthHeaderProvider;
 import org.mozilla.gecko.sync.stage.GlobalSyncStage.Stage;
 
 import android.content.SharedPreferences;
@@ -184,14 +183,14 @@ public class SyncConfiguration {
   public String          userAPI;
   public URI             serverURL;
   public URI             clusterURL;
-  public String          username;
   public KeyBundle       syncKeyBundle;
 
   public CollectionKeys  collectionKeys;
   public InfoCollections infoCollections;
   public MetaGlobal      metaGlobal;
-  public String          password;
   public String          syncID;
+
+  protected final String username;
 
   /**
    * Persisted collection of enabledEngineNames.
@@ -245,6 +244,8 @@ public class SyncConfiguration {
   public String          prefsPath;
   public PrefsSource     prefsSource;
 
+  protected final AuthHeaderProvider authHeaderProvider;
+
   public static final String PREF_PREFS_VERSION = "prefs.version";
   public static final long CURRENT_PREFS_VERSION = 1;
 
@@ -269,7 +270,9 @@ public class SyncConfiguration {
    * Create a new SyncConfiguration instance. Pass in a PrefsSource to
    * provide access to preferences.
    */
-  public SyncConfiguration(String prefsPath, PrefsSource prefsSource) {
+  public SyncConfiguration(String username, AuthHeaderProvider authHeaderProvider, String prefsPath, PrefsSource prefsSource) {
+    this.username = username;
+    this.authHeaderProvider = authHeaderProvider;
     this.prefsPath   = prefsPath;
     this.prefsSource = prefsSource;
     this.loadFromPrefs(getPrefs());
@@ -440,7 +443,7 @@ public class SyncConfiguration {
   }
 
   public AuthHeaderProvider getAuthHeaderProvider() {
-    return new BasicAuthHeaderProvider(username, password);
+    return authHeaderProvider;
   }
 
   public CollectionKeys getCollectionKeys() {

--- a/src/main/java/org/mozilla/gecko/sync/SyncConfiguration.java
+++ b/src/main/java/org/mozilla/gecko/sync/SyncConfiguration.java
@@ -481,16 +481,20 @@ public class SyncConfiguration {
   }
 
   public String metaURL() {
-    return clusterURL + GlobalSession.API_VERSION + "/" + username + "/storage/meta/global";
+    return storageURL() + "/meta/global";
   }
 
-  public String storageURL(boolean trailingSlash) {
-    return clusterURL + GlobalSession.API_VERSION + "/" + username +
-           (trailingSlash ? "/storage/" : "/storage");
+  /**
+   * Return path to storage endpoint without trailing slash.
+   *
+   * @return storage endpoint without trailing slash.
+   */
+  public String storageURL() {
+    return clusterURL + GlobalSession.API_VERSION + "/" + username + "/storage";
   }
 
   public URI collectionURI(String collection) throws URISyntaxException {
-    return new URI(storageURL(true) + collection);
+    return new URI(storageURL() + "/" + collection);
   }
 
   public URI collectionURI(String collection, boolean full) throws URISyntaxException {
@@ -505,12 +509,12 @@ public class SyncConfiguration {
       }
       uriParams = params.toString();
     }
-    String uri = storageURL(true) + collection + uriParams;
+    String uri = storageURL() + "/" + collection + uriParams;
     return new URI(uri);
   }
 
   public URI wboURI(String collection, String id) throws URISyntaxException {
-    return new URI(storageURL(true) + collection + "/" + id);
+    return new URI(storageURL() + "/" + collection + "/" + id);
   }
 
   public URI keysURI() throws URISyntaxException {
@@ -604,12 +608,5 @@ public class SyncConfiguration {
 
   public PersistedMetaGlobal persistedMetaGlobal() {
     return new PersistedMetaGlobal(getPrefs());
-  }
-
-  // XXX
-  public static final String VERSION_PATH_FRAGMENT = "1.1/";
-
-  public String getCollectionURLString(String collection) {
-    return getClusterURLString() + VERSION_PATH_FRAGMENT + this.username + "/storage/" + collection;
   }
 }

--- a/src/main/java/org/mozilla/gecko/sync/SyncConfiguration.java
+++ b/src/main/java/org/mozilla/gecko/sync/SyncConfiguration.java
@@ -180,7 +180,6 @@ public class SyncConfiguration {
   private static final String LOG_TAG = "SyncConfiguration";
 
   // These must be set in GlobalSession's constructor.
-  public String          userAPI;
   public URI             serverURL;
   public URI             clusterURL;
   public KeyBundle       syncKeyBundle;

--- a/src/main/java/org/mozilla/gecko/sync/SyncConfiguration.java
+++ b/src/main/java/org/mozilla/gecko/sync/SyncConfiguration.java
@@ -16,12 +16,14 @@ import java.util.Set;
 import org.mozilla.gecko.background.common.log.Logger;
 import org.mozilla.gecko.sync.crypto.KeyBundle;
 import org.mozilla.gecko.sync.crypto.PersistedCrypto5Keys;
+import org.mozilla.gecko.sync.net.AuthHeaderProvider;
+import org.mozilla.gecko.sync.net.BasicAuthHeaderProvider;
 import org.mozilla.gecko.sync.stage.GlobalSyncStage.Stage;
 
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 
-public class SyncConfiguration implements CredentialsSource {
+public class SyncConfiguration {
 
   public class EditorBranch implements Editor {
 
@@ -437,9 +439,8 @@ public class SyncConfiguration implements CredentialsSource {
     // TODO: keys.
   }
 
-  @Override
-  public String credentials() {
-    return username + ":" + password;
+  public AuthHeaderProvider getAuthHeaderProvider() {
+    return new BasicAuthHeaderProvider(username, password);
   }
 
   public CollectionKeys getCollectionKeys() {
@@ -601,5 +602,12 @@ public class SyncConfiguration implements CredentialsSource {
 
   public PersistedMetaGlobal persistedMetaGlobal() {
     return new PersistedMetaGlobal(getPrefs());
+  }
+
+  // XXX
+  public static final String VERSION_PATH_FRAGMENT = "1.1/";
+
+  public String getCollectionURLString(String collection) {
+    return getClusterURLString() + VERSION_PATH_FRAGMENT + this.username + "/storage/" + collection;
   }
 }

--- a/src/main/java/org/mozilla/gecko/sync/config/ClientRecordTerminator.java
+++ b/src/main/java/org/mozilla/gecko/sync/config/ClientRecordTerminator.java
@@ -8,6 +8,7 @@ import java.net.URI;
 
 import org.mozilla.gecko.background.common.log.Logger;
 import org.mozilla.gecko.sync.GlobalSession;
+import org.mozilla.gecko.sync.net.AuthHeaderProvider;
 import org.mozilla.gecko.sync.net.BaseResource;
 import org.mozilla.gecko.sync.net.SyncStorageRecordRequest;
 import org.mozilla.gecko.sync.net.SyncStorageRequestDelegate;
@@ -27,9 +28,9 @@ public class ClientRecordTerminator {
   }
 
   public static void deleteClientRecord(final String username,
-      final String password,
       final String clusterURL,
-      final String clientGuid)
+      final String clientGuid,
+      final AuthHeaderProvider authHeaderProvider)
     throws Exception {
 
     // Would prefer to delegate to SyncConfiguration, but that would proliferate static methods.
@@ -40,8 +41,8 @@ public class ClientRecordTerminator {
     final SyncStorageRecordRequest r = new SyncStorageRecordRequest(wboURI);
     r.delegate = new SyncStorageRequestDelegate() {
       @Override
-      public String credentials() {
-        return username + ":" + password;
+      public AuthHeaderProvider getAuthHeaderProvider() {
+        return authHeaderProvider;
       }
 
       @Override

--- a/src/main/java/org/mozilla/gecko/sync/net/SyncStorageRequest.java
+++ b/src/main/java/org/mozilla/gecko/sync/net/SyncStorageRequest.java
@@ -92,12 +92,7 @@ public class SyncStorageRequest implements Resource {
 
     @Override
     public AuthHeaderProvider getAuthHeaderProvider() {
-      String credentials = request.delegate.credentials();
-      if (credentials == null) {
-        return null;
-      }
-
-      return new BasicAuthHeaderProvider(credentials);
+      return request.delegate.getAuthHeaderProvider();
     }
 
     @Override

--- a/src/main/java/org/mozilla/gecko/sync/net/SyncStorageRequestDelegate.java
+++ b/src/main/java/org/mozilla/gecko/sync/net/SyncStorageRequestDelegate.java
@@ -5,7 +5,8 @@
 package org.mozilla.gecko.sync.net;
 
 public interface SyncStorageRequestDelegate {
-  String credentials();
+  public AuthHeaderProvider getAuthHeaderProvider();
+
   String ifUnmodifiedSince();
 
   // TODO: at this point we can access X-Weave-Timestamp, compare

--- a/src/main/java/org/mozilla/gecko/sync/receivers/SyncAccountDeletedService.java
+++ b/src/main/java/org/mozilla/gecko/sync/receivers/SyncAccountDeletedService.java
@@ -12,6 +12,7 @@ import org.mozilla.gecko.sync.SyncConfiguration;
 import org.mozilla.gecko.sync.Utils;
 import org.mozilla.gecko.sync.config.AccountPickler;
 import org.mozilla.gecko.sync.config.ClientRecordTerminator;
+import org.mozilla.gecko.sync.net.BasicAuthHeaderProvider;
 import org.mozilla.gecko.sync.setup.Constants;
 import org.mozilla.gecko.sync.setup.SyncAccounts.SyncAccountParameters;
 
@@ -129,7 +130,7 @@ public class SyncAccountDeletedService extends IntentService {
     }
 
     try {
-      ClientRecordTerminator.deleteClientRecord(encodedUsername, password, clusterURL, clientGuid);
+      ClientRecordTerminator.deleteClientRecord(encodedUsername, clusterURL, clientGuid, new BasicAuthHeaderProvider(encodedUsername, password));
     } catch (Exception e) {
       // This should never happen, but we really don't want to die in a background thread.
       Logger.warn(LOG_TAG, "Got exception deleting client record from server; ignoring.", e);

--- a/src/main/java/org/mozilla/gecko/sync/repositories/ConstrainedServer11Repository.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/ConstrainedServer11Repository.java
@@ -19,8 +19,8 @@ public class ConstrainedServer11Repository extends Server11Repository {
   private String sort = null;
   private long limit  = -1;
 
-  public ConstrainedServer11Repository(String collection, String collectionPath, AuthHeaderProvider authHeaderProvider, long limit, String sort) throws URISyntaxException {
-    super(collection, collectionPath, authHeaderProvider);
+  public ConstrainedServer11Repository(String collection, String storageURL, AuthHeaderProvider authHeaderProvider, long limit, String sort) throws URISyntaxException {
+    super(collection, storageURL, authHeaderProvider);
     this.limit = limit;
     this.sort  = sort;
   }

--- a/src/main/java/org/mozilla/gecko/sync/repositories/ConstrainedServer11Repository.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/ConstrainedServer11Repository.java
@@ -6,7 +6,7 @@ package org.mozilla.gecko.sync.repositories;
 
 import java.net.URISyntaxException;
 
-import org.mozilla.gecko.sync.CredentialsSource;
+import org.mozilla.gecko.sync.net.AuthHeaderProvider;
 
 /**
  * A kind of Server11Repository that supports explicit setting of limit and sort on operations.
@@ -19,9 +19,8 @@ public class ConstrainedServer11Repository extends Server11Repository {
   private String sort = null;
   private long limit  = -1;
 
-  public ConstrainedServer11Repository(String serverURI, String username, String collection, CredentialsSource credentialsSource, long limit, String sort) throws URISyntaxException {
-    super(serverURI, username, collection, credentialsSource);
-
+  public ConstrainedServer11Repository(String collection, String collectionPath, AuthHeaderProvider authHeaderProvider, long limit, String sort) throws URISyntaxException {
+    super(collection, collectionPath, authHeaderProvider);
     this.limit = limit;
     this.sort  = sort;
   }

--- a/src/main/java/org/mozilla/gecko/sync/repositories/Server11Repository.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/Server11Repository.java
@@ -27,18 +27,16 @@ public class Server11Repository extends Repository {
   public static final String VERSION_PATH_FRAGMENT = "1.1/";
 
   /**
+   * Construct a new repository that fetches and stores against the Sync 1.1. API.
    *
-   * @param serverURI
-   *        URI of the Sync 1.1 server (string)
-   * @param username
-   *        Username on the server (string)
-   * @param collection
-   *        Name of the collection (string)
+   * @param collection name.
+   * @param storageURL full URL to storage endpoint.
+   * @param authHeaderProvider to use in requests.
    * @throws URISyntaxException
    */
-  public Server11Repository(String collection, String collectionPath, AuthHeaderProvider authHeaderProvider) throws URISyntaxException {
+  public Server11Repository(String collection, String storageURL, AuthHeaderProvider authHeaderProvider) throws URISyntaxException {
     this.collection = collection;
-    this.collectionURI = new URI(collectionPath);
+    this.collectionURI = new URI(storageURL + (storageURL.endsWith("/") ? collection : "/" + collection));
     this.authHeaderProvider = authHeaderProvider;
   }
 

--- a/src/main/java/org/mozilla/gecko/sync/repositories/Server11Repository.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/Server11Repository.java
@@ -8,8 +8,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 
-import org.mozilla.gecko.sync.CredentialsSource;
 import org.mozilla.gecko.sync.Utils;
+import org.mozilla.gecko.sync.net.AuthHeaderProvider;
 import org.mozilla.gecko.sync.repositories.delegates.RepositorySessionCreationDelegate;
 
 import android.content.Context;
@@ -21,13 +21,9 @@ import android.content.Context;
  * @author rnewman
  */
 public class Server11Repository extends Repository {
-
-  private String serverURI;
-  private String username;
   protected String collection;
-  private String collectionPath;
-  private URI collectionPathURI;
-  public CredentialsSource credentialsSource;
+  protected URI collectionURI;
+  protected final AuthHeaderProvider authHeaderProvider;
   public static final String VERSION_PATH_FRAGMENT = "1.1/";
 
   /**
@@ -40,14 +36,10 @@ public class Server11Repository extends Repository {
    *        Name of the collection (string)
    * @throws URISyntaxException
    */
-  public Server11Repository(String serverURI, String username, String collection, CredentialsSource credentialsSource) throws URISyntaxException {
-    this.serverURI  = serverURI;
-    this.username   = username;
+  public Server11Repository(String collection, String collectionPath, AuthHeaderProvider authHeaderProvider) throws URISyntaxException {
     this.collection = collection;
-
-    this.collectionPath = this.serverURI + VERSION_PATH_FRAGMENT + this.username + "/storage/" + this.collection;
-    this.collectionPathURI = new URI(this.collectionPath);
-    this.credentialsSource = credentialsSource;
+    this.collectionURI = new URI(collectionPath);
+    this.authHeaderProvider = authHeaderProvider;
   }
 
   @Override
@@ -57,7 +49,7 @@ public class Server11Repository extends Repository {
   }
 
   public URI collectionURI() {
-    return this.collectionPathURI;
+    return this.collectionURI;
   }
 
   public URI collectionURI(boolean full, long newer, long limit, String sort, String ids) throws URISyntaxException {
@@ -81,7 +73,7 @@ public class Server11Repository extends Repository {
     }
 
     if (params.size() == 0) {
-      return this.collectionPathURI;
+      return this.collectionURI;
     }
 
     StringBuilder out = new StringBuilder();
@@ -91,12 +83,12 @@ public class Server11Repository extends Repository {
       indicator = '&';
       out.append(param);
     }
-    String uri = this.collectionPath + out.toString();
+    String uri = this.collectionURI + out.toString();
     return new URI(uri);
   }
 
   public URI wboURI(String id) throws URISyntaxException {
-    return new URI(this.collectionPath + "/" + id);
+    return new URI(this.collectionURI + "/" + id);
   }
 
   // Override these.
@@ -108,5 +100,9 @@ public class Server11Repository extends Repository {
   @SuppressWarnings("static-method")
   protected String getDefaultSort() {
     return null;
+  }
+
+  public AuthHeaderProvider getAuthHeaderProvider() {
+    return authHeaderProvider;
   }
 }

--- a/src/main/java/org/mozilla/gecko/sync/repositories/Server11RepositorySession.java
+++ b/src/main/java/org/mozilla/gecko/sync/repositories/Server11RepositorySession.java
@@ -25,6 +25,7 @@ import org.mozilla.gecko.sync.Server11PreviousPostFailedException;
 import org.mozilla.gecko.sync.Server11RecordPostFailedException;
 import org.mozilla.gecko.sync.UnexpectedJSONException;
 import org.mozilla.gecko.sync.crypto.KeyBundle;
+import org.mozilla.gecko.sync.net.AuthHeaderProvider;
 import org.mozilla.gecko.sync.net.SyncStorageCollectionRequest;
 import org.mozilla.gecko.sync.net.SyncStorageRequest;
 import org.mozilla.gecko.sync.net.SyncStorageRequestDelegate;
@@ -135,8 +136,8 @@ public class Server11RepositorySession extends RepositorySession {
     }
 
     @Override
-    public String credentials() {
-      return serverRepository.credentialsSource.credentials();
+    public AuthHeaderProvider getAuthHeaderProvider() {
+      return serverRepository.getAuthHeaderProvider();
     }
 
     @Override
@@ -442,8 +443,8 @@ public class Server11RepositorySession extends RepositorySession {
     }
 
     @Override
-    public String credentials() {
-      return serverRepository.credentialsSource.credentials();
+    public AuthHeaderProvider getAuthHeaderProvider() {
+      return serverRepository.getAuthHeaderProvider();
     }
 
     @Override

--- a/src/main/java/org/mozilla/gecko/sync/stage/AndroidBrowserBookmarksServerSyncStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/AndroidBrowserBookmarksServerSyncStage.java
@@ -8,6 +8,7 @@ import java.net.URISyntaxException;
 
 import org.mozilla.gecko.sync.JSONRecordFetcher;
 import org.mozilla.gecko.sync.MetaGlobalException;
+import org.mozilla.gecko.sync.net.AuthHeaderProvider;
 import org.mozilla.gecko.sync.repositories.RecordFactory;
 import org.mozilla.gecko.sync.repositories.Repository;
 import org.mozilla.gecko.sync.repositories.android.AndroidBrowserBookmarksRepository;
@@ -41,11 +42,13 @@ public class AndroidBrowserBookmarksServerSyncStage extends ServerSyncStage {
   protected Repository getRemoteRepository() throws URISyntaxException {
     // If this is a first sync, we need to check server counts to make sure that we aren't
     // going to screw up. SafeConstrainedServer11Repository does this. See Bug 814331.
-    final JSONRecordFetcher countsFetcher = new JSONRecordFetcher(session.config.infoCollectionCountsURL(), session.credentials());
-    return new SafeConstrainedServer11Repository(session.config.getClusterURLString(),
-                                                 session.config.username,
-                                                 getCollection(),
-                                                 session,
+    AuthHeaderProvider authHeaderProvider = session.getAuthHeaderProvider();
+    final JSONRecordFetcher countsFetcher = new JSONRecordFetcher(session.config.infoCollectionCountsURL(), authHeaderProvider);
+    String collection = getCollection();
+    return new SafeConstrainedServer11Repository(
+                                                 collection,
+                                                 session.config.getCollectionURLString(collection),
+                                                 session.getAuthHeaderProvider(),
                                                  BOOKMARKS_REQUEST_LIMIT,
                                                  BOOKMARKS_SORT,
                                                  countsFetcher);

--- a/src/main/java/org/mozilla/gecko/sync/stage/AndroidBrowserBookmarksServerSyncStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/AndroidBrowserBookmarksServerSyncStage.java
@@ -47,7 +47,7 @@ public class AndroidBrowserBookmarksServerSyncStage extends ServerSyncStage {
     String collection = getCollection();
     return new SafeConstrainedServer11Repository(
                                                  collection,
-                                                 session.config.getCollectionURLString(collection),
+                                                 session.config.storageURL(),
                                                  session.getAuthHeaderProvider(),
                                                  BOOKMARKS_REQUEST_LIMIT,
                                                  BOOKMARKS_SORT,

--- a/src/main/java/org/mozilla/gecko/sync/stage/AndroidBrowserHistoryServerSyncStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/AndroidBrowserHistoryServerSyncStage.java
@@ -44,10 +44,11 @@ public class AndroidBrowserHistoryServerSyncStage extends ServerSyncStage {
 
   @Override
   protected Repository getRemoteRepository() throws URISyntaxException {
-    return new ConstrainedServer11Repository(session.config.getClusterURLString(),
-                                             session.config.username,
-                                             getCollection(),
-                                             session,
+    String collection = getCollection();
+    return new ConstrainedServer11Repository(
+                                             collection,
+                                             session.config.getCollectionURLString(collection),
+                                             session.getAuthHeaderProvider(),
                                              HISTORY_REQUEST_LIMIT,
                                              HISTORY_SORT);
   }

--- a/src/main/java/org/mozilla/gecko/sync/stage/AndroidBrowserHistoryServerSyncStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/AndroidBrowserHistoryServerSyncStage.java
@@ -47,7 +47,7 @@ public class AndroidBrowserHistoryServerSyncStage extends ServerSyncStage {
     String collection = getCollection();
     return new ConstrainedServer11Repository(
                                              collection,
-                                             session.config.getCollectionURLString(collection),
+                                             session.config.storageURL(),
                                              session.getAuthHeaderProvider(),
                                              HISTORY_REQUEST_LIMIT,
                                              HISTORY_SORT);

--- a/src/main/java/org/mozilla/gecko/sync/stage/EnsureCrypto5KeysStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/EnsureCrypto5KeysStage.java
@@ -16,6 +16,7 @@ import org.mozilla.gecko.sync.InfoCollections;
 import org.mozilla.gecko.sync.NoCollectionKeysSetException;
 import org.mozilla.gecko.sync.crypto.KeyBundle;
 import org.mozilla.gecko.sync.crypto.PersistedCrypto5Keys;
+import org.mozilla.gecko.sync.net.AuthHeaderProvider;
 import org.mozilla.gecko.sync.net.SyncStorageRecordRequest;
 import org.mozilla.gecko.sync.net.SyncStorageRequestDelegate;
 import org.mozilla.gecko.sync.net.SyncStorageResponse;
@@ -63,8 +64,8 @@ implements SyncStorageRequestDelegate {
   }
 
   @Override
-  public String credentials() {
-    return session.credentials();
+  public AuthHeaderProvider getAuthHeaderProvider() {
+    return session.getAuthHeaderProvider();
   }
 
   @Override

--- a/src/main/java/org/mozilla/gecko/sync/stage/FetchMetaGlobalStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/FetchMetaGlobalStage.java
@@ -62,7 +62,7 @@ public class FetchMetaGlobalStage extends AbstractNonRepositorySyncStage {
     if (!infoCollections.updateNeeded(META_COLLECTION, lastModified)) {
       // Try to use our local collection keys for this session.
       Logger.info(LOG_TAG, "Trying to use persisted meta/global for this session.");
-      MetaGlobal global = session.config.persistedMetaGlobal().metaGlobal(session.config.metaURL(), session.credentials());
+      MetaGlobal global = session.config.persistedMetaGlobal().metaGlobal(session.config.metaURL(), session.getAuthHeaderProvider());
       if (global != null) {
         Logger.info(LOG_TAG, "Using persisted meta/global for this session.");
         session.processMetaGlobal(global); // Calls session.advance().
@@ -73,7 +73,7 @@ public class FetchMetaGlobalStage extends AbstractNonRepositorySyncStage {
 
     // We need an update: fetch or upload meta/global as necessary.
     Logger.info(LOG_TAG, "Fetching fresh meta/global for this session.");
-    MetaGlobal global = new MetaGlobal(session.config.metaURL(), session.credentials());
+    MetaGlobal global = new MetaGlobal(session.config.metaURL(), session.getAuthHeaderProvider());
     global.fetch(new StageMetaGlobalDelegate(session));
   }
 }

--- a/src/main/java/org/mozilla/gecko/sync/stage/FormHistoryServerSyncStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/FormHistoryServerSyncStage.java
@@ -42,7 +42,7 @@ public class FormHistoryServerSyncStage extends ServerSyncStage {
     String collection = getCollection();
     return new ConstrainedServer11Repository(
                                              collection,
-                                             session.config.getCollectionURLString(collection),
+                                             session.config.storageURL(),
                                              session.getAuthHeaderProvider(),
                                              FORM_HISTORY_REQUEST_LIMIT,
                                              FORM_HISTORY_SORT);

--- a/src/main/java/org/mozilla/gecko/sync/stage/FormHistoryServerSyncStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/FormHistoryServerSyncStage.java
@@ -39,10 +39,11 @@ public class FormHistoryServerSyncStage extends ServerSyncStage {
 
   @Override
   protected Repository getRemoteRepository() throws URISyntaxException {
-    return new ConstrainedServer11Repository(session.config.getClusterURLString(),
-                                             session.config.username,
-                                             getCollection(),
-                                             session,
+    String collection = getCollection();
+    return new ConstrainedServer11Repository(
+                                             collection,
+                                             session.config.getCollectionURLString(collection),
+                                             session.getAuthHeaderProvider(),
                                              FORM_HISTORY_REQUEST_LIMIT,
                                              FORM_HISTORY_SORT);
   }

--- a/src/main/java/org/mozilla/gecko/sync/stage/SafeConstrainedServer11Repository.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/SafeConstrainedServer11Repository.java
@@ -33,13 +33,13 @@ public class SafeConstrainedServer11Repository extends ConstrainedServer11Reposi
   private JSONRecordFetcher countFetcher;
 
   public SafeConstrainedServer11Repository(String collection,
-                                           String collectionPath,
+                                           String storageURL,
                                            AuthHeaderProvider authHeaderProvider,
                                            long limit,
                                            String sort,
                                            JSONRecordFetcher countFetcher)
     throws URISyntaxException {
-    super(collection, collectionPath, authHeaderProvider, limit, sort);
+    super(collection, storageURL, authHeaderProvider, limit, sort);
     this.countFetcher = countFetcher;
   }
 

--- a/src/main/java/org/mozilla/gecko/sync/stage/SafeConstrainedServer11Repository.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/SafeConstrainedServer11Repository.java
@@ -7,9 +7,9 @@ package org.mozilla.gecko.sync.stage;
 import java.net.URISyntaxException;
 
 import org.mozilla.gecko.background.common.log.Logger;
-import org.mozilla.gecko.sync.CredentialsSource;
 import org.mozilla.gecko.sync.InfoCounts;
 import org.mozilla.gecko.sync.JSONRecordFetcher;
+import org.mozilla.gecko.sync.net.AuthHeaderProvider;
 import org.mozilla.gecko.sync.repositories.ConstrainedServer11Repository;
 import org.mozilla.gecko.sync.repositories.Repository;
 import org.mozilla.gecko.sync.repositories.Server11RepositorySession;
@@ -32,15 +32,14 @@ public class SafeConstrainedServer11Repository extends ConstrainedServer11Reposi
   // This can be lazily evaluated if we need it.
   private JSONRecordFetcher countFetcher;
 
-  public SafeConstrainedServer11Repository(String serverURI,
-                                           String username,
-                                           String collection,
-                                           CredentialsSource credentialsSource,
+  public SafeConstrainedServer11Repository(String collection,
+                                           String collectionPath,
+                                           AuthHeaderProvider authHeaderProvider,
                                            long limit,
                                            String sort,
                                            JSONRecordFetcher countFetcher)
     throws URISyntaxException {
-    super(serverURI, username, collection, credentialsSource, limit, sort);
+    super(collection, collectionPath, authHeaderProvider, limit, sort);
     this.countFetcher = countFetcher;
   }
 

--- a/src/main/java/org/mozilla/gecko/sync/stage/ServerSyncStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/ServerSyncStage.java
@@ -11,7 +11,6 @@ import java.util.concurrent.ExecutorService;
 
 import org.json.simple.parser.ParseException;
 import org.mozilla.gecko.background.common.log.Logger;
-import org.mozilla.gecko.sync.CredentialsSource;
 import org.mozilla.gecko.sync.EngineSettings;
 import org.mozilla.gecko.sync.GlobalSession;
 import org.mozilla.gecko.sync.HTTPFailureException;
@@ -23,6 +22,7 @@ import org.mozilla.gecko.sync.Utils;
 import org.mozilla.gecko.sync.crypto.KeyBundle;
 import org.mozilla.gecko.sync.delegates.WipeServerDelegate;
 import org.mozilla.gecko.sync.middleware.Crypto5MiddlewareRepository;
+import org.mozilla.gecko.sync.net.AuthHeaderProvider;
 import org.mozilla.gecko.sync.net.BaseResource;
 import org.mozilla.gecko.sync.net.SyncStorageRequest;
 import org.mozilla.gecko.sync.net.SyncStorageRequestDelegate;
@@ -145,10 +145,10 @@ public abstract class ServerSyncStage extends AbstractSessionManagingSyncStage i
 
   // Override this in subclasses.
   protected Repository getRemoteRepository() throws URISyntaxException {
-    return new Server11Repository(session.config.getClusterURLString(),
-                                  session.config.username,
-                                  getCollection(),
-                                  session);
+    String collection = getCollection();
+    return new Server11Repository(collection,
+                                  session.config.getCollectionURLString(collection),
+                                  session.getAuthHeaderProvider());
   }
 
   /**
@@ -374,7 +374,7 @@ public abstract class ServerSyncStage extends AbstractSessionManagingSyncStage i
   /**
    * Asynchronously wipe collection on server.
    */
-  protected void wipeServer(final CredentialsSource credentials, final WipeServerDelegate wipeDelegate) {
+  protected void wipeServer(final AuthHeaderProvider authHeaderProvider, final WipeServerDelegate wipeDelegate) {
     SyncStorageRequest request;
 
     try {
@@ -415,8 +415,8 @@ public abstract class ServerSyncStage extends AbstractSessionManagingSyncStage i
       }
 
       @Override
-      public String credentials() {
-        return credentials.credentials();
+      public AuthHeaderProvider getAuthHeaderProvider() {
+        return authHeaderProvider;
       }
     };
 
@@ -436,7 +436,7 @@ public abstract class ServerSyncStage extends AbstractSessionManagingSyncStage i
     final Runnable doWipe = new Runnable() {
       @Override
       public void run() {
-        wipeServer(session, new WipeServerDelegate() {
+        wipeServer(session.getAuthHeaderProvider(), new WipeServerDelegate() {
           @Override
           public void onWiped(long timestamp) {
             synchronized (monitor) {

--- a/src/main/java/org/mozilla/gecko/sync/stage/ServerSyncStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/ServerSyncStage.java
@@ -147,7 +147,7 @@ public abstract class ServerSyncStage extends AbstractSessionManagingSyncStage i
   protected Repository getRemoteRepository() throws URISyntaxException {
     String collection = getCollection();
     return new Server11Repository(collection,
-                                  session.config.getCollectionURLString(collection),
+                                  session.config.storageURL(),
                                   session.getAuthHeaderProvider());
   }
 

--- a/src/main/java/org/mozilla/gecko/sync/stage/SyncClientsEngineStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/SyncClientsEngineStage.java
@@ -24,6 +24,7 @@ import org.mozilla.gecko.sync.Utils;
 import org.mozilla.gecko.sync.crypto.CryptoException;
 import org.mozilla.gecko.sync.crypto.KeyBundle;
 import org.mozilla.gecko.sync.delegates.ClientsDataDelegate;
+import org.mozilla.gecko.sync.net.AuthHeaderProvider;
 import org.mozilla.gecko.sync.net.BaseResource;
 import org.mozilla.gecko.sync.net.SyncStorageCollectionRequest;
 import org.mozilla.gecko.sync.net.SyncStorageRecordRequest;
@@ -96,8 +97,8 @@ public class SyncClientsEngineStage extends AbstractSessionManagingSyncStage {
     boolean localAccountGUIDDownloaded = false;
 
     @Override
-    public String credentials() {
-      return session.credentials();
+    public AuthHeaderProvider getAuthHeaderProvider() {
+      return session.getAuthHeaderProvider();
     }
 
     @Override
@@ -215,8 +216,8 @@ public class SyncClientsEngineStage extends AbstractSessionManagingSyncStage {
     public boolean currentlyUploadingLocalRecord;
 
     @Override
-    public String credentials() {
-      return session.credentials();
+    public AuthHeaderProvider getAuthHeaderProvider() {
+      return session.getAuthHeaderProvider();
     }
 
     private void setUploadDetails(boolean isLocalRecord) {

--- a/src/main/java/org/mozilla/gecko/sync/syncadapter/SyncAdapter.java
+++ b/src/main/java/org/mozilla/gecko/sync/syncadapter/SyncAdapter.java
@@ -10,16 +10,16 @@ import java.security.NoSuchAlgorithmException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.json.simple.parser.ParseException;
+import org.mozilla.gecko.background.common.GlobalConstants;
+import org.mozilla.gecko.background.common.log.Logger;
 import org.mozilla.gecko.db.BrowserContract;
 import org.mozilla.gecko.sync.AlreadySyncingException;
 import org.mozilla.gecko.sync.CredentialException;
-import org.mozilla.gecko.background.common.GlobalConstants;
-import org.mozilla.gecko.background.common.log.Logger;
-import org.mozilla.gecko.sync.SyncConstants;
 import org.mozilla.gecko.sync.GlobalSession;
 import org.mozilla.gecko.sync.NonObjectJSONException;
 import org.mozilla.gecko.sync.SyncConfiguration;
 import org.mozilla.gecko.sync.SyncConfigurationException;
+import org.mozilla.gecko.sync.SyncConstants;
 import org.mozilla.gecko.sync.SyncException;
 import org.mozilla.gecko.sync.ThreadPool;
 import org.mozilla.gecko.sync.Utils;
@@ -28,6 +28,8 @@ import org.mozilla.gecko.sync.crypto.CryptoException;
 import org.mozilla.gecko.sync.crypto.KeyBundle;
 import org.mozilla.gecko.sync.delegates.ClientsDataDelegate;
 import org.mozilla.gecko.sync.delegates.GlobalSessionCallback;
+import org.mozilla.gecko.sync.net.AuthHeaderProvider;
+import org.mozilla.gecko.sync.net.BasicAuthHeaderProvider;
 import org.mozilla.gecko.sync.net.ConnectionMonitorThread;
 import org.mozilla.gecko.sync.setup.Constants;
 import org.mozilla.gecko.sync.setup.SyncAccounts;
@@ -502,8 +504,9 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements GlobalSe
 
     // TODO: default serverURL.
     final KeyBundle keyBundle = new KeyBundle(username, syncKey);
+    final AuthHeaderProvider authHeaderProvider = new BasicAuthHeaderProvider(username, password);
     GlobalSession globalSession = new GlobalSession(SyncConfiguration.DEFAULT_USER_API,
-                                                    serverURL, username, password, prefsPath,
+                                                    serverURL, username, authHeaderProvider, prefsPath,
                                                     keyBundle, this, this.mContext, extras, this);
 
     globalSession.start();

--- a/src/main/java/org/mozilla/gecko/sync/syncadapter/SyncAdapter.java
+++ b/src/main/java/org/mozilla/gecko/sync/syncadapter/SyncAdapter.java
@@ -505,8 +505,7 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements GlobalSe
     // TODO: default serverURL.
     final KeyBundle keyBundle = new KeyBundle(username, syncKey);
     final AuthHeaderProvider authHeaderProvider = new BasicAuthHeaderProvider(username, password);
-    GlobalSession globalSession = new GlobalSession(SyncConfiguration.DEFAULT_USER_API,
-                                                    serverURL, username, authHeaderProvider, prefsPath,
+    GlobalSession globalSession = new GlobalSession(serverURL, username, authHeaderProvider, prefsPath,
                                                     keyBundle, this, this.mContext, extras, this);
 
     globalSession.start();

--- a/src/test/java/org/mozilla/android/sync/net/test/TestGlobalSession.java
+++ b/src/test/java/org/mozilla/android/sync/net/test/TestGlobalSession.java
@@ -38,7 +38,6 @@ import org.mozilla.gecko.sync.ExtendedJSONObject;
 import org.mozilla.gecko.sync.GlobalSession;
 import org.mozilla.gecko.sync.MetaGlobal;
 import org.mozilla.gecko.sync.NonObjectJSONException;
-import org.mozilla.gecko.sync.SyncConfiguration;
 import org.mozilla.gecko.sync.SyncConfigurationException;
 import org.mozilla.gecko.sync.Utils;
 import org.mozilla.gecko.sync.crypto.CryptoException;
@@ -74,7 +73,7 @@ public class TestGlobalSession {
   public void testGetSyncStagesBy() throws SyncConfigurationException, IllegalArgumentException, NonObjectJSONException, IOException, ParseException, CryptoException, NoSuchStageException {
 
     final MockGlobalSessionCallback callback = new MockGlobalSessionCallback();
-    GlobalSession s = new MockPrefsGlobalSession(SyncConfiguration.DEFAULT_USER_API, TEST_CLUSTER_URL,
+    GlobalSession s = new MockPrefsGlobalSession(TEST_CLUSTER_URL,
                                                  TEST_USERNAME, TEST_PASSWORD, null,
                                                  new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY),
                                                  callback, /* context */ null, null, null);
@@ -332,7 +331,7 @@ public class TestGlobalSession {
   @Test
   public void testGenerateNewMetaGlobalNonePersisted() throws Exception {
     final MockGlobalSessionCallback callback = new MockGlobalSessionCallback();
-    final GlobalSession session = new MockPrefsGlobalSession(SyncConfiguration.DEFAULT_USER_API, TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD, null,
+    final GlobalSession session = new MockPrefsGlobalSession(TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD, null,
         new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY), callback, null, null, null);
 
     // Verify we fill in all of our known engines when none are persisted.
@@ -352,7 +351,7 @@ public class TestGlobalSession {
   @Test
   public void testGenerateNewMetaGlobalSomePersisted() throws Exception {
     final MockGlobalSessionCallback callback = new MockGlobalSessionCallback();
-    final GlobalSession session = new MockPrefsGlobalSession(SyncConfiguration.DEFAULT_USER_API, TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD, null,
+    final GlobalSession session = new MockPrefsGlobalSession(TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD, null,
         new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY), callback, null, null, null);
 
     // Verify we preserve engines with version 0 if some are persisted.
@@ -380,7 +379,7 @@ public class TestGlobalSession {
   public void testUploadUpdatedMetaGlobal() throws Exception {
     // Set up session with meta/global.
     final MockGlobalSessionCallback callback = new MockGlobalSessionCallback();
-    final GlobalSession session = new MockPrefsGlobalSession(SyncConfiguration.DEFAULT_USER_API, TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD, null,
+    final GlobalSession session = new MockPrefsGlobalSession(TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD, null,
         new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY), callback, null, null, null);
     session.config.metaGlobal = session.generateNewMetaGlobal();
     session.enginesToUpdate.clear();

--- a/src/test/java/org/mozilla/android/sync/net/test/TestLineByLineHandling.java
+++ b/src/test/java/org/mozilla/android/sync/net/test/TestLineByLineHandling.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import org.mozilla.android.sync.test.helpers.HTTPServerTestHelper;
 import org.mozilla.android.sync.test.helpers.MockServer;
 import org.mozilla.gecko.background.common.log.Logger;
+import org.mozilla.gecko.sync.net.AuthHeaderProvider;
 import org.mozilla.gecko.sync.net.BaseResource;
 import org.mozilla.gecko.sync.net.SyncStorageCollectionRequest;
 import org.mozilla.gecko.sync.net.SyncStorageCollectionRequestDelegate;
@@ -58,7 +59,7 @@ public class TestLineByLineHandling {
     }
 
     @Override
-    public String credentials() {
+    public AuthHeaderProvider getAuthHeaderProvider() {
       return null;
     }
 

--- a/src/test/java/org/mozilla/android/sync/net/test/TestServer11Repository.java
+++ b/src/test/java/org/mozilla/android/sync/net/test/TestServer11Repository.java
@@ -1,3 +1,6 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
 package org.mozilla.android.sync.net.test;
 
 import static org.junit.Assert.assertEquals;
@@ -10,9 +13,8 @@ import org.mozilla.gecko.sync.repositories.Server11Repository;
 
 public class TestServer11Repository {
 
-  private static final String SERVER_URI = "http://foo.com/";
-  private static final String USERNAME   = "johndoe";
   private static final String COLLECTION = "bookmarks";
+  private static final String COLLECTION_URL = "http://foo.com/1.1/n6ec3u5bee3tixzp2asys7bs6fve4jfw/storage/" + COLLECTION;
 
   public static void assertQueryEquals(String expected, URI u) {
     assertEquals(expected, u.getRawQuery());
@@ -21,7 +23,7 @@ public class TestServer11Repository {
   @SuppressWarnings("static-method")
   @Test
   public void testCollectionURI() throws URISyntaxException {
-    Server11Repository r = new Server11Repository(SERVER_URI, USERNAME, COLLECTION, null);
+    Server11Repository r = new Server11Repository(COLLECTION, COLLECTION_URL, null);
     assertQueryEquals("full=1&newer=5000.000",              r.collectionURI(true,  5000000L, -1,    null, null));
     assertQueryEquals("newer=1230.000",                     r.collectionURI(false, 1230000L, -1,    null, null));
     assertQueryEquals("newer=5000.000&limit=10",            r.collectionURI(false, 5000000L, 10,    null, null));

--- a/src/test/java/org/mozilla/android/sync/net/test/TestServer11Repository.java
+++ b/src/test/java/org/mozilla/android/sync/net/test/TestServer11Repository.java
@@ -3,31 +3,38 @@
 
 package org.mozilla.android.sync.net.test;
 
-import static org.junit.Assert.assertEquals;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.mozilla.gecko.sync.repositories.Server11Repository;
 
 public class TestServer11Repository {
 
   private static final String COLLECTION = "bookmarks";
-  private static final String COLLECTION_URL = "http://foo.com/1.1/n6ec3u5bee3tixzp2asys7bs6fve4jfw/storage/" + COLLECTION;
+  private static final String COLLECTION_URL = "http://foo.com/1.1/n6ec3u5bee3tixzp2asys7bs6fve4jfw/storage";
 
   public static void assertQueryEquals(String expected, URI u) {
-    assertEquals(expected, u.getRawQuery());
+    Assert.assertEquals(expected, u.getRawQuery());
   }
 
   @SuppressWarnings("static-method")
   @Test
-  public void testCollectionURI() throws URISyntaxException {
+  public void testCollectionURIFull() throws URISyntaxException {
     Server11Repository r = new Server11Repository(COLLECTION, COLLECTION_URL, null);
     assertQueryEquals("full=1&newer=5000.000",              r.collectionURI(true,  5000000L, -1,    null, null));
     assertQueryEquals("newer=1230.000",                     r.collectionURI(false, 1230000L, -1,    null, null));
     assertQueryEquals("newer=5000.000&limit=10",            r.collectionURI(false, 5000000L, 10,    null, null));
     assertQueryEquals("full=1&newer=5000.000&sort=index",   r.collectionURI(true,  5000000L,  0, "index", null));
     assertQueryEquals("full=1&ids=123,abc",                 r.collectionURI(true,       -1L, -1,    null, "123,abc"));
+  }
+
+  @Test
+  public void testCollectionURI() throws URISyntaxException {
+    Server11Repository noTrailingSlash = new Server11Repository(COLLECTION, COLLECTION_URL, null);
+    Server11Repository trailingSlash = new Server11Repository(COLLECTION, COLLECTION_URL + "/", null);
+    Assert.assertEquals("http://foo.com/1.1/n6ec3u5bee3tixzp2asys7bs6fve4jfw/storage/bookmarks", noTrailingSlash.collectionURI().toASCIIString());
+    Assert.assertEquals("http://foo.com/1.1/n6ec3u5bee3tixzp2asys7bs6fve4jfw/storage/bookmarks", trailingSlash.collectionURI().toASCIIString());
   }
 }

--- a/src/test/java/org/mozilla/android/sync/test/TestResetCommands.java
+++ b/src/test/java/org/mozilla/android/sync/test/TestResetCommands.java
@@ -22,7 +22,6 @@ import org.mozilla.gecko.sync.ExtendedJSONObject;
 import org.mozilla.gecko.sync.GlobalSession;
 import org.mozilla.gecko.sync.MetaGlobalException;
 import org.mozilla.gecko.sync.NonObjectJSONException;
-import org.mozilla.gecko.sync.SyncConfiguration;
 import org.mozilla.gecko.sync.SyncConfigurationException;
 import org.mozilla.gecko.sync.crypto.CryptoException;
 import org.mozilla.gecko.sync.crypto.KeyBundle;
@@ -76,7 +75,6 @@ public class TestResetCommands {
 
     // Side-effect: modifies global command processor.
     final GlobalSession session = new MockPrefsGlobalSession(
-        SyncConfiguration.DEFAULT_USER_API,
         null,
         TEST_USERNAME, TEST_PASSWORD, null,
         new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY),

--- a/src/test/java/org/mozilla/android/sync/test/TestSyncConfiguration.java
+++ b/src/test/java/org/mozilla/android/sync/test/TestSyncConfiguration.java
@@ -1,0 +1,35 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+package org.mozilla.android.sync.test;
+
+import java.net.URI;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mozilla.gecko.background.testhelpers.MockSharedPreferences;
+import org.mozilla.gecko.sync.PrefsSource;
+import org.mozilla.gecko.sync.SyncConfiguration;
+
+import android.content.SharedPreferences;
+
+public class TestSyncConfiguration implements PrefsSource {
+
+  @Override
+  public SharedPreferences getPrefs(String name, int mode) {
+    return new MockSharedPreferences();
+  }
+
+  @Test
+  public void testURLs() throws Exception {
+    SyncConfiguration config = new SyncConfiguration("username", null, "prefsPath", this);
+    config.serverURL = new URI("http://userapi.com/endpoint");
+    config.clusterURL = new URI("https://db.com/internal/");
+    Assert.assertEquals("http://userapi.com/endpoint/user/1.0/username/node/weave", config.nodeWeaveURL());
+    Assert.assertEquals("https://db.com/internal/1.1/username/info/collections", config.infoCollectionsURL());
+    Assert.assertEquals("https://db.com/internal/1.1/username/info/collection_counts", config.infoCollectionCountsURL());
+    Assert.assertEquals("https://db.com/internal/1.1/username/storage/meta/global", config.metaURL());
+    Assert.assertEquals("https://db.com/internal/1.1/username/storage", config.storageURL());
+    Assert.assertEquals("https://db.com/internal/1.1/username/storage/collection", config.collectionURI("collection").toASCIIString());
+  }
+}

--- a/src/test/java/org/mozilla/android/sync/test/helpers/BaseTestStorageRequestDelegate.java
+++ b/src/test/java/org/mozilla/android/sync/test/helpers/BaseTestStorageRequestDelegate.java
@@ -7,17 +7,28 @@ import static org.junit.Assert.fail;
 
 import java.io.IOException;
 
+import org.mozilla.gecko.sync.net.AuthHeaderProvider;
 import org.mozilla.gecko.sync.net.BaseResource;
+import org.mozilla.gecko.sync.net.BasicAuthHeaderProvider;
 import org.mozilla.gecko.sync.net.SyncStorageRequestDelegate;
 import org.mozilla.gecko.sync.net.SyncStorageResponse;
 
 public class BaseTestStorageRequestDelegate implements
     SyncStorageRequestDelegate {
-  public String _credentials;
+
+  protected final AuthHeaderProvider authHeaderProvider;
+
+  public BaseTestStorageRequestDelegate(AuthHeaderProvider authHeaderProvider) {
+    this.authHeaderProvider = authHeaderProvider;
+  }
+
+  public BaseTestStorageRequestDelegate(String username, String password) {
+    this(new BasicAuthHeaderProvider(username, password));
+  }
 
   @Override
-  public String credentials() {
-    return _credentials;
+  public AuthHeaderProvider getAuthHeaderProvider() {
+    return authHeaderProvider;
   }
 
   @Override

--- a/src/test/java/org/mozilla/android/sync/test/integration/TestBasicFetch.java
+++ b/src/test/java/org/mozilla/android/sync/test/integration/TestBasicFetch.java
@@ -85,17 +85,25 @@ public class TestBasicFetch {
     }
 
     public ExtendedJSONObject decrypt(String syncKey) throws Exception {
+      return decrypt(new KeyBundle(TEST_USERNAME, syncKey));
+    }
+
+    public ExtendedJSONObject decrypt(KeyBundle keyBundle) throws Exception {
       CryptoRecord rec;
       rec = CryptoRecord.fromJSONRecord(body);
-      rec.keyBundle = new KeyBundle(TEST_USERNAME, syncKey);
+      rec.keyBundle = keyBundle;
       rec.decrypt();
       return rec.payload;
     }
   }
 
   public static LiveDelegate realLiveFetch(String username, String password, String url) throws URISyntaxException {
+    return realLiveFetch(new BasicAuthHeaderProvider(username, password), url);
+  }
+
+  public static LiveDelegate realLiveFetch(AuthHeaderProvider authHeaderProvider, String url) throws URISyntaxException {
     final SyncStorageRecordRequest r = new SyncStorageRecordRequest(new URI(url));
-    LiveDelegate delegate = new LiveDelegate(username, password);
+    LiveDelegate delegate = new LiveDelegate(authHeaderProvider);
     r.delegate = delegate;
     WaitHelper.getTestWaiter().performWait(new Runnable() {
       @Override
@@ -107,8 +115,12 @@ public class TestBasicFetch {
   }
 
   public static LiveDelegate realLivePut(String username, String password, String url, final CryptoRecord record) throws URISyntaxException {
+    return realLivePut(new BasicAuthHeaderProvider(username, password), url, record);
+  }
+
+  public static LiveDelegate realLivePut(AuthHeaderProvider authHeaderProvider, String url, final CryptoRecord record) throws URISyntaxException {
     final SyncStorageRecordRequest r = new SyncStorageRecordRequest(new URI(url));
-    LiveDelegate delegate = new LiveDelegate(username, password);
+    LiveDelegate delegate = new LiveDelegate(authHeaderProvider);
     r.delegate = delegate;
     WaitHelper.getTestWaiter().performWait(new Runnable() {
       @Override

--- a/src/test/java/org/mozilla/android/sync/test/integration/TestBasicFetch.java
+++ b/src/test/java/org/mozilla/android/sync/test/integration/TestBasicFetch.java
@@ -18,7 +18,9 @@ import org.mozilla.gecko.sync.CryptoRecord;
 import org.mozilla.gecko.sync.ExtendedJSONObject;
 import org.mozilla.gecko.sync.NonObjectJSONException;
 import org.mozilla.gecko.sync.crypto.KeyBundle;
+import org.mozilla.gecko.sync.net.AuthHeaderProvider;
 import org.mozilla.gecko.sync.net.BaseResource;
+import org.mozilla.gecko.sync.net.BasicAuthHeaderProvider;
 import org.mozilla.gecko.sync.net.SyncStorageRecordRequest;
 import org.mozilla.gecko.sync.net.SyncStorageResponse;
 
@@ -31,21 +33,20 @@ public class TestBasicFetch {
   static final String REMOTE_INFO_COLLECTIONS_URL = "https://phx-sync545.services.mozilla.com/1.1/c6o7dvmr2c4ud2fyv6woz2u4zi22bcyd/info/collections";
 
   // Corresponds to rnewman+testandroid@mozilla.com.
-  static final String USERNAME     = "c6o7dvmr2c4ud2fyv6woz2u4zi22bcyd";
-  static final String PASSWORD     = "password";
+  static final String TEST_USERNAME     = "c6o7dvmr2c4ud2fyv6woz2u4zi22bcyd";
+  static final String TEST_PASSWORD     = "password";
   static final String SYNC_KEY     = "6m8mv8ex2brqnrmsb9fjuvfg7y";
 
   public static class LiveDelegate extends BaseTestStorageRequestDelegate {
-    protected String body = null;
-
-    protected final String username;
-    protected final String password;
-
     public LiveDelegate(String username, String password) {
-      this.username = username;
-      this.password = password;
-      this._credentials = username + ":" + password;
+      super(new BasicAuthHeaderProvider(username, password));
     }
+
+    public LiveDelegate(AuthHeaderProvider authHeaderProvider) {
+      super(authHeaderProvider);
+    }
+
+    protected String body = null;
 
     @Override
     public void handleRequestSuccess(SyncStorageResponse res) {
@@ -86,7 +87,7 @@ public class TestBasicFetch {
     public ExtendedJSONObject decrypt(String syncKey) throws Exception {
       CryptoRecord rec;
       rec = CryptoRecord.fromJSONRecord(body);
-      rec.keyBundle = new KeyBundle(username, syncKey);
+      rec.keyBundle = new KeyBundle(TEST_USERNAME, syncKey);
       rec.decrypt();
       return rec.payload;
     }
@@ -120,19 +121,19 @@ public class TestBasicFetch {
 
   @Test
   public void testRealLiveMetaGlobal() throws Exception {
-    LiveDelegate ld = realLiveFetch(USERNAME, PASSWORD, REMOTE_META_URL);
+    LiveDelegate ld = realLiveFetch(TEST_USERNAME, TEST_PASSWORD, REMOTE_META_URL);
     System.out.println(ld.body());
   }
 
   @Test
   public void testRealLiveCryptoKeys() throws Exception {
-    LiveDelegate ld = realLiveFetch(USERNAME, PASSWORD, REMOTE_KEYS_URL);
+    LiveDelegate ld = realLiveFetch(TEST_USERNAME, TEST_PASSWORD, REMOTE_KEYS_URL);
     System.out.println(ld.decrypt(SYNC_KEY));
   }
 
   @Test
   public void testRealLiveInfoCollections() throws Exception {
-    LiveDelegate ld = realLiveFetch(USERNAME, PASSWORD, REMOTE_INFO_COLLECTIONS_URL);
+    LiveDelegate ld = realLiveFetch(TEST_USERNAME, TEST_PASSWORD, REMOTE_INFO_COLLECTIONS_URL);
     System.out.println(ld.body());
   }
 }

--- a/src/test/java/org/mozilla/android/sync/test/integration/TestClientRecordTerminator.java
+++ b/src/test/java/org/mozilla/android/sync/test/integration/TestClientRecordTerminator.java
@@ -28,6 +28,7 @@ import org.mozilla.gecko.sync.SyncConfigurationException;
 import org.mozilla.gecko.sync.config.ClientRecordTerminator;
 import org.mozilla.gecko.sync.crypto.CryptoException;
 import org.mozilla.gecko.sync.crypto.KeyBundle;
+import org.mozilla.gecko.sync.net.BasicAuthHeaderProvider;
 import org.mozilla.gecko.sync.repositories.domain.FormHistoryRecord;
 
 @Category(IntegrationTestCategory.class)
@@ -37,7 +38,6 @@ public class TestClientRecordTerminator {
   static final String TEST_ACCOUNT      = "nalexander+test0425@mozilla.com";
   static final String TEST_USERNAME     = "6gnkjphdltbntwnrgvu46ey6mu7ncjdl";
   static final String TEST_PASSWORD     = "test0425";
-  static final String TEST_USER_PASS    = TEST_USERNAME + ":" + TEST_PASSWORD;
   static final String TEST_SYNC_KEY     = "fuyx96ea8rkfazvjdfuqumupye"; // Weave.Identity.syncKey
 
   static final String TEST_CLIENT_GUID_PREFIX  = "testGuid";
@@ -91,7 +91,7 @@ public class TestClientRecordTerminator {
     }
 
     for (String guid : KILL) {
-      ClientRecordTerminator.deleteClientRecord(TEST_USERNAME, TEST_PASSWORD, TEST_CLUSTER_URL, guid);
+      ClientRecordTerminator.deleteClientRecord(TEST_USERNAME, TEST_CLUSTER_URL, guid, new BasicAuthHeaderProvider(TEST_USERNAME, TEST_PASSWORD));
     }
 
     // Make sure record does not appear in collection guids.

--- a/src/test/java/org/mozilla/android/sync/test/integration/TestClientRecordTerminator.java
+++ b/src/test/java/org/mozilla/android/sync/test/integration/TestClientRecordTerminator.java
@@ -23,7 +23,6 @@ import org.mozilla.gecko.sync.CryptoRecord;
 import org.mozilla.gecko.sync.ExtendedJSONObject;
 import org.mozilla.gecko.sync.GlobalSession;
 import org.mozilla.gecko.sync.NonObjectJSONException;
-import org.mozilla.gecko.sync.SyncConfiguration;
 import org.mozilla.gecko.sync.SyncConfigurationException;
 import org.mozilla.gecko.sync.config.ClientRecordTerminator;
 import org.mozilla.gecko.sync.crypto.CryptoException;
@@ -57,7 +56,7 @@ public class TestClientRecordTerminator {
     syncKeyBundle = new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY);
 
     callback = new MockGlobalSessionCallback();
-    session = new MockPrefsGlobalSession(SyncConfiguration.DEFAULT_USER_API, TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD, null,
+    session = new MockPrefsGlobalSession(TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD, null,
         syncKeyBundle, callback, null, null, null);
     session.config.clusterURL = new URI(TEST_CLUSTER_URL);
   }

--- a/src/test/java/org/mozilla/android/sync/test/integration/TestFreshStart.java
+++ b/src/test/java/org/mozilla/android/sync/test/integration/TestFreshStart.java
@@ -27,7 +27,6 @@ import org.mozilla.gecko.sync.ExtendedJSONObject;
 import org.mozilla.gecko.sync.GlobalSession;
 import org.mozilla.gecko.sync.InfoCollections;
 import org.mozilla.gecko.sync.MetaGlobal;
-import org.mozilla.gecko.sync.SyncConfiguration;
 import org.mozilla.gecko.sync.Utils;
 import org.mozilla.gecko.sync.crypto.KeyBundle;
 import org.mozilla.gecko.sync.delegates.FreshStartDelegate;
@@ -56,7 +55,7 @@ public class TestFreshStart {
     syncKeyBundle = new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY);
 
     callback = new MockGlobalSessionCallback();
-    session = new MockPrefsGlobalSession(SyncConfiguration.DEFAULT_USER_API, TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD, null,
+    session = new MockPrefsGlobalSession(TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD, null,
         syncKeyBundle, callback, null, null, null) {
       @Override
       public CollectionKeys generateNewCryptoKeys() {

--- a/src/test/java/org/mozilla/android/sync/test/integration/TestWBOCollectionRequestDelegate.java
+++ b/src/test/java/org/mozilla/android/sync/test/integration/TestWBOCollectionRequestDelegate.java
@@ -17,7 +17,9 @@ import org.junit.experimental.categories.Category;
 import org.mozilla.gecko.background.common.log.Logger;
 import org.mozilla.gecko.sync.CryptoRecord;
 import org.mozilla.gecko.sync.crypto.KeyBundle;
+import org.mozilla.gecko.sync.net.AuthHeaderProvider;
 import org.mozilla.gecko.sync.net.BaseResource;
+import org.mozilla.gecko.sync.net.BasicAuthHeaderProvider;
 import org.mozilla.gecko.sync.net.SyncStorageCollectionRequest;
 import org.mozilla.gecko.sync.net.SyncStorageResponse;
 import org.mozilla.gecko.sync.net.WBOCollectionRequestDelegate;
@@ -28,7 +30,7 @@ public class TestWBOCollectionRequestDelegate {
 
   static final String REMOTE_BOOKMARKS_URL = "https://phx-sync545.services.mozilla.com/1.1/c6o7dvmr2c4ud2fyv6woz2u4zi22bcyd/storage/bookmarks?full=1";
   static final String USERNAME     = "c6o7dvmr2c4ud2fyv6woz2u4zi22bcyd";
-  static final String USER_PASS    = "c6o7dvmr2c4ud2fyv6woz2u4zi22bcyd:password";
+  static final String PASSWORD     = "password";
   static final String SYNC_KEY     = "6m8mv8ex2brqnrmsb9fjuvfg7y";
 
   public class LiveDelegate extends WBOCollectionRequestDelegate {
@@ -37,14 +39,14 @@ public class TestWBOCollectionRequestDelegate {
     public ArrayList<CryptoRecord> wbos = new ArrayList<CryptoRecord>();
 
     @Override
-    public String credentials() {
-      return USER_PASS;
+    public AuthHeaderProvider getAuthHeaderProvider() {
+      return new BasicAuthHeaderProvider(USERNAME, PASSWORD);
     }
 
     @Override
     public String ifUnmodifiedSince() {
       return null;
-    }    
+    }
 
     @Override
     public void handleRequestSuccess(SyncStorageResponse response) {

--- a/src/test/java/org/mozilla/android/sync/test/integration/TestWipeServer.java
+++ b/src/test/java/org/mozilla/android/sync/test/integration/TestWipeServer.java
@@ -38,7 +38,6 @@ public class TestWipeServer {
   static final String TEST_ACCOUNT      = "nalexander+test0425@mozilla.com";
   static final String TEST_USERNAME     = "6gnkjphdltbntwnrgvu46ey6mu7ncjdl";
   static final String TEST_PASSWORD     = "test0425";
-  static final String TEST_USER_PASS    = TEST_USERNAME + ":" + TEST_PASSWORD;
   static final String TEST_SYNC_KEY     = "fuyx96ea8rkfazvjdfuqumupye"; // Weave.Identity.syncKey
 
   private KeyBundle syncKeyBundle;

--- a/src/test/java/org/mozilla/android/sync/test/integration/TestWipeServer.java
+++ b/src/test/java/org/mozilla/android/sync/test/integration/TestWipeServer.java
@@ -23,7 +23,6 @@ import org.mozilla.gecko.sync.CryptoRecord;
 import org.mozilla.gecko.sync.ExtendedJSONObject;
 import org.mozilla.gecko.sync.GlobalSession;
 import org.mozilla.gecko.sync.NonObjectJSONException;
-import org.mozilla.gecko.sync.SyncConfiguration;
 import org.mozilla.gecko.sync.SyncConfigurationException;
 import org.mozilla.gecko.sync.crypto.CryptoException;
 import org.mozilla.gecko.sync.crypto.KeyBundle;
@@ -52,7 +51,7 @@ public class TestWipeServer {
     syncKeyBundle = new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY);
 
     callback = new MockGlobalSessionCallback();
-    session = new MockPrefsGlobalSession(SyncConfiguration.DEFAULT_USER_API, TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD, null,
+    session = new MockPrefsGlobalSession(TEST_CLUSTER_URL, TEST_USERNAME, TEST_PASSWORD, null,
         syncKeyBundle, callback, null, null, null);
     session.config.clusterURL = new URI(TEST_CLUSTER_URL);
   }

--- a/src/test/java/org/mozilla/gecko/sync/repositories/test/TestSafeConstrainedServer11Repository.java
+++ b/src/test/java/org/mozilla/gecko/sync/repositories/test/TestSafeConstrainedServer11Repository.java
@@ -12,22 +12,21 @@ import org.junit.Test;
 import org.mozilla.android.sync.test.helpers.HTTPServerTestHelper;
 import org.mozilla.android.sync.test.helpers.MockServer;
 import org.mozilla.gecko.background.testhelpers.WaitHelper;
-import org.mozilla.gecko.sync.CredentialsSource;
 import org.mozilla.gecko.sync.JSONRecordFetcher;
+import org.mozilla.gecko.sync.net.AuthHeaderProvider;
 import org.mozilla.gecko.sync.repositories.RepositorySession;
 import org.mozilla.gecko.sync.repositories.delegates.RepositorySessionCreationDelegate;
 import org.mozilla.gecko.sync.stage.SafeConstrainedServer11Repository;
 import org.simpleframework.http.Request;
 import org.simpleframework.http.Response;
 
-public class TestSafeConstrainedServer11Repository implements CredentialsSource {
+public class TestSafeConstrainedServer11Repository {
   private static final int     TEST_PORT      = HTTPServerTestHelper.getTestPort();
   private static final String  TEST_SERVER    = "http://localhost:" + TEST_PORT + "/";
   private static final String  TEST_USERNAME  = "c6o7dvmr2c4ud2fyv6woz2u4zi22bcyd";
   private static final String  TEST_BASE_PATH = "/1.1/" + TEST_USERNAME + "/";
 
-  @Override
-  public String credentials() {
+  public AuthHeaderProvider getAuthHeaderProvider() {
     return null;
   }
 
@@ -74,14 +73,13 @@ public class TestSafeConstrainedServer11Repository implements CredentialsSource 
 
     try {
       String countsURL = TEST_SERVER + TEST_BASE_PATH + "info/collection_counts";
-      JSONRecordFetcher countFetcher = new JSONRecordFetcher(countsURL, this.credentials());
+      JSONRecordFetcher countFetcher = new JSONRecordFetcher(countsURL, getAuthHeaderProvider());
       String sort = "sortindex";
-      CredentialsSource credentialsSource = this;
       String collection = "rotary";
 
       final int TEST_LIMIT = 1000;
       final SafeConstrainedServer11Repository repo = new SafeConstrainedServer11Repository(
-          TEST_SERVER, TEST_USERNAME, collection, credentialsSource, TEST_LIMIT, sort, countFetcher);
+          collection, getCollectionURL(collection), null, TEST_LIMIT, sort, countFetcher);
 
       final AtomicBoolean shouldSkipLots = new AtomicBoolean(false);
       final AtomicBoolean shouldSkipFew = new AtomicBoolean(true);
@@ -129,5 +127,9 @@ public class TestSafeConstrainedServer11Repository implements CredentialsSource 
     } finally {
       data.stopHTTPServer();
     }
+  }
+
+  protected String getCollectionURL(String collection) {
+    return TEST_BASE_PATH + "/storage/" + collection;
   }
 }

--- a/src/test/java/org/mozilla/gecko/sync/stage/test/TestFetchMetaGlobalStage.java
+++ b/src/test/java/org/mozilla/gecko/sync/stage/test/TestFetchMetaGlobalStage.java
@@ -22,7 +22,6 @@ import org.mozilla.gecko.background.testhelpers.MockGlobalSession;
 import org.mozilla.gecko.background.testhelpers.WaitHelper;
 import org.mozilla.gecko.sync.AlreadySyncingException;
 import org.mozilla.gecko.sync.CollectionKeys;
-import org.mozilla.gecko.sync.CredentialsSource;
 import org.mozilla.gecko.sync.CryptoRecord;
 import org.mozilla.gecko.sync.ExtendedJSONObject;
 import org.mozilla.gecko.sync.GlobalSession;
@@ -35,6 +34,7 @@ import org.mozilla.gecko.sync.crypto.KeyBundle;
 import org.mozilla.gecko.sync.delegates.FreshStartDelegate;
 import org.mozilla.gecko.sync.delegates.KeyUploadDelegate;
 import org.mozilla.gecko.sync.delegates.WipeServerDelegate;
+import org.mozilla.gecko.sync.net.AuthHeaderProvider;
 import org.mozilla.gecko.sync.stage.FetchMetaGlobalStage;
 import org.mozilla.gecko.sync.stage.GlobalSyncStage.Stage;
 import org.simpleframework.http.Request;
@@ -131,7 +131,7 @@ public class TestFetchMetaGlobalStage {
 
       // Don't really wipeServer.
       @Override
-      protected void wipeServer(final CredentialsSource credentials, final WipeServerDelegate wipeDelegate) {
+      protected void wipeServer(final AuthHeaderProvider authHeaderProvider, final WipeServerDelegate wipeDelegate) {
         calledWipeServer = true;
         wipeDelegate.onWiped(System.currentTimeMillis());
       }

--- a/src/test/java/org/mozilla/gecko/sync/test/TestPersistedMetaGlobal.java
+++ b/src/test/java/org/mozilla/gecko/sync/test/TestPersistedMetaGlobal.java
@@ -17,6 +17,8 @@ import org.mozilla.gecko.sync.MetaGlobal;
 import org.mozilla.gecko.sync.NoCollectionKeysSetException;
 import org.mozilla.gecko.sync.PersistedMetaGlobal;
 import org.mozilla.gecko.sync.crypto.CryptoException;
+import org.mozilla.gecko.sync.net.AuthHeaderProvider;
+import org.mozilla.gecko.sync.net.BasicAuthHeaderProvider;
 
 public class TestPersistedMetaGlobal {
   MockSharedPreferences prefs = null;
@@ -48,17 +50,18 @@ public class TestPersistedMetaGlobal {
   @Test
   public void testPersistMetaGlobal() throws Exception {
     PersistedMetaGlobal persisted = new PersistedMetaGlobal(prefs);
+    AuthHeaderProvider authHeaderProvider = new BasicAuthHeaderProvider(TEST_CREDENTIALS);
 
     // Test fresh start.
-    assertNull(persisted.metaGlobal(TEST_META_URL, TEST_CREDENTIALS));
+    assertNull(persisted.metaGlobal(TEST_META_URL, authHeaderProvider));
 
     // Test persisting.
     String body = "{\"id\":\"global\",\"payload\":\"{\\\"syncID\\\":\\\"zPSQTm7WBVWB\\\",\\\"storageVersion\\\":5,\\\"engines\\\":{\\\"clients\\\":{\\\"version\\\":1,\\\"syncID\\\":\\\"fDg0MS5bDtV7\\\"},\\\"bookmarks\\\":{\\\"version\\\":2,\\\"syncID\\\":\\\"NNaQr6_F-9dm\\\"},\\\"forms\\\":{\\\"version\\\":1,\\\"syncID\\\":\\\"GXF29AFprnvc\\\"},\\\"history\\\":{\\\"version\\\":1,\\\"syncID\\\":\\\"av75g4vm-_rp\\\"},\\\"passwords\\\":{\\\"version\\\":1,\\\"syncID\\\":\\\"LT_ACGpuKZ6a\\\"},\\\"prefs\\\":{\\\"version\\\":2,\\\"syncID\\\":\\\"-3nsksP9wSAs\\\"},\\\"tabs\\\":{\\\"version\\\":1,\\\"syncID\\\":\\\"W4H5lOMChkYA\\\"}}}\",\"username\":\"5817483\",\"modified\":1.32046073744E9}";
-    MetaGlobal mg = new MetaGlobal(TEST_META_URL, TEST_CREDENTIALS);
+    MetaGlobal mg = new MetaGlobal(TEST_META_URL, authHeaderProvider);
     mg.setFromRecord(CryptoRecord.fromJSONRecord(body));
     persisted.persistMetaGlobal(mg);
 
-    MetaGlobal persistedGlobal = persisted.metaGlobal(TEST_META_URL, TEST_CREDENTIALS);
+    MetaGlobal persistedGlobal = persisted.metaGlobal(TEST_META_URL, authHeaderProvider);
     assertNotNull(persistedGlobal);
     assertEquals("zPSQTm7WBVWB", persistedGlobal.getSyncID());
     assertTrue(persistedGlobal.getEngines() instanceof ExtendedJSONObject);

--- a/test/src/org/mozilla/gecko/background/sync/TestClientsStage.java
+++ b/test/src/org/mozilla/gecko/background/sync/TestClientsStage.java
@@ -12,6 +12,7 @@ import org.mozilla.gecko.sync.SyncConfiguration;
 import org.mozilla.gecko.sync.crypto.KeyBundle;
 import org.mozilla.gecko.sync.delegates.ClientsDataDelegate;
 import org.mozilla.gecko.sync.delegates.GlobalSessionCallback;
+import org.mozilla.gecko.sync.net.BasicAuthHeaderProvider;
 import org.mozilla.gecko.sync.repositories.android.ClientsDatabaseAccessor;
 import org.mozilla.gecko.sync.repositories.domain.ClientRecord;
 import org.mozilla.gecko.sync.stage.SyncClientsEngineStage;
@@ -43,7 +44,7 @@ public class TestClientsStage extends AndroidSyncTestCase {
     final GlobalSession session = new GlobalSession(
         SyncConfiguration.DEFAULT_USER_API,
         null,
-        TEST_USERNAME, TEST_PASSWORD, null,
+        TEST_USERNAME, new BasicAuthHeaderProvider(TEST_USERNAME, TEST_PASSWORD), null,
         new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY),
         callback, context, null, delegate);
 

--- a/test/src/org/mozilla/gecko/background/sync/TestClientsStage.java
+++ b/test/src/org/mozilla/gecko/background/sync/TestClientsStage.java
@@ -8,7 +8,6 @@ import org.mozilla.gecko.background.helpers.AndroidSyncTestCase;
 import org.mozilla.gecko.background.testhelpers.DefaultGlobalSessionCallback;
 import org.mozilla.gecko.background.testhelpers.MockClientsDataDelegate;
 import org.mozilla.gecko.sync.GlobalSession;
-import org.mozilla.gecko.sync.SyncConfiguration;
 import org.mozilla.gecko.sync.crypto.KeyBundle;
 import org.mozilla.gecko.sync.delegates.ClientsDataDelegate;
 import org.mozilla.gecko.sync.delegates.GlobalSessionCallback;
@@ -42,7 +41,6 @@ public class TestClientsStage extends AndroidSyncTestCase {
     final ClientsDataDelegate delegate = new MockClientsDataDelegate();
 
     final GlobalSession session = new GlobalSession(
-        SyncConfiguration.DEFAULT_USER_API,
         null,
         TEST_USERNAME, new BasicAuthHeaderProvider(TEST_USERNAME, TEST_PASSWORD), null,
         new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY),

--- a/test/src/org/mozilla/gecko/background/sync/TestResetting.java
+++ b/test/src/org/mozilla/gecko/background/sync/TestResetting.java
@@ -22,6 +22,7 @@ import org.mozilla.gecko.sync.SynchronizerConfiguration;
 import org.mozilla.gecko.sync.crypto.CryptoException;
 import org.mozilla.gecko.sync.crypto.KeyBundle;
 import org.mozilla.gecko.sync.delegates.GlobalSessionCallback;
+import org.mozilla.gecko.sync.net.BasicAuthHeaderProvider;
 import org.mozilla.gecko.sync.repositories.domain.Record;
 import org.mozilla.gecko.sync.stage.NoSuchStageException;
 import org.mozilla.gecko.sync.synchronizer.Synchronizer;
@@ -155,7 +156,7 @@ public class TestResetting extends AndroidSyncTestCase {
     return new GlobalSession(
         SyncConfiguration.DEFAULT_USER_API,
         null,
-        TEST_USERNAME, TEST_PASSWORD, null,
+        TEST_USERNAME, new BasicAuthHeaderProvider(TEST_USERNAME, TEST_PASSWORD), null,
         new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY),
         callback, getApplicationContext(), null, null) {
 

--- a/test/src/org/mozilla/gecko/background/sync/TestResetting.java
+++ b/test/src/org/mozilla/gecko/background/sync/TestResetting.java
@@ -16,7 +16,6 @@ import org.mozilla.gecko.sync.EngineSettings;
 import org.mozilla.gecko.sync.GlobalSession;
 import org.mozilla.gecko.sync.MetaGlobalException;
 import org.mozilla.gecko.sync.NonObjectJSONException;
-import org.mozilla.gecko.sync.SyncConfiguration;
 import org.mozilla.gecko.sync.SyncConfigurationException;
 import org.mozilla.gecko.sync.SynchronizerConfiguration;
 import org.mozilla.gecko.sync.crypto.CryptoException;
@@ -154,7 +153,6 @@ public class TestResetting extends AndroidSyncTestCase {
 
   private GlobalSession createDefaultGlobalSession(final GlobalSessionCallback callback) throws SyncConfigurationException, IllegalArgumentException, NonObjectJSONException, IOException, ParseException, CryptoException {
     return new GlobalSession(
-        SyncConfiguration.DEFAULT_USER_API,
         null,
         TEST_USERNAME, new BasicAuthHeaderProvider(TEST_USERNAME, TEST_PASSWORD), null,
         new KeyBundle(TEST_USERNAME, TEST_SYNC_KEY),

--- a/test/src/org/mozilla/gecko/background/sync/TestSyncConfiguration.java
+++ b/test/src/org/mozilla/gecko/background/sync/TestSyncConfiguration.java
@@ -29,13 +29,13 @@ public class TestSyncConfiguration extends AndroidSyncTestCase implements PrefsS
     SyncConfiguration config = null;
     SharedPreferences prefs = getPrefs(TEST_PREFS_NAME, 0);
 
-    config = new SyncConfiguration(TEST_PREFS_NAME, this);
+    config = newSyncConfiguration();
     config.enabledEngineNames = new HashSet<String>();
     config.enabledEngineNames.add("test1");
     config.enabledEngineNames.add("test2");
     config.persistToPrefs();
     assertTrue(prefs.contains(SyncConfiguration.PREF_ENABLED_ENGINE_NAMES));
-    config = new SyncConfiguration(TEST_PREFS_NAME, this);
+    config = newSyncConfiguration();
     Set<String> expected = new HashSet<String>();
     for (String name : new String[] { "test1", "test2" }) {
       expected.add(name);
@@ -45,7 +45,7 @@ public class TestSyncConfiguration extends AndroidSyncTestCase implements PrefsS
     config.enabledEngineNames = null;
     config.persistToPrefs();
     assertFalse(prefs.contains(SyncConfiguration.PREF_ENABLED_ENGINE_NAMES));
-    config = new SyncConfiguration(TEST_PREFS_NAME, this);
+    config = newSyncConfiguration();
     assertNull(config.enabledEngineNames);
   }
 
@@ -53,11 +53,11 @@ public class TestSyncConfiguration extends AndroidSyncTestCase implements PrefsS
     SyncConfiguration config = null;
     SharedPreferences prefs = getPrefs(TEST_PREFS_NAME, 0);
 
-    config = new SyncConfiguration(TEST_PREFS_NAME, this);
+    config = newSyncConfiguration();
     config.syncID = "test1";
     config.persistToPrefs();
     assertTrue(prefs.contains(SyncConfiguration.PREF_SYNC_ID));
-    config = new SyncConfiguration(TEST_PREFS_NAME, this);
+    config = newSyncConfiguration();
     assertEquals("test1", config.syncID);
   }
 
@@ -74,7 +74,7 @@ public class TestSyncConfiguration extends AndroidSyncTestCase implements PrefsS
     // Read values from selectedEngines.
     assertTrue(prefs.contains(SyncConfiguration.PREF_USER_SELECTED_ENGINES_TO_SYNC));
     SyncConfiguration config = null;
-    config = new SyncConfiguration(TEST_PREFS_NAME, this);
+    config = newSyncConfiguration();
     config.loadFromPrefs(prefs);
     assertEquals(expectedEngines, config.userSelectedEngines);
   }
@@ -95,7 +95,7 @@ public class TestSyncConfiguration extends AndroidSyncTestCase implements PrefsS
     // Read values from selectedEngines.
     assertTrue(prefs.contains(SyncConfiguration.PREF_USER_SELECTED_ENGINES_TO_SYNC));
     SyncConfiguration config = null;
-    config = new SyncConfiguration(TEST_PREFS_NAME, this);
+    config = newSyncConfiguration();
     config.loadFromPrefs(prefs);
     assertEquals(storedEngines, config.userSelectedEngines);
   }
@@ -111,9 +111,13 @@ public class TestSyncConfiguration extends AndroidSyncTestCase implements PrefsS
     // Read values from selectedEngines.
     assertTrue(prefs.contains(SyncConfiguration.PREF_USER_SELECTED_ENGINES_TO_SYNC));
     SyncConfiguration config = null;
-    config = new SyncConfiguration(TEST_PREFS_NAME, this);
+    config = newSyncConfiguration();
     config.loadFromPrefs(prefs);
     // Forms should not be selected if history is not present.
     assertTrue(config.userSelectedEngines.isEmpty());
+  }
+
+  protected SyncConfiguration newSyncConfiguration() {
+    return new SyncConfiguration(null, null, TEST_PREFS_NAME, this);
   }
 }


### PR DESCRIPTION
This is a long and awful series of patches that removes the assumption from Sync 1.1 code that we are authenticating with a password.

I have tested it on a device and adding, syncing (bookmarks both ways), and removing accounts appear to work fine.

The commits labelled with letters are kept apart for reviewing, but can be folded together for landing.  We should land this on develop and merge it to elm.
