### PR TITLE
Bumping maven-site-plugin to 3.3 to work with Maven 3.1.1

### DIFF
--- a/android-sync-app/pom.xml
+++ b/android-sync-app/pom.xml
@@ -224,7 +224,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.0</version>
+        <version>3.3</version>
         <configuration>
           <reportPlugins>
             <plugin>


### PR DESCRIPTION
Bumping maven-site-plugin to 3.3 to work with Maven 3.1.1
- https://bugzilla.mozilla.org/show_bug.cgi?id=949716
- https://github.com/jacoco/jacoco/issues/121
- http://search.maven.org/#artifactdetails|org.apache.maven.plugins|maven-site-plugin|3.3|maven-plugin
