### PR TITLE
Bug 969227 - Handle X-Backoff headers

### DIFF
--- a/src/main/java/org/mozilla/gecko/fxa/sync/FxAccountSyncAdapter.java
+++ b/src/main/java/org/mozilla/gecko/fxa/sync/FxAccountSyncAdapter.java
@@ -265,6 +265,10 @@ public class FxAccountSyncAdapter extends AbstractThreadedSyncAdapter {
         Logger.error(LOG_TAG, "Failed to get token.", e);
         callback.handleError(null, e);
       }
+
+      @Override
+      public void handleBackoff(int backoffSeconds) {
+      }
     });
   }
 

--- a/src/main/java/org/mozilla/gecko/sync/net/SyncResponse.java
+++ b/src/main/java/org/mozilla/gecko/sync/net/SyncResponse.java
@@ -49,6 +49,20 @@ public class SyncResponse {
     return this.getStatusCode() == 200;
   }
 
+  /**
+   * Fetch the content type of the HTTP response body.
+   *
+   * @return a <code>Header</code> instance, or <code>null</code> if there was
+   *         no body or no valid Content-Type.
+   */
+  public Header getContentType() {
+    HttpEntity entity = this.response.getEntity();
+    if (entity == null) {
+      return null;
+    }
+    return entity.getContentType();
+  }
+
   private String body = null;
   public String body() throws IllegalStateException, IOException {
     if (body != null) {

--- a/src/main/java/org/mozilla/gecko/sync/net/SyncStorageRecordRequest.java
+++ b/src/main/java/org/mozilla/gecko/sync/net/SyncStorageRecordRequest.java
@@ -25,6 +25,7 @@ import org.mozilla.gecko.sync.ThreadPool;
  * * Headers:
  *   * Retry-After
  *   * X-Weave-Backoff
+ *   * X-Backoff
  *   * X-Weave-Records?
  *   * ...
  * * Timeouts

--- a/src/main/java/org/mozilla/gecko/tokenserver/TokenServerClient.java
+++ b/src/main/java/org/mozilla/gecko/tokenserver/TokenServerClient.java
@@ -94,6 +94,19 @@ public class TokenServerClient {
     });
   }
 
+  /**
+   * Notify the delegate that some kind of backoff header (X-Backoff,
+   * X-Weave-Backoff, Retry-After) was received and should be acted upon.
+   *
+   * This method is non-terminal, and will be followed by a separate
+   * <code>invoke*</code> call.
+   *
+   * @param delegate
+   *          the delegate to inform.
+   * @param backoffSeconds
+   *          the number of seconds for which the system should wait before
+   *          making another token server request to this server.
+   */
   protected void notifyBackoff(final TokenServerClientDelegate delegate, final int backoffSeconds) {
     executor.execute(new Runnable() {
       @Override

--- a/src/main/java/org/mozilla/gecko/tokenserver/TokenServerClient.java
+++ b/src/main/java/org/mozilla/gecko/tokenserver/TokenServerClient.java
@@ -93,6 +93,15 @@ public class TokenServerClient {
     });
   }
 
+  protected void invokeHandleBackoff(final TokenServerClientDelegate delegate, final int backoffSeconds) {
+    executor.execute(new Runnable() {
+      @Override
+      public void run() {
+        delegate.handleBackoff(backoffSeconds);
+      }
+    });
+  }
+
   protected void invokeHandleError(final TokenServerClientDelegate delegate, final Exception e) {
     executor.execute(new Runnable() {
       @Override

--- a/src/main/java/org/mozilla/gecko/tokenserver/TokenServerClientDelegate.java
+++ b/src/main/java/org/mozilla/gecko/tokenserver/TokenServerClientDelegate.java
@@ -8,5 +8,9 @@ public interface TokenServerClientDelegate {
   void handleSuccess(TokenServerToken token);
   void handleFailure(TokenServerException e);
   void handleError(Exception e);
+
+  /**
+   * Might be called multiple times, in addition to the other terminating handler methods.
+   */
   void handleBackoff(int backoffSeconds);
 }

--- a/src/main/java/org/mozilla/gecko/tokenserver/TokenServerClientDelegate.java
+++ b/src/main/java/org/mozilla/gecko/tokenserver/TokenServerClientDelegate.java
@@ -4,9 +4,9 @@
 
 package org.mozilla.gecko.tokenserver;
 
-
 public interface TokenServerClientDelegate {
   void handleSuccess(TokenServerToken token);
   void handleFailure(TokenServerException e);
   void handleError(Exception e);
+  void handleBackoff(int backoffSeconds);
 }

--- a/src/test/java/org/mozilla/android/sync/test/integration/TestFreshStart.java
+++ b/src/test/java/org/mozilla/android/sync/test/integration/TestFreshStart.java
@@ -89,6 +89,10 @@ public class TestFreshStart {
           public void handleError(Exception e) {
             WaitHelper.getTestWaiter().performNotify(e);
           }
+
+          @Override
+          public void handleBackoff(int backoffSeconds) {
+          }
         });
       }
     });

