### PR TITLE
Bug 983350 - Follow-up: Rev User-Agent string.

### DIFF
--- a/src/main/java/org/mozilla/gecko/background/healthreport/HealthReportConstants.java.in
+++ b/src/main/java/org/mozilla/gecko/background/healthreport/HealthReportConstants.java.in
@@ -11,7 +11,7 @@ public class HealthReportConstants {
   public static final String HEALTH_AUTHORITY = "@ANDROID_PACKAGE_NAME@.health";
   public static final String GLOBAL_LOG_TAG = "GeckoHealth";
 
-  public static final String USER_AGENT = "Firefox-Android-HealthReport/ (" + GlobalConstants.MOZ_APP_DISPLAYNAME + " " + GlobalConstants.MOZ_APP_VERSION + ")";
+  public static final String USER_AGENT = "Firefox-Android-HealthReport/" + GlobalConstants.MOZ_APP_VERSION + " (" + GlobalConstants.MOZ_APP_DISPLAYNAME + ")";
 
   /**
    * The earliest allowable value for the last ping time, corresponding to May 2nd 2013.

--- a/src/main/java/org/mozilla/gecko/fxa/FxAccountConstants.java.in
+++ b/src/main/java/org/mozilla/gecko/fxa/FxAccountConstants.java.in
@@ -33,7 +33,7 @@ public class FxAccountConstants {
   // You must wait 15 minutes after failing an age check before trying to create a different account.
   public static final long MINIMUM_TIME_TO_WAIT_AFTER_AGE_CHECK_FAILED_IN_MILLISECONDS = 15 * 60 * 1000;
 
-  public static final String USER_AGENT = "Firefox-Android-FxAccounts/ (" + GlobalConstants.MOZ_APP_DISPLAYNAME + " " + GlobalConstants.MOZ_APP_VERSION + ")";
+  public static final String USER_AGENT = "Firefox-Android-FxAccounts/" + GlobalConstants.MOZ_APP_VERSION + " (" + GlobalConstants.MOZ_APP_DISPLAYNAME + ")";
 
   public static final String ACCOUNT_PICKLE_FILENAME = "fxa.account.json";
 

--- a/src/test/java/org/mozilla/gecko/sync/net/test/TestUserAgentHeaders.java
+++ b/src/test/java/org/mozilla/gecko/sync/net/test/TestUserAgentHeaders.java
@@ -96,7 +96,11 @@ public class TestUserAgentHeaders {
       }
     });
 
+    // Verify that we're getting the value from the correct place.
     Assert.assertEquals(SyncConstants.USER_AGENT, userAgentServer.lastUserAgent);
+    // And that the value is correct. This is fragile, but better than breaking
+    // our header and not discovering until too late.
+    Assert.assertEquals("Firefox AndroidSync 1.24.0a1.0 (FxSync)", userAgentServer.lastUserAgent);
   }
 
   @Test
@@ -124,6 +128,10 @@ public class TestUserAgentHeaders {
       }
     });
 
+    // Verify that we're getting the value from the correct place.
     Assert.assertEquals(FxAccountConstants.USER_AGENT, userAgentServer.lastUserAgent);
+    // And that the value is correct. This is fragile, but better than breaking
+    // our header and not discovering until too late.
+    Assert.assertEquals("Firefox-Android-FxAccounts/24.0a1 (FxSync)", userAgentServer.lastUserAgent);
   }
 }


### PR DESCRIPTION
This replaces

Firefox-Android-FxAccounts/ (Nightly 31.0a1)

with

Firefox-Android-FxAccounts/31.0a1 (Nightly)
