### PR TITLE
Bug 918012 - sync with token server

### DIFF
--- a/AndroidManifest.xml.in
+++ b/AndroidManifest.xml.in
@@ -33,6 +33,7 @@
 #include manifests/SyncAndroidManifest_activities.xml.in
 #include manifests/SyncAndroidManifest_services.xml.in
 
+#include manifests/FxAccountAndroidManifest_activities.xml.in
 #include manifests/FxAccountAndroidManifest_services.xml.in
     </application>
 

--- a/manifests/FxAccountAndroidManifest_activities.xml.in
+++ b/manifests/FxAccountAndroidManifest_activities.xml.in
@@ -1,0 +1,14 @@
+        <activity
+            android:theme="@style/FxAccountTheme"
+            android:icon="@drawable/icon"
+            android:label="@string/fxaccount_label"
+            android:clearTaskOnLaunch="true"
+            android:name="org.mozilla.gecko.fxa.activities.FxAccountSetupActivity"
+            android:windowSoftInputMode="adjustResize">
+            <!-- Adding a launcher will make this activity appear on the
+                 Apps screen, which we only want when testing. -->
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>

--- a/res/layout/fxaccount_setup.xml
+++ b/res/layout/fxaccount_setup.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:orientation="vertical">
+</LinearLayout>

--- a/res/values/fxaccount_styles.xml
+++ b/res/values/fxaccount_styles.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<resources xmlns:android="http://schemas.android.com/apk/res/android">
+  <style name="FxAccountTheme" parent="@style/Gecko" />
+</resources>

--- a/src/main/java/org/mozilla/gecko/background/fxa/FxAccountClient.java
+++ b/src/main/java/org/mozilla/gecko/background/fxa/FxAccountClient.java
@@ -535,7 +535,7 @@ public class FxAccountClient {
   }
 
   @SuppressWarnings("unchecked")