--- a/src/test/java/org/mozilla/gecko/tokenserver/test/TestLiveTokenServerClient.java
+++ b/src/test/java/org/mozilla/gecko/tokenserver/test/TestLiveTokenServerClient.java
@@ -112,6 +112,10 @@ public class TestLiveTokenServerClient {
           public void handleError(Exception e) {
             WaitHelper.getTestWaiter().performNotify(e);
           }
+
+          @Override
+          public void handleBackoff(int backoffSeconds) {
+          }
         });
       }
     };
@@ -148,6 +152,10 @@ public class TestLiveTokenServerClient {
           public void handleError(Exception e) {
             WaitHelper.getTestWaiter().performNotify(e);
           }
+
+          @Override
+          public void handleBackoff(int backoffSeconds) {
+          }
         });
       }
     });
@@ -181,6 +189,10 @@ public class TestLiveTokenServerClient {
           @Override
           public void handleError(Exception e) {
             WaitHelper.getTestWaiter().performNotify(e);
+          }
+
+          @Override
+          public void handleBackoff(int backoffSeconds) {
           }
         });
       }

--- a/src/test/java/org/mozilla/gecko/tokenserver/test/TestTokenServerClient.java
+++ b/src/test/java/org/mozilla/gecko/tokenserver/test/TestTokenServerClient.java
@@ -21,6 +21,7 @@ import org.mozilla.gecko.background.common.log.writers.StringLogWriter;
 import org.mozilla.gecko.sync.ExtendedJSONObject;
 import org.mozilla.gecko.sync.net.AuthHeaderProvider;
 import org.mozilla.gecko.sync.net.BaseResource;
+import org.mozilla.gecko.sync.net.SyncResponse;
 import org.mozilla.gecko.tokenserver.TokenServerClient;
 import org.mozilla.gecko.tokenserver.TokenServerClientDelegate;
 import org.mozilla.gecko.tokenserver.TokenServerException;
@@ -75,7 +76,7 @@ public class TestTokenServerClient {
     stringEntity.setContentType(contentType);
     response.setEntity(stringEntity);
 
-    return client.processResponse(response);
+    return client.processResponse(new SyncResponse(response));
   }
 
   @SuppressWarnings("rawtypes")

--- a/src/test/java/org/mozilla/gecko/tokenserver/test/TestTokenServerClient.java
+++ b/src/test/java/org/mozilla/gecko/tokenserver/test/TestTokenServerClient.java
@@ -209,6 +209,10 @@ public class TestTokenServerClient {
       @Override
       public void handleError(Exception e) {
       }
+
+      @Override
+      public void handleBackoff(int backoffSeconds) {
+      }
     };
 
     resource.delegate = new TokenServerClient.TokenFetchResourceDelegate(client, resource, delegate, assertion, clientState , true) {


### PR DESCRIPTION
This is the token server client part. The rest comes in the full backoff/scheduling branch (rnewman/periodic).
