### PR TITLE
Bug 788688 - set client device name

### DIFF
--- a/res/xml/fxaccount_status_prefscreen.xml
+++ b/res/xml/fxaccount_status_prefscreen.xml
@@ -12,6 +12,15 @@
             android:title="@string/fxaccount_email_hint" />
     </PreferenceCategory>
     <PreferenceCategory
+        android:key="device_name_category"
+        android:title="@string/fxaccount_status_device_name" >
+        <EditTextPreference
+            android:singleLine="true"
+            android:key="device_name"
+            android:persistent="false"
+            android:title="" />
+    </PreferenceCategory>
+    <PreferenceCategory
         android:key="sync_category"
         android:title="@string/fxaccount_status_sync" >
         <Preference

--- a/src/main/java/org/mozilla/gecko/background/testhelpers/MockClientsDataDelegate.java
+++ b/src/main/java/org/mozilla/gecko/background/testhelpers/MockClientsDataDelegate.java
@@ -10,6 +10,7 @@ public class MockClientsDataDelegate implements ClientsDataDelegate {
   private String accountGUID;
   private String clientName;
   private int clientsCount;
+  private long clientDataTimestamp = 0;
 
   @Override
   public synchronized String getAccountGUID() {
@@ -20,9 +21,20 @@ public class MockClientsDataDelegate implements ClientsDataDelegate {
   }
 
   @Override
+  public synchronized String getDefaultClientName() {
+    return "Default client";
+  }
+
+  @Override
+  public synchronized void setClientName(String clientName) {
+    this.clientName = clientName;
+    this.clientDataTimestamp = System.currentTimeMillis();
+  }
+
+  @Override
   public synchronized String getClientName() {
     if (clientName == null) {
-      clientName = "Default Name";
+      setClientName(getDefaultClientName());
     }
     return clientName;
   }
@@ -38,7 +50,12 @@ public class MockClientsDataDelegate implements ClientsDataDelegate {
   }
 
   @Override
-  public boolean isLocalGUID(String guid) {
+  public synchronized boolean isLocalGUID(String guid) {
     return getAccountGUID().equals(guid);
+  }
+
+  @Override
+  public synchronized long getLastModifiedTimestamp() {
+    return clientDataTimestamp;
   }
 }

--- a/src/main/java/org/mozilla/gecko/fxa/activities/FxAccountGetStartedActivity.java
+++ b/src/main/java/org/mozilla/gecko/fxa/activities/FxAccountGetStartedActivity.java
@@ -6,13 +6,11 @@ package org.mozilla.gecko.fxa.activities;
 
 import java.util.Locale;
 
-import org.mozilla.gecko.AppConstants;
 import org.mozilla.gecko.R;
 import org.mozilla.gecko.background.common.log.Logger;
 import org.mozilla.gecko.background.fxa.FxAccountAgeLockoutHelper;
 import org.mozilla.gecko.fxa.FirefoxAccounts;
 import org.mozilla.gecko.fxa.FxAccountConstants;
-import org.mozilla.gecko.sync.Utils;
 import org.mozilla.gecko.sync.setup.activities.ActivityUtils;
 import org.mozilla.gecko.sync.setup.activities.LocaleAware;
 

--- a/src/main/java/org/mozilla/gecko/fxa/activities/FxAccountStatusFragment.java
+++ b/src/main/java/org/mozilla/gecko/fxa/activities/FxAccountStatusFragment.java
@@ -346,14 +346,17 @@ public class FxAccountStatusFragment
     FxAccountSyncStatusHelper.getInstance().stopObserving(syncStatusDelegate);
   }
 
-  protected void refresh() {
+  protected void hardRefresh() {
     // This is the only way to guarantee that the EditText dialogs created by
     // EditTextPreferences are re-created. This works around the issue described
     // at http://androiddev.orkitra.com/?p=112079.
     final PreferenceScreen statusScreen = (PreferenceScreen) ensureFindPreference("status_screen");
     statusScreen.removeAll();
     addPreferences();
+    refresh();
+  }
 
+  protected void refresh() {
     // refresh is called from our onResume, which can happen before the owning
     // Activity tells us about an account (via our public
     // refresh(AndroidFxAccount) method).

--- a/src/main/java/org/mozilla/gecko/fxa/activities/FxAccountStatusFragment.java
+++ b/src/main/java/org/mozilla/gecko/fxa/activities/FxAccountStatusFragment.java
@@ -18,6 +18,7 @@ import org.mozilla.gecko.fxa.login.Married;
 import org.mozilla.gecko.fxa.login.State;
 import org.mozilla.gecko.fxa.sync.FxAccountSyncStatusHelper;
 import org.mozilla.gecko.fxa.tasks.FxAccountCodeResender;
+import org.mozilla.gecko.sync.SharedPreferencesClientsDataDelegate;
 import org.mozilla.gecko.sync.SyncConfiguration;
 
 import android.accounts.Account;
@@ -28,7 +29,9 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.Handler;
 import android.preference.CheckBoxPreference;
+import android.preference.EditTextPreference;
 import android.preference.Preference;
+import android.preference.Preference.OnPreferenceChangeListener;
 import android.preference.Preference.OnPreferenceClickListener;
 import android.preference.PreferenceCategory;
 import android.preference.PreferenceScreen;
@@ -39,7 +42,9 @@ import android.preference.PreferenceScreen;
  * The owning activity is responsible for providing an AndroidFxAccount at
  * appropriate times.
  */
-public class FxAccountStatusFragment extends PreferenceFragment implements OnPreferenceClickListener {
+public class FxAccountStatusFragment
+    extends PreferenceFragment
+    implements OnPreferenceClickListener, OnPreferenceChangeListener {
   private static final String LOG_TAG = FxAccountStatusFragment.class.getSimpleName();
 
   // When a checkbox is toggled, wait 5 seconds (for other checkbox actions)
@@ -65,7 +70,12 @@ public class FxAccountStatusFragment extends PreferenceFragment implements OnPre
   protected CheckBoxPreference tabsPreference;
   protected CheckBoxPreference passwordsPreference;
 
+  protected EditTextPreference deviceNamePreference;
+
   protected volatile AndroidFxAccount fxAccount;
+  // The contract is: when fxAccount is non-null, then clientsDataDelegate is
+  // non-null.
+  protected volatile SharedPreferencesClientsDataDelegate clientsDataDelegate;
 
   // Used to post delayed sync requests.
   protected Handler handler;
@@ -88,6 +98,10 @@ public class FxAccountStatusFragment extends PreferenceFragment implements OnPre
   @Override
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
+    addPreferences();
+  }
+
+  protected void addPreferences() {
     addPreferencesFromResource(R.xml.fxaccount_status_prefscreen);
 
     emailPreference = ensureFindPreference("email");
@@ -119,6 +133,9 @@ public class FxAccountStatusFragment extends PreferenceFragment implements OnPre
     historyPreference.setOnPreferenceClickListener(this);
     tabsPreference.setOnPreferenceClickListener(this);
     passwordsPreference.setOnPreferenceClickListener(this);
+
+    deviceNamePreference = (EditTextPreference) ensureFindPreference("device_name");
+    deviceNamePreference.setOnPreferenceChangeListener(this);
   }
 
   /**
@@ -177,6 +194,8 @@ public class FxAccountStatusFragment extends PreferenceFragment implements OnPre
     historyPreference.setEnabled(enabled);
     tabsPreference.setEnabled(enabled);
     passwordsPreference.setEnabled(enabled);
+    // Since we can't sync, we can't update our remote client record.
+    deviceNamePreference.setEnabled(enabled);
   }
 
   /**
@@ -294,6 +313,14 @@ public class FxAccountStatusFragment extends PreferenceFragment implements OnPre
       throw new IllegalArgumentException("fxAccount must not be null");
     }
     this.fxAccount = fxAccount;
+    try {
+      this.clientsDataDelegate = new SharedPreferencesClientsDataDelegate(fxAccount.getSyncPrefs());
+    } catch (Exception e) {
+      Logger.error(LOG_TAG, "Got exception fetching Sync prefs associated to Firefox Account; aborting.", e);
+      // Something is terribly wrong; best to get a stack trace rather than
+      // continue with a null clients delegate.
+      throw new IllegalStateException(e);
+    }
 
     handler = new Handler(); // Attached to current (assumed to be UI) thread.
 
@@ -320,6 +347,13 @@ public class FxAccountStatusFragment extends PreferenceFragment implements OnPre
   }
 
   protected void refresh() {
+    // This is the only way to guarantee that the EditText dialogs created by
+    // EditTextPreferences are re-created. This works around the issue described
+    // at http://androiddev.orkitra.com/?p=112079.
+    final PreferenceScreen statusScreen = (PreferenceScreen) ensureFindPreference("status_screen");
+    statusScreen.removeAll();
+    addPreferences();
+
     // refresh is called from our onResume, which can happen before the owning
     // Activity tells us about an account (via our public
     // refresh(AndroidFxAccount) method).
@@ -372,6 +406,10 @@ public class FxAccountStatusFragment extends PreferenceFragment implements OnPre
       // No matter our state, we should update the checkboxes.
       updateSelectedEngines();
     }
+
+    final String clientName = clientsDataDelegate.getClientName();
+    deviceNamePreference.setTitle(clientName);
+    deviceNamePreference.setText(clientName);
   }
 
   /**
@@ -570,5 +608,22 @@ public class FxAccountStatusFragment extends PreferenceFragment implements OnPre
       button.setTitle(debugKey); // Not very friendly, but this is for debugging only!
       button.setOnPreferenceClickListener(listener);
     }
+  }
+
+  @Override
+  public boolean onPreferenceChange(Preference preference, Object newValue) {
+    if (preference == deviceNamePreference) {
+      String newClientName = (String) newValue;
+      if (newClientName == null || newClientName.length() < 1) {
+        newClientName = clientsDataDelegate.getDefaultClientName();
+      }
+      clientsDataDelegate.setClientName(newClientName);
+      requestDelayedSync(); // Try to update our remote client record.
+      refresh(); // Updates the value displayed to the user, among other things.
+      return true;
+    }
+
+    // For everything else, accept the change.
+    return true;
   }
 }

--- a/src/main/java/org/mozilla/gecko/fxa/sync/FxAccountSyncAdapter.java
+++ b/src/main/java/org/mozilla/gecko/fxa/sync/FxAccountSyncAdapter.java
@@ -357,7 +357,11 @@ public class FxAccountSyncAdapter extends AbstractThreadedSyncAdapter {
 
         FxAccountGlobalSession globalSession = null;
         try {
-          ClientsDataDelegate clientsDataDelegate = new SharedPreferencesClientsDataDelegate(sharedPrefs);
+          final ClientsDataDelegate clientsDataDelegate = new SharedPreferencesClientsDataDelegate(sharedPrefs);
+          if (FxAccountConstants.LOG_PERSONAL_INFORMATION) {
+            FxAccountConstants.pii(LOG_TAG, "Client device name is: '" + clientsDataDelegate.getClientName() + "'.");
+            FxAccountConstants.pii(LOG_TAG, "Client device data last modified: " + clientsDataDelegate.getLastModifiedTimestamp());
+          }
 
           // We compute skew over time using SkewHandler. This yields an unchanging
           // skew adjustment that the HawkAuthHeaderProvider uses to adjust its

--- a/src/main/java/org/mozilla/gecko/sync/SharedPreferencesClientsDataDelegate.java
+++ b/src/main/java/org/mozilla/gecko/sync/SharedPreferencesClientsDataDelegate.java
@@ -30,12 +30,32 @@ public class SharedPreferencesClientsDataDelegate implements ClientsDataDelegate
     return accountGUID;
   }
 
+  /**
+   * Set client name.
+   *
+   * @param clientName to change to.
+   */
+  @Override
+  public synchronized void setClientName(String clientName) {
+    sharedPreferences
+      .edit()
+      .putString(SyncConfiguration.PREF_CLIENT_NAME, clientName)
+      .putLong(SyncConfiguration.PREF_CLIENT_DATA_TIMESTAMP, System.currentTimeMillis())
+      .commit();
+  }
+
+  @Override
+  public String getDefaultClientName() {
+    // XXX localize this string!
+    return GlobalConstants.MOZ_APP_DISPLAYNAME + " on " + android.os.Build.MODEL;
+  }
+
   @Override
   public synchronized String getClientName() {
     String clientName = sharedPreferences.getString(SyncConfiguration.PREF_CLIENT_NAME, null);
     if (clientName == null) {
-      clientName = GlobalConstants.MOZ_APP_DISPLAYNAME + " on " + android.os.Build.MODEL;
-      sharedPreferences.edit().putString(SyncConfiguration.PREF_CLIENT_NAME, clientName).commit();
+      clientName = getDefaultClientName();
+      setClientName(clientName);
     }
     return clientName;
   }
@@ -53,5 +73,10 @@ public class SharedPreferencesClientsDataDelegate implements ClientsDataDelegate
   @Override
   public synchronized int getClientsCount() {
     return (int) sharedPreferences.getLong(SyncConfiguration.PREF_NUM_CLIENTS, 0);
+  }
+
+  @Override
+  public long getLastModifiedTimestamp() {
+    return sharedPreferences.getLong(SyncConfiguration.PREF_CLIENT_DATA_TIMESTAMP, 0);
   }
 }

--- a/src/main/java/org/mozilla/gecko/sync/SyncConfiguration.java
+++ b/src/main/java/org/mozilla/gecko/sync/SyncConfiguration.java
@@ -258,6 +258,7 @@ public class SyncConfiguration {
   public static final String PREF_ACCOUNT_GUID = "account.guid";
   public static final String PREF_CLIENT_NAME = "account.clientName";
   public static final String PREF_NUM_CLIENTS = "account.numClients";
+  public static final String PREF_CLIENT_DATA_TIMESTAMP = "account.clientDataTimestamp";
 
   private static final String API_VERSION = "1.5";
 

--- a/src/main/java/org/mozilla/gecko/sync/delegates/ClientsDataDelegate.java
+++ b/src/main/java/org/mozilla/gecko/sync/delegates/ClientsDataDelegate.java
@@ -6,8 +6,22 @@ package org.mozilla.gecko.sync.delegates;
 
 public interface ClientsDataDelegate {
   public String getAccountGUID();
+  public String getDefaultClientName();
+  public void setClientName(String clientName);
   public String getClientName();
   public void setClientsCount(int clientsCount);
   public int getClientsCount();
   public boolean isLocalGUID(String guid);
+
+  /**
+   * The last time the client's data was modified in a way that should be
+   * reflected remotely.
+   * <p>
+   * Changing the client's name should be reflected remotely, while changing the
+   * clients count should not (since that data is only used to inform local
+   * policy.)
+   *
+   * @return timestamp in milliseconds.
+   */
+  public long getLastModifiedTimestamp();
 }

--- a/src/main/java/org/mozilla/gecko/sync/setup/activities/SendTabActivity.java
+++ b/src/main/java/org/mozilla/gecko/sync/setup/activities/SendTabActivity.java
@@ -25,12 +25,9 @@ import org.mozilla.gecko.sync.SyncConfiguration;
 import org.mozilla.gecko.sync.SyncConstants;
 import org.mozilla.gecko.sync.repositories.NullCursorException;
 import org.mozilla.gecko.sync.repositories.android.ClientsDatabaseAccessor;
-import org.mozilla.gecko.sync.repositories.android.FennecTabsRepository;
-import org.mozilla.gecko.sync.repositories.android.FennecTabsRepository.FennecTabsRepositorySession;
 import org.mozilla.gecko.sync.repositories.domain.ClientRecord;
 import org.mozilla.gecko.sync.setup.SyncAccounts;
 import org.mozilla.gecko.sync.setup.activities.LocaleAware.LocaleAwareActivity;
-import org.mozilla.gecko.sync.stage.SyncClientsEngineStage;
 import org.mozilla.gecko.sync.syncadapter.SyncAdapter;
 
 import android.accounts.Account;

--- a/src/main/java/org/mozilla/gecko/sync/stage/FennecTabsServerSyncStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/FennecTabsServerSyncStage.java
@@ -4,7 +4,6 @@
 
 package org.mozilla.gecko.sync.stage;
 
-import org.mozilla.gecko.sync.delegates.ClientsDataDelegate;
 import org.mozilla.gecko.sync.repositories.RecordFactory;
 import org.mozilla.gecko.sync.repositories.Repository;
 import org.mozilla.gecko.sync.repositories.android.FennecTabsRepository;
@@ -31,8 +30,7 @@ public class FennecTabsServerSyncStage extends ServerSyncStage {
 
   @Override
   protected Repository getLocalRepository() {
-    final ClientsDataDelegate clientsDelegate = session.getClientsDelegate();
-    return new FennecTabsRepository(clientsDelegate.getClientName(), clientsDelegate.getAccountGUID());
+    return new FennecTabsRepository(session.getClientsDelegate());
   }
 
   @Override

--- a/src/main/java/org/mozilla/gecko/sync/stage/SyncClientsEngineStage.java
+++ b/src/main/java/org/mozilla/gecko/sync/stage/SyncClientsEngineStage.java
@@ -397,6 +397,11 @@ public class SyncClientsEngineStage extends AbstractSessionManagingSyncStage {
       return true;
     }
 
+    if (session.getClientsDelegate().getLastModifiedTimestamp() > lastUpload) {
+      // Something's changed locally since we last uploaded.
+      return true;
+    }
+
     // Note the opportunity for clock drift problems here.
     // TODO: if we track download times, we can use the timestamp of most
     // recent download response instead of the current time.

--- a/src/test/java/org/mozilla/android/sync/net/test/TestClientsEngineStage.java
+++ b/src/test/java/org/mozilla/android/sync/net/test/TestClientsEngineStage.java
@@ -170,7 +170,7 @@ public class TestClientsEngineStage extends MockSyncClientsEngineStage {
 
   public static class MockClientsGlobalSession extends MockGlobalSession {
     private ClientsDataDelegate clientsDataDelegate = new MockClientsDataDelegate();
-  
+
     public MockClientsGlobalSession(SyncConfiguration config,
                                     GlobalSessionCallback callback)
         throws SyncConfigurationException,
@@ -180,7 +180,7 @@ public class TestClientsEngineStage extends MockSyncClientsEngineStage {
                NonObjectJSONException {
       super(config, callback);
     }
-  
+
     @Override
     public ClientsDataDelegate getClientsDelegate() {
       return clientsDataDelegate;
@@ -779,5 +779,19 @@ public class TestClientsEngineStage extends MockSyncClientsEngineStage {
     assertEquals(4, recordToUpload.commands.size());
     assertEquals(expectedGUID, recordToUpload.guid);
     assertEquals("12a1", recordToUpload.version);
+  }
+
+  @Test
+  public void testLastModifiedTimestamp() throws NullCursorException {
+    // If we uploaded a record a moment ago, we shouldn't upload another.
+    final long now = System.currentTimeMillis() - 1;
+    session.config.persistServerClientRecordTimestamp(now);
+    assertEquals(now, session.config.getPersistedServerClientRecordTimestamp());
+    assertFalse(shouldUploadLocalRecord);
+    assertFalse(shouldUpload());
+
+    // But if we change our client data, we should upload.
+    session.getClientsDelegate().setClientName("new name");
+    assertTrue(shouldUpload());
   }
 }

--- a/strings/strings.xml.in
+++ b/strings/strings.xml.in
@@ -169,6 +169,7 @@
 <string name="fxaccount_status_activity_label">&syncBrand.shortName.label;</string>
 <string name="fxaccount_status_header">&fxaccount_status_header2;</string>
 <string name="fxaccount_status_signed_in_as">&fxaccount_status_signed_in_as;</string>
+<string name="fxaccount_status_device_name">&fxaccount_status_device_name;</string>
 <string name="fxaccount_status_sync">&fxaccount_status_sync;</string>
 <string name="fxaccount_status_sync_enabled">&fxaccount_status_sync_enabled;</string>
 <string name="fxaccount_status_needs_verification">&fxaccount_status_needs_verification2;</string>

--- a/strings/sync_strings.dtd.in
+++ b/strings/sync_strings.dtd.in
@@ -175,6 +175,7 @@
 
 <!ENTITY fxaccount_status_header2 'Firefox Account'>
 <!ENTITY fxaccount_status_signed_in_as 'Signed in as'>
+<!ENTITY fxaccount_status_device_name 'Device name'>
 <!ENTITY fxaccount_status_sync '&syncBrand.shortName.label;'>
 <!ENTITY fxaccount_status_sync_enabled '&syncBrand.shortName.label;: enabled'>
 <!ENTITY fxaccount_status_needs_verification2 'Your account needs to be verified. Tap to resend verification email.'>

--- a/test/src/org/mozilla/gecko/background/db/TestFennecTabsRepositorySession.java
+++ b/test/src/org/mozilla/gecko/background/db/TestFennecTabsRepositorySession.java
@@ -7,6 +7,7 @@ import org.json.simple.JSONArray;
 import org.mozilla.gecko.background.helpers.AndroidSyncTestCase;
 import org.mozilla.gecko.background.sync.helpers.ExpectFetchDelegate;
 import org.mozilla.gecko.background.sync.helpers.SessionTestHelper;
+import org.mozilla.gecko.background.testhelpers.MockClientsDataDelegate;
 import org.mozilla.gecko.db.BrowserContract;
 import org.mozilla.gecko.sync.repositories.NoContentProviderException;
 import org.mozilla.gecko.sync.repositories.RepositorySession;
@@ -24,8 +25,9 @@ import android.database.Cursor;
 import android.os.RemoteException;
 
 public class TestFennecTabsRepositorySession extends AndroidSyncTestCase {
-  public static final String TEST_CLIENT_GUID = "test guid"; // Real GUIDs never contain spaces.
-  public static final String TEST_CLIENT_NAME = "test client name";
+  public static final MockClientsDataDelegate clientsDataDelegate = new MockClientsDataDelegate();
+  public static final String TEST_CLIENT_GUID = clientsDataDelegate.getAccountGUID();
+  public static final String TEST_CLIENT_NAME = clientsDataDelegate.getClientName();
 
   // Override these to test against data that is not live.
   public static final String TEST_TABS_CLIENT_GUID_IS_LOCAL_SELECTION = BrowserContract.Tabs.CLIENT_GUID + " IS ?";
@@ -72,7 +74,7 @@ public class TestFennecTabsRepositorySession extends AndroidSyncTestCase {
      * Override this chain in order to avoid our test code having to create two
      * sessions all the time.
      */
-    return new FennecTabsRepository(TEST_CLIENT_NAME, TEST_CLIENT_GUID) {
+    return new FennecTabsRepository(clientsDataDelegate) {
       @Override
       public void createSession(RepositorySessionCreationDelegate delegate,
                                 Context context) {
@@ -197,8 +199,19 @@ public class TestFennecTabsRepositorySession extends AndroidSyncTestCase {
     // Not all tabs are modified after this, but the record should contain them all.
     performWait(fetchSinceRunnable(session, 1000, new Record[] { tabsRecord }));
 
-    // No tabs are modified after this, so we shouldn't get a record at all.
-    performWait(fetchSinceRunnable(session, 4000, new Record[] { }));
+    // No tabs are modified after this, but our client name has changed in the interim.
+    performWait(fetchSinceRunnable(session, 4000, new Record[] { tabsRecord }));
+
+    // No tabs are modified after this, and our client name hasn't changed, so
+    // we shouldn't get a record at all. Note: this runs after our static
+    // initializer that sets the client data timestamp.
+    final long now = System.currentTimeMillis();
+    performWait(fetchSinceRunnable(session, now, new Record[] { }));
+
+    // No tabs are modified after this, but our client name has changed, so
+    // again we get a record.
+    clientsDataDelegate.setClientName("new client name");
+    performWait(fetchSinceRunnable(session, now, new Record[] { tabsRecord }));
 
     session.abort();
   }


### PR DESCRIPTION
This ended up being more complicated than expected.  Pay particular attention to the Preferences hi-jinks; it's delicate.  I could see not worrying about this corner case if it caused problems in testing.  Observe also the less-than-general approach to force a clients and tabs upload on client name change.  An alternate route would be to invalidate timestamps, but that's really hacky when done from the Status activity.