-  public void sign(final byte[] sessionToken, final ExtendedJSONObject publicKey, int durationInSeconds, final RequestDelegate<String> delegate) {
+  public void sign(final byte[] sessionToken, final ExtendedJSONObject publicKey, long durationInSeconds, final RequestDelegate<String> delegate) {
     final JSONObject body = new JSONObject();
     body.put("publicKey", publicKey);
     body.put("duration", durationInSeconds);

--- a/src/main/java/org/mozilla/gecko/background/fxa/FxAccountUtils.java
+++ b/src/main/java/org/mozilla/gecko/background/fxa/FxAccountUtils.java
@@ -6,9 +6,12 @@ package org.mozilla.gecko.background.fxa;
 
 import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
+import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 
 import org.mozilla.gecko.sync.Utils;
+import org.mozilla.gecko.sync.crypto.HKDF;
+import org.mozilla.gecko.sync.crypto.KeyBundle;
 
 public class FxAccountUtils {
   public static final int SALT_LENGTH_BYTES = 32;
@@ -67,5 +70,14 @@ public class FxAccountUtils {
     int byteLength = (N.bitLength() + 7) / 8;
     int hexLength = 2 * byteLength;
     return Utils.byte2Hex(Utils.hex2Byte((x.mod(N)).toString(16), byteLength), hexLength);
+  }
+
+  public static KeyBundle generateSyncKeyBundle(final byte[] kB) throws InvalidKeyException, NoSuchAlgorithmException, UnsupportedEncodingException {
+    byte[] encryptionKey = new byte[32];
+    byte[] hmacKey = new byte[32];
+    byte[] derived = HKDF.derive(kB, new byte[0], FxAccountUtils.KW("oldsync"), 2*32);
+    System.arraycopy(derived, 0*32, encryptionKey, 0, 1*32);
+    System.arraycopy(derived, 1*32, hmacKey, 0, 1*32);
+    return new KeyBundle(encryptionKey, hmacKey);
   }
 }

--- a/src/main/java/org/mozilla/gecko/browserid/JSONWebTokenUtils.java
+++ b/src/main/java/org/mozilla/gecko/browserid/JSONWebTokenUtils.java
@@ -126,4 +126,65 @@ public class JSONWebTokenUtils {
     long durationInMilliseconds = DEFAULT_ASSERTION_DURATION_IN_MILLISECONDS;
     return createAssertion(privateKeyToSignWith, certificate, audience, issuer, issuedAt, durationInMilliseconds);
   }
+
+  /**
+   * For debugging only!
+   *
+   * @param input certificate to dump.
+   * @return true if the certificate is well-formed.
+   */
+  public static boolean dumpCertificate(String input) {
+    try {
+      String[] parts = input.split("\\.");
+      if (parts.length != 3) {
+        throw new IllegalArgumentException("certificate must have three parts");
+      }
+      String cHeader = new String(Base64.decodeBase64(parts[0]));
+      String cPayload = new String(Base64.decodeBase64(parts[1]));
+      String cSignature = Utils.byte2Hex(Base64.decodeBase64(parts[2]));
+      System.out.println("certificate header:    " + cHeader);
+      System.out.println("certificate payload:   " + cPayload);
+      System.out.println("certificate signature: " + cSignature);
+      return true;
+    } catch (Exception e) {
+      System.out.println("Malformed certificate -- got exception trying to dump contents.");
+      e.printStackTrace();
+      return false;
+    }
+  }
+
+  /**
+   * For debugging only!
+   *
+   * @param input assertion to dump.
+   * @return true if the assertion is well-formed.
+   */
+  public static boolean dumpAssertion(String input) {
+    try {
+      String[] parts = input.split("~");
+      if (parts.length != 2) {
+        throw new IllegalArgumentException("input must have two parts");
+      }
+      String certificate = parts[0];
+      String assertion = parts[1];
+      parts = assertion.split("\\.");
+      if (parts.length != 3) {
+        throw new IllegalArgumentException("assertion must have three parts");
+      }
+      String aHeader = new String(Base64.decodeBase64(parts[0]));
+      String aPayload = new String(Base64.decodeBase64(parts[1]));
+      String aSignature = Utils.byte2Hex(Base64.decodeBase64(parts[2]));
+      // We do all the assertion parsing *before* dumping the certificate in
+      // case there's a malformed assertion.
+      dumpCertificate(certificate);
+      System.out.println("assertion   header:    " + aHeader);
+      System.out.println("assertion   payload:   " + aPayload);
+      System.out.println("assertion   signature: " + aSignature);
+      return true;
+    } catch (Exception e) {
+      System.out.println("Malformed assertion -- got exception trying to dump contents.");
+      e.printStackTrace();
+      return false;
+    }
+  }
 }

--- a/src/main/java/org/mozilla/gecko/fxa/FxAccountConstants.java.in
+++ b/src/main/java/org/mozilla/gecko/fxa/FxAccountConstants.java.in
@@ -8,4 +8,9 @@ package org.mozilla.gecko.fxa;
 public class FxAccountConstants {
   public static final String GLOBAL_LOG_TAG = "FxAccounts";
   public static final String ACCOUNT_TYPE = "@MOZ_ANDROID_SHARED_FXACCOUNT_TYPE@";
+
+  public static final String DEFAULT_IDP_ENDPOINT = "https://api-accounts.dev.lcip.org";
+  public static final String DEFAULT_AUTH_ENDPOINT = "http://auth.oldsync.dev.lcip.org";
+
+  public static final String PREFS_PATH = "fxa.v1";
 }

--- a/src/main/java/org/mozilla/gecko/fxa/activities/FxAccountSetupActivity.java
+++ b/src/main/java/org/mozilla/gecko/fxa/activities/FxAccountSetupActivity.java
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.gecko.fxa.activities;
+
+import org.mozilla.gecko.AppConstants;
+import org.mozilla.gecko.R;
+import org.mozilla.gecko.background.common.log.Logger;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+
+/**
+ * Activity which displays login screen to the user.
+ */
+public class FxAccountSetupActivity extends Activity {
+  protected static final String LOG_TAG = FxAccountSetupActivity.class.getSimpleName();
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void onCreate(Bundle icicle) {
+    Logger.debug(LOG_TAG, "onCreate(" + icicle + ")");
+
+    super.onCreate(icicle);
+    setContentView(R.layout.fxaccount_setup);
+  }
+
+  @Override
+  public void onResume() {
+    Logger.debug(LOG_TAG, "onResume()");
+
+    super.onResume();
+
+    // Start Fennec at about:accounts page.
+    Intent intent = new Intent(Intent.ACTION_VIEW);
+    intent.setClassName(AppConstants.ANDROID_PACKAGE_NAME,
+        AppConstants.ANDROID_PACKAGE_NAME + ".App");
+    intent.setData(Uri.parse("about:accounts"));
+
+    startActivity(intent);
+    finish();
+  }
+}

--- a/src/main/java/org/mozilla/gecko/fxa/authenticator/FxAccountAuthenticator.java
+++ b/src/main/java/org/mozilla/gecko/fxa/authenticator/FxAccountAuthenticator.java
@@ -7,6 +7,7 @@ package org.mozilla.gecko.fxa.authenticator;
 import org.mozilla.gecko.AppConstants;
 import org.mozilla.gecko.background.common.log.Logger;
 import org.mozilla.gecko.fxa.FxAccountConstants;
+import org.mozilla.gecko.fxa.activities.FxAccountSetupActivity;
 import org.mozilla.gecko.fxa.sync.FxAccount;
 import org.mozilla.gecko.sync.Utils;
 
@@ -18,7 +19,6 @@ import android.accounts.NetworkErrorException;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
-import android.net.Uri;
 import android.os.Bundle;
 
 public class FxAccountAuthenticator extends AbstractAccountAuthenticator {
@@ -86,11 +86,7 @@ public class FxAccountAuthenticator extends AbstractAccountAuthenticator {
       return res;
     }
 
-    // Start Fennec at about:accounts page.
-    Intent intent = new Intent(Intent.ACTION_VIEW);
-    intent.setClassName(AppConstants.ANDROID_PACKAGE_NAME,
-        AppConstants.ANDROID_PACKAGE_NAME + ".App");
-    intent.setData(Uri.parse("about:accounts"));
+    Intent intent = new Intent(context, FxAccountSetupActivity.class);
     res.putParcelable(AccountManager.KEY_INTENT, intent);
     return res;
   }

--- a/src/main/java/org/mozilla/gecko/fxa/authenticator/FxAccountAuthenticator.java
+++ b/src/main/java/org/mozilla/gecko/fxa/authenticator/FxAccountAuthenticator.java
@@ -15,10 +15,19 @@ import android.accounts.AccountManager;
 import android.accounts.NetworkErrorException;
 import android.content.ContentResolver;
 import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 
 public class FxAccountAuthenticator extends AbstractAccountAuthenticator {
   public static final String LOG_TAG = FxAccountAuthenticator.class.getSimpleName();
+
+  public static final String JSON_KEY_UID = "uid";
+  public static final String JSON_KEY_SESSION_TOKEN = "session_token";
+  public static final String JSON_KEY_KA = "kA";
+  public static final String JSON_KEY_KB = "kB";
+  public static final String JSON_KEY_IDP_ENDPOINT = "idp_endpoint";
+  public static final String JSON_KEY_AUTH_ENDPOINT = "auth_endpoint";
 
   protected final Context context;
   protected final AccountManager accountManager;
@@ -27,6 +36,37 @@ public class FxAccountAuthenticator extends AbstractAccountAuthenticator {
     super(context);
     this.context = context;
     this.accountManager = AccountManager.get(context);
+  }
+
+  protected static void enableSyncing(Context context, Account account) {
+    for (String authority : new String[] {
+        AppConstants.ANDROID_PACKAGE_NAME + ".db.browser",
+        AppConstants.ANDROID_PACKAGE_NAME + ".db.formhistory",
+        AppConstants.ANDROID_PACKAGE_NAME + ".db.tabs",
+        AppConstants.ANDROID_PACKAGE_NAME + ".db.passwords",
+    }) {
+      ContentResolver.setSyncAutomatically(account, authority, true);
+      ContentResolver.setIsSyncable(account, authority, 1);
+    }
+  }
+
+  public static Account addAccount(Context context, String email, String uid, String sessionToken, String kA, String kB) {
+    final AccountManager accountManager = AccountManager.get(context);
+    final Account account = new Account(email, FxAccountConstants.ACCOUNT_TYPE);
+    final Bundle userData = new Bundle();
+    userData.putString(JSON_KEY_UID, uid);
+    userData.putString(JSON_KEY_SESSION_TOKEN, sessionToken);
+    userData.putString(JSON_KEY_KA, kA);
+    userData.putString(JSON_KEY_KB, kB);
+    userData.putString(JSON_KEY_IDP_ENDPOINT, FxAccountConstants.DEFAULT_IDP_ENDPOINT);
+    userData.putString(JSON_KEY_AUTH_ENDPOINT, FxAccountConstants.DEFAULT_AUTH_ENDPOINT);
+    if (!accountManager.addAccountExplicitly(account, sessionToken, userData)) {
+      Logger.warn(LOG_TAG, "Error adding account named " + account.name + " of type " + account.type);
+      return null;
+    }
+    // Enable syncing by default.
+    enableSyncing(context, account);
+    return account;
   }
 
   @Override
@@ -44,31 +84,12 @@ public class FxAccountAuthenticator extends AbstractAccountAuthenticator {
       return res;
     }
 
-    final Account account = new Account("test@test.com", FxAccountConstants.ACCOUNT_TYPE);
-    final String password = "password";
-    final Bundle userData = Bundle.EMPTY;
-
-    if (!accountManager.addAccountExplicitly(account, password, userData)) {
-      res.putInt(AccountManager.KEY_ERROR_CODE, -1);
-      res.putString(AccountManager.KEY_ERROR_MESSAGE, "Failed to add account explicitly.");
-      return res;
-    }
-
-    Logger.info(LOG_TAG, "Added account named " + account.name + " of type " + account.type);
-
-    // Enable syncing by default.
-    for (String authority : new String[] {
-        AppConstants.ANDROID_PACKAGE_NAME + ".db.browser",
-        AppConstants.ANDROID_PACKAGE_NAME + ".db.formhistory",
-        AppConstants.ANDROID_PACKAGE_NAME + ".db.tabs",
-        AppConstants.ANDROID_PACKAGE_NAME + ".db.passwords",
-        }) {
-      ContentResolver.setSyncAutomatically(account, authority, true);
-      ContentResolver.setIsSyncable(account, authority, 1);
-    }
-
-    res.putString(AccountManager.KEY_ACCOUNT_NAME, account.name);
-    res.putString(AccountManager.KEY_ACCOUNT_TYPE, account.type);
+    // Start Fennec at about:accounts page.
+    Intent intent = new Intent(Intent.ACTION_VIEW);
+    intent.setClassName(AppConstants.ANDROID_PACKAGE_NAME,
+        AppConstants.ANDROID_PACKAGE_NAME + ".App");
+    intent.setData(Uri.parse("about:accounts"));
+    res.putParcelable(AccountManager.KEY_INTENT, intent);
     return res;
   }
 

--- a/src/main/java/org/mozilla/gecko/fxa/authenticator/FxAccountAuthenticator.java
+++ b/src/main/java/org/mozilla/gecko/fxa/authenticator/FxAccountAuthenticator.java
@@ -7,6 +7,8 @@ package org.mozilla.gecko.fxa.authenticator;
 import org.mozilla.gecko.AppConstants;
 import org.mozilla.gecko.background.common.log.Logger;
 import org.mozilla.gecko.fxa.FxAccountConstants;
+import org.mozilla.gecko.fxa.sync.FxAccount;
+import org.mozilla.gecko.sync.Utils;
 
 import android.accounts.AbstractAccountAuthenticator;
 import android.accounts.Account;
@@ -141,5 +143,25 @@ public class FxAccountAuthenticator extends AbstractAccountAuthenticator {
     Logger.debug(LOG_TAG, "updateCredentials");
 
     return null;
+  }
+
+  /**
+   * Extract an FxAccount from an Android Account object.
+   *
+   * @param context to use for AccountManager.
+   * @param account to extract FxAccount from.
+   * @return FxAccount instance.
+   */
+  public static FxAccount fromAndroidAccount(Context context, Account account) {
+    AccountManager accountManager = AccountManager.get(context);
+
+    final byte[] sessionTokenBytes = Utils.hex2Byte(accountManager.getUserData(account, JSON_KEY_SESSION_TOKEN));
+    final byte[] kA = Utils.hex2Byte(accountManager.getUserData(account, JSON_KEY_KA), 16);
+    final byte[] kB = Utils.hex2Byte(accountManager.getUserData(account, JSON_KEY_KB), 16);
+
+    final String idpEndpoint = accountManager.getUserData(account, JSON_KEY_IDP_ENDPOINT);
+    final String authEndpoint = accountManager.getUserData(account, JSON_KEY_AUTH_ENDPOINT);
+
+    return new FxAccount(account.name, sessionTokenBytes, kA, kB, idpEndpoint, authEndpoint);
   }
 }

