### PR TITLE
Bug 961187 - Remove "Change password" link entirely.

### DIFF
--- a/res/layout/fxaccount_status.xml
+++ b/res/layout/fxaccount_status.xml
@@ -24,15 +24,6 @@
             style="@style/FxAccountSubHeaderItem" >
         </TextView>
 
-        <TextView
-            android:id="@+id/change_password"
-            style="@style/FxAccountLinkItem"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="10dp"
-            android:text="@string/fxaccount_change_password" >
-        </TextView>
-
         <ViewFlipper
             android:id="@+id/connection_status_view"
             style="@style/FxAccountTextItem"
@@ -41,7 +32,7 @@
             android:layout_marginBottom="10dp" >
 
             <TextView
-                android:id="@+id/unverified_view"
+                android:id="@+id/needs_upgrade_view"
                 style="@style/FxAccountTextItem"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"

--- a/strings/strings.xml.in
+++ b/strings/strings.xml.in
@@ -141,7 +141,6 @@
   <string name="fxaccount_mail_contentDescription">&fxaccount.mail.contentDescription;</string>
   <string name="fxaccount_confirmation_email_sent">&fxaccount.confirmation.email.sent;</string>
   <string name="fxaccount_password_length_restriction">&fxaccount.password.length.restriction;</string>
-  <string name="fxaccount_change_password">&fxaccount.change.password;</string>
   <string name="fxaccount_status_needs_upgrade">You need to upgrade Firefox to log in to this account.</string>
   <string name="fxaccount_status_needs_verification">&fxaccount.status.needs.verification;</string>
   <string name="fxaccount_status_needs_credentials">&fxaccount.status.needs.credentials;</string>

--- a/strings/sync_strings.dtd.in
+++ b/strings/sync_strings.dtd.in
@@ -148,7 +148,6 @@
 <!ENTITY fxaccount.confirmation.description 'Your confirmation link awaits at:'>
 <!ENTITY fxaccount.offer.resend.confirmation.email 'Don\&apos;t see an email? Resend.'>
 <!ENTITY fxaccount.password.length.restriction 'Must be at least 8 characters.'>
-<!ENTITY fxaccount.change.password 'Change password'>
 <!ENTITY fxaccount.status.needs.verification 'Your account needs to be verified. Tap here to verify and start syncing.'>
 <!ENTITY fxaccount.status.needs.credentials 'Your account details are out of date. Tap here to sign in again and resume syncing.'>
 <!ENTITY fxaccount.status.syncing 'Firefox is syncing...'>


### PR DESCRIPTION
We're not shipping native client change password for Firefox 29.
