### PR TITLE
Bug 983856 - Message when syncing is disabled by Android.

### DIFF
--- a/res/xml/fxaccount_status_prefscreen.xml
+++ b/res/xml/fxaccount_status_prefscreen.xml
@@ -35,6 +35,20 @@
             android:layout="@layout/fxaccount_status_error_preference"
             android:persistent="false"
             android:title="@string/fxaccount_status_needs_verification" />
+        <Preference
+            android:editable="false"
+            android:icon="@drawable/fxaccount_sync_error"
+            android:key="needs_master_sync_automatically_enabled"
+            android:layout="@layout/fxaccount_status_error_preference"
+            android:persistent="false"
+            android:title="@string/fxaccount_status_needs_master_sync_automatically_enabled" />
+        <Preference
+            android:editable="false"
+            android:icon="@drawable/fxaccount_sync_error"
+            android:key="needs_account_enabled"
+            android:layout="@layout/fxaccount_status_error_preference"
+            android:persistent="false"
+            android:title="@string/fxaccount_status_needs_account_enabled" />
 
         <CheckBoxPreference
             android:key="bookmarks"

--- a/src/main/java/org/mozilla/gecko/fxa/activities/FxAccountStatusFragment.java
+++ b/src/main/java/org/mozilla/gecko/fxa/activities/FxAccountStatusFragment.java
@@ -17,6 +17,7 @@ import org.mozilla.gecko.fxa.authenticator.AndroidFxAccount;
 import org.mozilla.gecko.fxa.login.Married;
 import org.mozilla.gecko.fxa.login.State;
 import org.mozilla.gecko.sync.SyncConfiguration;
+import org.mozilla.gecko.sync.Utils;
 
 import android.content.ContentResolver;
 import android.content.Intent;
@@ -51,6 +52,8 @@ public class FxAccountStatusFragment extends PreferenceFragment implements OnPre
   protected Preference needsPasswordPreference;
   protected Preference needsUpgradePreference;
   protected Preference needsVerificationPreference;
+  protected Preference needsMasterSyncAutomaticallyEnabledPreference;
+  protected Preference needsAccountEnabledPreference;
 
   protected PreferenceCategory syncCategory;
 
@@ -87,6 +90,8 @@ public class FxAccountStatusFragment extends PreferenceFragment implements OnPre
     needsPasswordPreference = ensureFindPreference("needs_credentials");
     needsUpgradePreference = ensureFindPreference("needs_upgrade");
     needsVerificationPreference = ensureFindPreference("needs_verification");
+    needsMasterSyncAutomaticallyEnabledPreference = ensureFindPreference("needs_master_sync_automatically_enabled");
+    needsAccountEnabledPreference = ensureFindPreference("needs_account_enabled");
 
     syncCategory = (PreferenceCategory) ensureFindPreference("sync_category");
 
@@ -103,6 +108,7 @@ public class FxAccountStatusFragment extends PreferenceFragment implements OnPre
 
     needsPasswordPreference.setOnPreferenceClickListener(this);
     needsVerificationPreference.setOnPreferenceClickListener(this);
+    needsAccountEnabledPreference.setOnPreferenceClickListener(this);
 
     bookmarksPreference.setOnPreferenceClickListener(this);
     historyPreference.setOnPreferenceClickListener(this);
@@ -143,6 +149,13 @@ public class FxAccountStatusFragment extends PreferenceFragment implements OnPre
       return true;
     }
 