--- a/src/main/java/org/mozilla/gecko/fxa/sync/FxAccount.java
+++ b/src/main/java/org/mozilla/gecko/fxa/sync/FxAccount.java
@@ -6,7 +6,7 @@ package org.mozilla.gecko.fxa.sync;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
 import org.mozilla.gecko.background.common.log.Logger;
@@ -31,10 +31,10 @@ import ch.boye.httpclientandroidlib.HttpResponse;
 /**
  * Represent a Firefox Account.
  *
- * This is the FxAccounts equivalent of {@link SyncAccountParameters}. 
+ * This is the FxAccounts equivalent of {@link SyncAccountParameters}.
  */
 public class FxAccount {
-  private static final String LOG_TAG = FxAccount.class.getSimpleName();
+  protected static final String LOG_TAG = FxAccount.class.getSimpleName();
 
   public interface Delegate {
     public void handleSuccess(String uid, String endpoint, AuthHeaderProvider authHeaderProvider);
@@ -47,7 +47,7 @@ public class FxAccount {
   protected final byte[] kB;
   protected final String idpEndpoint;
   protected final String authEndpoint;
-  protected final ExecutorService executor;
+  protected final Executor executor;
 
   public FxAccount(String email, byte[] sessionTokenBytes, byte[] kA, byte[] kB, String idpEndpoint, String authEndpoint) {
     this.email = email;
@@ -59,6 +59,89 @@ public class FxAccount {
     this.executor = Executors.newSingleThreadExecutor();
   }
 
+  protected static class InnerFxAccountClientRequestDelegate implements FxAccountClient.RequestDelegate<String> {
+    protected final Executor executor;
+    protected final String audience;
+    protected final String tokenServerEndpoint;
+    protected final BrowserIDKeyPair keyPair;
+    protected final Delegate delegate;
+
+    protected InnerFxAccountClientRequestDelegate(Executor executor, String audience, String tokenServerEndpoint, BrowserIDKeyPair keyPair, Delegate delegate) {
+      this.executor = executor;
+      this.audience = audience;
+      this.tokenServerEndpoint = tokenServerEndpoint;
+      this.keyPair = keyPair;
+      this.delegate = delegate;
+    }
+
+    @Override
+    public void handleError(Exception e) {
+      Logger.error(LOG_TAG, "Failed to sign.", e);
+      delegate.handleError(e);
+    }
+
+    @Override
+    public void handleFailure(int status, HttpResponse response) {
+      HTTPFailureException e = new HTTPFailureException(new SyncStorageResponse(response));
+      Logger.error(LOG_TAG, "Failed to sign.", e);
+      delegate.handleError(e);
+    }
+
+    @Override
+    public void handleSuccess(String certificate) {
+      Logger.pii(LOG_TAG, "Got certificate " + certificate);
+
+      try {
+        String assertion = JSONWebTokenUtils.createAssertion(keyPair.getPrivate(), certificate, audience);
+        if (Logger.LOG_PERSONAL_INFORMATION) {
+          Logger.pii(LOG_TAG, "Generated assertion " + assertion);
+          JSONWebTokenUtils.dumpAssertion(assertion);
+        }
+
+        TokenServerClient tokenServerclient = new TokenServerClient(new URI(tokenServerEndpoint), executor);
+
+        tokenServerclient.getTokenFromBrowserIDAssertion(assertion, true, new InnerTokenServerClientDelegate(delegate));
+      } catch (Exception e) {
+        Logger.error(LOG_TAG, "Got error doing stuff.", e);
+        delegate.handleError(e);
+      }
+    }
+  }
+
+  protected static class InnerTokenServerClientDelegate implements TokenServerClientDelegate {
+    protected final Delegate delegate;
+
+    public InnerTokenServerClientDelegate(Delegate delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public void handleSuccess(TokenServerToken token) {
+      AuthHeaderProvider authHeaderProvider;
+      try {
+        authHeaderProvider = new HawkAuthHeaderProvider(token.id, token.key.getBytes("UTF-8"), false);
+      } catch (UnsupportedEncodingException e) {
+        Logger.error(LOG_TAG, "Failed to sync.", e);
+        delegate.handleError(e);
+        return;
+      }
+
+      delegate.handleSuccess(token.uid, token.endpoint, authHeaderProvider);
+    }
+
+    @Override
+    public void handleFailure(TokenServerException e) {
+      Logger.error(LOG_TAG, "Failed fetching server token.", e);
+      delegate.handleError(e);
+    }
+
+    @Override
+    public void handleError(Exception e) {
+      Logger.error(LOG_TAG, "Got error fetching token server token.", e);
+      delegate.handleError(e);
+    }
+  }
+
   /**
    * Request a signed certificate and exchange it for a token.
    *
@@ -66,10 +149,12 @@ public class FxAccount {
    * should be made obsolete by a fully featured {@link FxAccountAuthenticator}.
    *
    * @param context to use.
+   * @param tokenServerEndpoint to get token from.
    * @param keyPair to sign certificate for.
    * @param delegate to callback to.
    */
-  public void login(final Context context, final BrowserIDKeyPair keyPair, final Delegate delegate) {
+  public void login(final Context context, final String tokenServerEndpoint,
+      final BrowserIDKeyPair keyPair, final Delegate delegate) {
     ExtendedJSONObject keyPairObject;
     try {
       keyPairObject = new ExtendedJSONObject(keyPair.getPublic().serialize());
@@ -78,67 +163,13 @@ public class FxAccount {
       return;
     }
 
-    FxAccountClient fxAccountClient = new FxAccountClient(idpEndpoint, Executors.newSingleThreadExecutor());
-    fxAccountClient.sign(sessionTokenBytes, keyPairObject, JSONWebTokenUtils.DEFAULT_CERTIFICATE_DURATION_IN_MILLISECONDS,
-        new FxAccountClient.RequestDelegate<String>() {
-      @Override
-      public void handleError(Exception e) {
-        Logger.error(LOG_TAG, "Failed to sign.", e);
-        delegate.handleError(e);
-      }
-
-      @Override
-      public void handleFailure(int status, HttpResponse response) {
-        HTTPFailureException e = new HTTPFailureException(new SyncStorageResponse(response));
-        Logger.error(LOG_TAG, "Failed to sign.", e);
-        delegate.handleError(e);
-      }
-
-      @Override
-      public void handleSuccess(String certificate) {
-        Logger.pii(LOG_TAG, "Got certificate " + certificate);
-
-        try {
-          String assertion = JSONWebTokenUtils.createAssertion(keyPair.getPrivate(), certificate, authEndpoint);
-          Logger.pii(LOG_TAG, "Generated assertion " + assertion);
-
-          JSONWebTokenUtils.dumpAssertion(assertion);
-
-          String uri = authEndpoint + (authEndpoint.endsWith("/") ? "" : "/") + "1.0/sync/1.1";
-          TokenServerClient tokenServerclient = new TokenServerClient(new URI(uri), executor);
-
-          tokenServerclient.getTokenFromBrowserIDAssertion(assertion, true, new TokenServerClientDelegate() {
-            @Override
-            public void handleSuccess(TokenServerToken token) {
-              AuthHeaderProvider authHeaderProvider;
-              try {
-                authHeaderProvider = new HawkAuthHeaderProvider(token.id, token.key.getBytes("UTF-8"), false);
-              } catch (UnsupportedEncodingException e) {
-                Logger.error(LOG_TAG, "Failed to sync.", e);
-                delegate.handleError(e);
-                return;
-              }
-
-              delegate.handleSuccess(token.uid, token.endpoint, authHeaderProvider);
-            }
-
-            @Override
-            public void handleFailure(TokenServerException e) {
-              Logger.error(LOG_TAG, "Failed fetching server token.", e);
-              delegate.handleError(e);
-            }
-
-            @Override
-            public void handleError(Exception e) {
-              Logger.error(LOG_TAG, "Got error fetching token server token.", e);
-              delegate.handleError(e);
-            }
-          });
-        } catch (Exception e) {
-          Logger.error(LOG_TAG, "Got error doing stuff.", e);
-          delegate.handleError(e);
-        }
-      }
-    });
+    // We have nested executors in play here. Since we control the executor and
+    // the delegates, we can guarantee that there is no dead-lock between the
+    // inner FxAccountClient delegate, the outer TokenServerClient delegate, and
+    // the user supplied delegate.
+    FxAccountClient fxAccountClient = new FxAccountClient(idpEndpoint, executor);
+    fxAccountClient.sign(sessionTokenBytes, keyPairObject,
+        JSONWebTokenUtils.DEFAULT_CERTIFICATE_DURATION_IN_MILLISECONDS,
+        new InnerFxAccountClientRequestDelegate(executor, authEndpoint, tokenServerEndpoint, keyPair, delegate));
   }
 }

--- a/src/main/java/org/mozilla/gecko/fxa/sync/FxAccount.java
+++ b/src/main/java/org/mozilla/gecko/fxa/sync/FxAccount.java
@@ -1,0 +1,144 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.gecko.fxa.sync;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.mozilla.gecko.background.common.log.Logger;
+import org.mozilla.gecko.background.fxa.FxAccountClient;
+import org.mozilla.gecko.browserid.BrowserIDKeyPair;
+import org.mozilla.gecko.browserid.JSONWebTokenUtils;
+import org.mozilla.gecko.fxa.authenticator.FxAccountAuthenticator;
+import org.mozilla.gecko.sync.ExtendedJSONObject;
+import org.mozilla.gecko.sync.HTTPFailureException;
+import org.mozilla.gecko.sync.net.AuthHeaderProvider;
+import org.mozilla.gecko.sync.net.HawkAuthHeaderProvider;
+import org.mozilla.gecko.sync.net.SyncStorageResponse;
+import org.mozilla.gecko.sync.setup.SyncAccounts.SyncAccountParameters;
+import org.mozilla.gecko.tokenserver.TokenServerClient;
+import org.mozilla.gecko.tokenserver.TokenServerClientDelegate;
+import org.mozilla.gecko.tokenserver.TokenServerException;
+import org.mozilla.gecko.tokenserver.TokenServerToken;
+
+import android.content.Context;
+import ch.boye.httpclientandroidlib.HttpResponse;
+
+/**
+ * Represent a Firefox Account.
+ *
+ * This is the FxAccounts equivalent of {@link SyncAccountParameters}. 
+ */
+public class FxAccount {
+  private static final String LOG_TAG = FxAccount.class.getSimpleName();
+
+  public interface Delegate {
+    public void handleSuccess(String uid, String endpoint, AuthHeaderProvider authHeaderProvider);
+    public void handleError(Exception e);
+  }
+
+  protected final String email;
+  protected final byte[] sessionTokenBytes;
+  protected final byte[] kA;
+  protected final byte[] kB;
+  protected final String idpEndpoint;
+  protected final String authEndpoint;
+  protected final ExecutorService executor;
+
+  public FxAccount(String email, byte[] sessionTokenBytes, byte[] kA, byte[] kB, String idpEndpoint, String authEndpoint) {
+    this.email = email;
+    this.sessionTokenBytes = sessionTokenBytes;
+    this.kA = kA;
+    this.kB = kB;
+    this.idpEndpoint = idpEndpoint;
+    this.authEndpoint = authEndpoint;
+    this.executor = Executors.newSingleThreadExecutor();
+  }
+
+  /**
+   * Request a signed certificate and exchange it for a token.
+   *
+   * This is temporary code that does not do production-ready caching. This
+   * should be made obsolete by a fully featured {@link FxAccountAuthenticator}.
+   *
+   * @param context to use.
+   * @param keyPair to sign certificate for.
+   * @param delegate to callback to.
+   */
+  public void login(final Context context, final BrowserIDKeyPair keyPair, final Delegate delegate) {
+    ExtendedJSONObject keyPairObject;
+    try {
+      keyPairObject = new ExtendedJSONObject(keyPair.getPublic().serialize());
+    } catch (Exception e) {
+      delegate.handleError(e);
+      return;
+    }
+
+    FxAccountClient fxAccountClient = new FxAccountClient(idpEndpoint, Executors.newSingleThreadExecutor());
+    fxAccountClient.sign(sessionTokenBytes, keyPairObject, JSONWebTokenUtils.DEFAULT_CERTIFICATE_DURATION_IN_MILLISECONDS,
+        new FxAccountClient.RequestDelegate<String>() {
+      @Override
+      public void handleError(Exception e) {
+        Logger.error(LOG_TAG, "Failed to sign.", e);
+        delegate.handleError(e);
+      }
+
+      @Override
+      public void handleFailure(int status, HttpResponse response) {
+        HTTPFailureException e = new HTTPFailureException(new SyncStorageResponse(response));
+        Logger.error(LOG_TAG, "Failed to sign.", e);
+        delegate.handleError(e);
+      }
+
+      @Override
+      public void handleSuccess(String certificate) {
+        Logger.pii(LOG_TAG, "Got certificate " + certificate);
+
+        try {
+          String assertion = JSONWebTokenUtils.createAssertion(keyPair.getPrivate(), certificate, authEndpoint);
+          Logger.pii(LOG_TAG, "Generated assertion " + assertion);
+
+          JSONWebTokenUtils.dumpAssertion(assertion);
+
+          String uri = authEndpoint + (authEndpoint.endsWith("/") ? "" : "/") + "1.0/sync/1.1";
+          TokenServerClient tokenServerclient = new TokenServerClient(new URI(uri), executor);
+
+          tokenServerclient.getTokenFromBrowserIDAssertion(assertion, true, new TokenServerClientDelegate() {
+            @Override
+            public void handleSuccess(TokenServerToken token) {
+              AuthHeaderProvider authHeaderProvider;
+              try {
+                authHeaderProvider = new HawkAuthHeaderProvider(token.id, token.key.getBytes("UTF-8"), false);
+              } catch (UnsupportedEncodingException e) {
+                Logger.error(LOG_TAG, "Failed to sync.", e);
+                delegate.handleError(e);
+                return;
+              }
+
+              delegate.handleSuccess(token.uid, token.endpoint, authHeaderProvider);
+            }
+
+            @Override
+            public void handleFailure(TokenServerException e) {
+              Logger.error(LOG_TAG, "Failed fetching server token.", e);
+              delegate.handleError(e);
+            }
+
+            @Override
+            public void handleError(Exception e) {
+              Logger.error(LOG_TAG, "Got error fetching token server token.", e);
+              delegate.handleError(e);
+            }
+          });
+        } catch (Exception e) {
+          Logger.error(LOG_TAG, "Got error doing stuff.", e);
+          delegate.handleError(e);
+        }
+      }
+    });
+  }
+}

--- a/src/main/java/org/mozilla/gecko/fxa/sync/FxAccountGlobalSession.java
+++ b/src/main/java/org/mozilla/gecko/fxa/sync/FxAccountGlobalSession.java
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.gecko.fxa.sync;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.HashMap;
+
+import org.json.simple.parser.ParseException;
+import org.mozilla.gecko.background.common.log.Logger;
+import org.mozilla.gecko.sync.GlobalSession;
+import org.mozilla.gecko.sync.NonObjectJSONException;
+import org.mozilla.gecko.sync.SyncConfigurationException;
+import org.mozilla.gecko.sync.crypto.KeyBundle;
+import org.mozilla.gecko.sync.delegates.BaseGlobalSessionCallback;
+import org.mozilla.gecko.sync.delegates.ClientsDataDelegate;
+import org.mozilla.gecko.sync.net.AuthHeaderProvider;
+import org.mozilla.gecko.sync.stage.CheckPreconditionsStage;
+import org.mozilla.gecko.sync.stage.GlobalSyncStage;
+import org.mozilla.gecko.sync.stage.GlobalSyncStage.Stage;
+
+import android.content.Context;
+import android.os.Bundle;
+
+public class FxAccountGlobalSession extends GlobalSession {
+  private static final String LOG_TAG = FxAccountGlobalSession.class.getSimpleName();
+
+  public FxAccountGlobalSession(String storageEndpoint, String username,
+      AuthHeaderProvider authHeaderProvider, String prefsPath,
+      KeyBundle syncKeyBundle, BaseGlobalSessionCallback callback,
+      Context context, Bundle extras, ClientsDataDelegate clientsDelegate)
+      throws SyncConfigurationException, IllegalArgumentException, IOException,
+      ParseException, NonObjectJSONException, URISyntaxException {
+    super(username, authHeaderProvider, prefsPath, syncKeyBundle,
+        callback, context, extras, clientsDelegate, null);
+    URI uri = new URI(storageEndpoint);
+    this.config.clusterURL = new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), uri.getPort(), "/", null, null);
+    Logger.warn(LOG_TAG, "storageEndpoint is " + uri + " and clusterURL is " + config.clusterURL);
+  }
+
+  @Override
+  public void prepareStages() {
+    super.prepareStages();
+    HashMap<Stage, GlobalSyncStage> stages = new HashMap<Stage, GlobalSyncStage>();
+    stages.putAll(this.stages);
+    stages.put(Stage.ensureClusterURL, new CheckPreconditionsStage());
+    this.stages = Collections.unmodifiableMap(stages);
+  }
+}

--- a/src/main/java/org/mozilla/gecko/fxa/sync/FxAccountSyncAdapter.java
+++ b/src/main/java/org/mozilla/gecko/fxa/sync/FxAccountSyncAdapter.java
@@ -4,27 +4,154 @@
 
 package org.mozilla.gecko.fxa.sync;
 
+import java.net.URI;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 import org.mozilla.gecko.background.common.log.Logger;
+import org.mozilla.gecko.background.fxa.FxAccountUtils;
+import org.mozilla.gecko.browserid.BrowserIDKeyPair;
+import org.mozilla.gecko.browserid.RSACryptoImplementation;
+import org.mozilla.gecko.fxa.FxAccountConstants;
+import org.mozilla.gecko.fxa.authenticator.FxAccountAuthenticator;
+import org.mozilla.gecko.sync.GlobalSession;
+import org.mozilla.gecko.sync.SharedPreferencesClientsDataDelegate;
+import org.mozilla.gecko.sync.crypto.KeyBundle;
+import org.mozilla.gecko.sync.delegates.BaseGlobalSessionCallback;
+import org.mozilla.gecko.sync.delegates.ClientsDataDelegate;
+import org.mozilla.gecko.sync.net.AuthHeaderProvider;
+import org.mozilla.gecko.sync.stage.GlobalSyncStage.Stage;
 
 import android.accounts.Account;
 import android.content.AbstractThreadedSyncAdapter;
 import android.content.ContentProviderClient;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.content.SyncResult;
 import android.os.Bundle;
 
 public class FxAccountSyncAdapter extends AbstractThreadedSyncAdapter {
   private static final String LOG_TAG = FxAccountSyncAdapter.class.getSimpleName();
 
+  protected final ExecutorService executor;
+
   public FxAccountSyncAdapter(Context context, boolean autoInitialize) {
     super(context, autoInitialize);
+    this.executor = Executors.newSingleThreadExecutor();
   }
 
+  /**
+   * A trivial global session callback that ignores backoff requests, upgrades,
+   * and authorization errors. It simply waits until the sync completes.
+   */
+  protected static class SessionCallback implements BaseGlobalSessionCallback {
+    protected final CountDownLatch latch;
+
+    public SessionCallback(CountDownLatch latch) {
+      if (latch == null) {
+        throw new IllegalArgumentException("latch must not be null");
+      }
+      this.latch = latch;
+    }
+
+    @Override
+    public boolean shouldBackOff() {
+      return false;
+    }
+
+    @Override
+    public void requestBackoff(long backoff) {
+    }
+
+    @Override
+    public void informUpgradeRequiredResponse(GlobalSession session) {
+    }
+
+    @Override
+    public void informUnauthorizedResponse(GlobalSession globalSession, URI oldClusterURL) {
+    }
+
+    @Override
+    public void handleStageCompleted(Stage currentState, GlobalSession globalSession) {
+    }
+
+    @Override
+    public void handleSuccess(GlobalSession globalSession) {
+      Logger.info(LOG_TAG, "Successfully synced!");
+      latch.countDown();
+    }
+
+    @Override
+    public void handleError(GlobalSession globalSession, Exception ex) {
+      Logger.warn(LOG_TAG, "Sync failed.", ex);
+      latch.countDown();
+    }
+
+    @Override
+    public void handleAborted(GlobalSession globalSession, String reason) {
+      Logger.warn(LOG_TAG, "Sync aborted: " + reason);
+      latch.countDown();
+    }
+  };
+
+  /**
+   * A trivial Sync implementation that does not cache client keys,
+   * certificates, or tokens.
+   *
+   * This should be replaced with a full {@link FxAccountAuthenticator}-based
+   * token implementation.
+   */
   @Override
-  public void onPerformSync(Account account, Bundle extras, String authority, ContentProviderClient provider, SyncResult syncResult) {
+  public void onPerformSync(final Account account, final Bundle extras, final String authority, ContentProviderClient provider, SyncResult syncResult) {
+    Logger.setThreadLogTag(FxAccountConstants.GLOBAL_LOG_TAG);
+
     Logger.info(LOG_TAG, "Syncing FxAccount" +
         " account named " + account.name +
         " for authority " + authority +
         " with instance " + this + ".");
+
+    final CountDownLatch latch = new CountDownLatch(1);
+    try {
+      final BrowserIDKeyPair keyPair = RSACryptoImplementation.generateKeypair(1024);
+      Logger.info(LOG_TAG, "Generated keypair. ");
+
+      final FxAccount fxAccount = FxAccountAuthenticator.fromAndroidAccount(getContext(), account);
+      fxAccount.login(getContext(), keyPair, new FxAccount.Delegate() {
+        @Override
+        public void handleSuccess(final String uid, final String endpoint, final AuthHeaderProvider authHeaderProvider) {
+          Logger.pii(LOG_TAG, "Got token! uid is " + uid + " and endpoint is " + endpoint + ".");
+
+          final BaseGlobalSessionCallback callback = new SessionCallback(latch);
+
+          Executors.newSingleThreadExecutor().execute(new Runnable() {
+            @Override
+            public void run() {
+              FxAccountGlobalSession globalSession = null;
+              try {
+                SharedPreferences sharedPrefs = getContext().getSharedPreferences(FxAccountConstants.PREFS_PATH, Context.MODE_PRIVATE);
+                ClientsDataDelegate clientsDataDelegate = new SharedPreferencesClientsDataDelegate(sharedPrefs);
+                final KeyBundle syncKeyBundle = FxAccountUtils.generateSyncKeyBundle(fxAccount.kB);
+                globalSession = new FxAccountGlobalSession(endpoint, uid, authHeaderProvider, FxAccountConstants.PREFS_PATH, syncKeyBundle, callback, getContext(), extras, clientsDataDelegate);
+                globalSession.start();
+              } catch (Exception e) {
+                callback.handleError(globalSession, e);
+                return;
+              }
+            }
+          });
+        }
+
+        @Override
+        public void handleError(Exception e) {
+          Logger.info(LOG_TAG, "Failed to get token.", e);
+          latch.countDown();
+        }
+      });
+
+      latch.await();
+    } catch (Exception e) {
+      Logger.error(LOG_TAG, "Got error logging in.", e);
+    }
   }
 }

--- a/src/main/java/org/mozilla/gecko/fxa/sync/FxAccountSyncAdapter.java
+++ b/src/main/java/org/mozilla/gecko/fxa/sync/FxAccountSyncAdapter.java
@@ -117,7 +117,9 @@ public class FxAccountSyncAdapter extends AbstractThreadedSyncAdapter {
       Logger.info(LOG_TAG, "Generated keypair. ");
 
       final FxAccount fxAccount = FxAccountAuthenticator.fromAndroidAccount(getContext(), account);
-      fxAccount.login(getContext(), keyPair, new FxAccount.Delegate() {
+      final String tokenServerEndpoint = fxAccount.authEndpoint + (fxAccount.authEndpoint.endsWith("/") ? "" : "/") + "1.0/sync/1.1";
+
+      fxAccount.login(getContext(), tokenServerEndpoint, keyPair, new FxAccount.Delegate() {
         @Override
         public void handleSuccess(final String uid, final String endpoint, final AuthHeaderProvider authHeaderProvider) {
           Logger.pii(LOG_TAG, "Got token! uid is " + uid + " and endpoint is " + endpoint + ".");

--- a/src/test/java/org/mozilla/gecko/background/fxa/test/TestFxAccountUtils.java
+++ b/src/test/java/org/mozilla/gecko/background/fxa/test/TestFxAccountUtils.java
@@ -7,8 +7,10 @@ import java.math.BigInteger;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.mozilla.apache.commons.codec.binary.Base64;
 import org.mozilla.gecko.background.fxa.FxAccountUtils;
 import org.mozilla.gecko.sync.Utils;
+import org.mozilla.gecko.sync.crypto.KeyBundle;
 import org.mozilla.gecko.sync.net.SRPConstants;
 
 public class TestFxAccountUtils {
@@ -61,5 +63,12 @@ public class TestFxAccountUtils {
 
     String expectedVHex = "00173ffa0263e63ccfd6791b8ee2a40f048ec94cd95aa8a3125726f9805e0c8283c658dc0b607fbb25db68e68e93f2658483049c68af7e8214c49fde2712a775b63e545160d64b00189a86708c69657da7a1678eda0cd79f86b8560ebdb1ffc221db360eab901d643a75bf1205070a5791230ae56466b8c3c1eb656e19b794f1ea0d2a077b3a755350208ea0118fec8c4b2ec344a05c66ae1449b32609ca7189451c259d65bd15b34d8729afdb5faff8af1f3437bbdc0c3d0b069a8ab2a959c90c5a43d42082c77490f3afcc10ef5648625c0605cdaace6c6fdc9e9a7e6635d619f50af7734522470502cab26a52a198f5b00a279858916507b0b4e9ef9524d6";
     Assert.assertEquals(expectedVHex, FxAccountUtils.hexModN(v, SRPConstants._2048.N));
+  }
+
+  public void testGenerateSyncKeyBundle() throws Exception {
+    byte[] kB = Utils.hex2Byte("d02d8fe39f28b601159c543f2deeb8f72bdf2043e8279aa08496fbd9ebaea361");
+    KeyBundle bundle = FxAccountUtils.generateSyncKeyBundle(kB);
+    Assert.assertEquals("rsLwECkgPYeGbYl92e23FskfIbgld9TgeifEaB9ZwTI=", Base64.encodeBase64String(bundle.getEncryptionKey()));
+    Assert.assertEquals("fs75EseCD/VOLodlIGmwNabBjhTYBHFCe7CGIf0t8Tw=", Base64.encodeBase64String(bundle.getHMACKey()));
   }
 }

--- a/src/test/java/org/mozilla/gecko/background/fxa/test/TestLiveFxAccountClient.java
+++ b/src/test/java/org/mozilla/gecko/background/fxa/test/TestLiveFxAccountClient.java
@@ -26,10 +26,10 @@ import ch.boye.httpclientandroidlib.HttpResponse;
 
 @Category(IntegrationTestCategory.class)
 public class TestLiveFxAccountClient {
-  protected static final String TEST_SERVERURI = "http://127.0.0.1:9000";
+  protected static final String TEST_SERVERURI = "http://127.0.0.1:9000/";
   // These tests fail against the live dev server because the accounts created
   // need to be manually verified.
-  // protected static final String TEST_SERVERURI = "https://idp.dev.lcip.org";
+  // protected static final String TEST_SERVERURI = "https://api-accounts.dev.lcip.org/";
 
   protected static final String TEST_EMAIL = "andre@example.org";
   protected static final String TEST_PASSWORD = "password";
@@ -333,6 +333,6 @@ public class TestLiveFxAccountClient {
     ExtendedJSONObject cert = new ExtendedJSONObject(new String(Base64.decodeBase64(rsaCert.split("\\.")[1]), "UTF-8"));
     Assert.assertNotNull(cert.getObject("principal"));
     String email = cert.getObject("principal").getString("email");
-    Assert.assertEquals(TEST_SERVERURI.split("//")[1], email.split("@")[1]);
+    Assert.assertEquals(TEST_SERVERURI.split("//")[1].split("/")[0], email.split("@")[1]);
   }
 }

--- a/src/test/java/org/mozilla/gecko/sync/net/test/TestLiveTLSSocketFactory.java
+++ b/src/test/java/org/mozilla/gecko/sync/net/test/TestLiveTLSSocketFactory.java
@@ -77,6 +77,6 @@ public class TestLiveTLSSocketFactory {
 
   @Test
   public void testIDPWeakerCiphersuitesNotAllowed() throws Exception {
-    testSSLConnection("https://idp.dev.lcip.org");
+    testSSLConnection("https://api-accounts.dev.lcip.org");
   }
 }


### PR DESCRIPTION
@rnewman: The first 7 parts are ready for review.  These patches split out pieces that in turn make it easy to build a new `FxAccountSyncAdapter` similar to `SyncAdapter` but intended for Firefox Accounts auth.  That work just needs cleaning before it goes up for review.