+    if (preference == needsAccountEnabledPreference) {
+      fxAccount.enableSyncing();
+      refresh();
+
+      return true;
+    }
+
     if (preference == bookmarksPreference ||
         preference == historyPreference ||
         preference == passwordsPreference ||
@@ -171,7 +184,10 @@ public class FxAccountStatusFragment extends PreferenceFragment implements OnPre
     final Preference[] errorPreferences = new Preference[] {
         this.needsPasswordPreference,
         this.needsUpgradePreference,
-        this.needsVerificationPreference };
+        this.needsVerificationPreference,
+        this.needsMasterSyncAutomaticallyEnabledPreference,
+        this.needsAccountEnabledPreference,
+    };
     for (Preference errorPreference : errorPreferences) {
       final boolean currentlyShown = null != findPreference(errorPreference.getKey());
       final boolean shouldBeShown = errorPreference == errorPreferenceToShow;
@@ -201,6 +217,18 @@ public class FxAccountStatusFragment extends PreferenceFragment implements OnPre
   protected void showNeedsVerification() {
     syncCategory.setTitle(R.string.fxaccount_status_sync);
     showOnlyOneErrorPreference(needsVerificationPreference);
+    setCheckboxesEnabled(false);
+  }
+
+  protected void showNeedsMasterSyncAutomaticallyEnabled() {
+    syncCategory.setTitle(R.string.fxaccount_status_sync);
+    showOnlyOneErrorPreference(needsMasterSyncAutomaticallyEnabledPreference);
+    setCheckboxesEnabled(false);
+  }
+
+  protected void showNeedsAccountEnabled() {
+    syncCategory.setTitle(R.string.fxaccount_status_sync);
+    showOnlyOneErrorPreference(needsAccountEnabledPreference);
     setCheckboxesEnabled(false);
   }
 
@@ -245,23 +273,49 @@ public class FxAccountStatusFragment extends PreferenceFragment implements OnPre
 
     emailPreference.setTitle(fxAccount.getEmail());
 
-    // Interrogate the Firefox Account's state.
-    State state = fxAccount.getState();
-    switch (state.getNeededAction()) {
-    case NeedsUpgrade:
-      showNeedsUpgrade();
-      break;
-    case NeedsPassword:
-      showNeedsPassword();
-      break;
-    case NeedsVerification:
-      showNeedsVerification();
-      break;
-    default:
-      showConnected();
-    }
+    try {
+      // There are error states determined by Android, not the login state
+      // machine, and we have a chance to present these states here.  We handle
+      // them specially, since we can't surface these states as part of syncing,
+      // because they generally stop syncs from happening regularly.
 
-    updateSelectedEngines();
+      // The action to enable syncing the Firefox Account doesn't require
+      // leaving this activity, so let's present it first.
+      final boolean isSyncing = fxAccount.isSyncing();
+      if (!isSyncing) {
+        showNeedsAccountEnabled();
+        return;
+      }
+
+      // Interrogate the Firefox Account's state.
+      State state = fxAccount.getState();
+      switch (state.getNeededAction()) {
+      case NeedsUpgrade:
+        showNeedsUpgrade();
+        break;
+      case NeedsPassword:
+        showNeedsPassword();
+        break;
+      case NeedsVerification:
+        showNeedsVerification();
+        break;
+      default:
+        showConnected();
+      }
+
+      // We check for the master setting last, since it is not strictly
+      // necessary for the user to address this error state: it's really a
+      // warning state. We surface it for the user's convenience, and to prevent
+      // confused folks wondering why Sync is not working at all.
+      final boolean masterSyncAutomatically = ContentResolver.getMasterSyncAutomatically();
+      if (!masterSyncAutomatically) {
+        showNeedsMasterSyncAutomaticallyEnabled();
+        return;
+      }
+    } finally {
+      // No matter our state, we should update the checkboxes.
+      updateSelectedEngines();
+    }
   }
 
   /**

--- a/src/main/java/org/mozilla/gecko/fxa/authenticator/AndroidFxAccount.java
+++ b/src/main/java/org/mozilla/gecko/fxa/authenticator/AndroidFxAccount.java
@@ -326,6 +326,14 @@ public class AndroidFxAccount {
     getSyncPrefs().edit().clear().commit();
   }
 
+  public boolean isSyncing() {
+    boolean isSyncEnabled = true;
+    for (String authority : new String[] { BrowserContract.AUTHORITY }) {
+      isSyncEnabled &= ContentResolver.getSyncAutomatically(account, authority);
+    }
+    return isSyncEnabled;
+  }
+
   public void enableSyncing() {
     Logger.info(LOG_TAG, "Disabling sync for account named like " + Utils.obfuscateEmail(getEmail()));
     for (String authority : new String[] { BrowserContract.AUTHORITY }) {

--- a/strings/strings.xml.in
+++ b/strings/strings.xml.in
@@ -172,6 +172,8 @@
 <string name="fxaccount_status_needs_verification">&fxaccount_status_needs_verification2;</string>
 <string name="fxaccount_status_needs_credentials">&fxaccount_status_needs_credentials;</string>
 <string name="fxaccount_status_needs_upgrade">&fxaccount_status_needs_upgrade;</string>
+<string name="fxaccount_status_needs_master_sync_automatically_enabled">&fxaccount_status_needs_master_sync_automatically_enabled;</string>
+<string name="fxaccount_status_needs_account_enabled">&fxaccount_status_needs_account_enabled;</string>
 <string name="fxaccount_status_bookmarks">&fxaccount_status_bookmarks;</string>
 <string name="fxaccount_status_history">&fxaccount_status_history;</string>
 <string name="fxaccount_status_passwords">&fxaccount_status_passwords;</string>

--- a/strings/sync_strings.dtd.in
+++ b/strings/sync_strings.dtd.in
@@ -178,6 +178,8 @@
 <!ENTITY fxaccount_status_needs_verification2 'Your account needs to be verified. Tap to resend verification email.'>
 <!ENTITY fxaccount_status_needs_credentials 'Cannot connect. Tap to sign in.'>
 <!ENTITY fxaccount_status_needs_upgrade 'You need to upgrade &brandShortName; to sign in.'>
+<!ENTITY fxaccount_status_needs_master_sync_automatically_enabled '&syncBrand.shortName.label; is set up, but not syncing automatically. Toggle “Auto-sync data” in Android Settings &gt; Data Usage.'>
+<!ENTITY fxaccount_status_needs_account_enabled '&syncBrand.shortName.label; is set up, but not syncing automatically. Tap to start syncing.'>
 <!ENTITY fxaccount_status_bookmarks 'Bookmarks'>
 <!ENTITY fxaccount_status_history 'History'>
 <!ENTITY fxaccount_status_passwords 'Passwords'>


### PR DESCRIPTION
This shows two new "error" (really, warning) states.  Both are shown
when the Firefox Account is correctly configured, and ready to sync, but
Android is preventing syncing automatically for some reason.  The first
is when Android is not syncing _any_ Account
automatically (getMasterSyncAutomatically is false); the second is when
Android is not syncing *this Account
automatically (getSyncAutomatically) is false.
