### PR TITLE
Bug 1022748 - use custom servers

### DIFF
--- a/src/main/java/org/mozilla/gecko/fxa/FxAccountConstants.java.in
+++ b/src/main/java/org/mozilla/gecko/fxa/FxAccountConstants.java.in
@@ -15,6 +15,7 @@ public class FxAccountConstants {
   public static final String DEFAULT_AUTH_SERVER_ENDPOINT = "https://api.accounts.firefox.com/v1";
   public static final String DEFAULT_TOKEN_SERVER_ENDPOINT = "https://token.services.mozilla.com/1.0/sync/1.5";
 
+  public static final String STAGE_AUTH_SERVER_ENDPOINT = "https://api-accounts.stage.mozaws.net/v1";
   public static final String STAGE_TOKEN_SERVER_ENDPOINT = "https://token.stage.mozaws.net/1.0/sync/1.5";
 
   // For extra debugging.  Not final so it can be changed from Fennec, or from

--- a/src/main/java/org/mozilla/gecko/fxa/activities/FxAccountCreateAccountActivity.java
+++ b/src/main/java/org/mozilla/gecko/fxa/activities/FxAccountCreateAccountActivity.java
@@ -89,32 +89,20 @@ public class FxAccountCreateAccountActivity extends FxAccountAbstractSetupActivi
     signInInsteadLink.setOnClickListener(new OnClickListener() {
       @Override
       public void onClick(View v) {
-        final String email = emailEdit.getText().toString();
-        final String password = passwordEdit.getText().toString();
-        doSigninInstead(email, password);
+        final Bundle extras = makeExtrasBundle(null, null);
+        startActivityInstead(FxAccountSignInActivity.class, CHILD_REQUEST_CODE, extras);
       }
     });
 
-    // Only set email/password in onCreate; we don't want to overwrite edited values onResume.
-    if (getIntent() != null && getIntent().getExtras() != null) {
-      Bundle bundle = getIntent().getExtras();
-      emailEdit.setText(bundle.getString("email"));
-      passwordEdit.setText(bundle.getString("password"));
-    }
+    updateFromIntentExtras();
   }
 
-  protected void doSigninInstead(final String email, final String password) {
-    Intent intent = new Intent(this, FxAccountSignInActivity.class);
-    if (email != null) {
-      intent.putExtra("email", email);
-    }
-    if (password != null) {
-      intent.putExtra("password", password);
-    }
-    // Per http://stackoverflow.com/a/8992365, this triggers a known bug with
-    // the soft keyboard not being shown for the started activity. Why, Android, why?
-    intent.setFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
-    startActivityForResult(intent, CHILD_REQUEST_CODE);
+  @Override
+  protected Bundle makeExtrasBundle(String email, String password) {
+    final Bundle extras = super.makeExtrasBundle(email, password);
+    final String year = yearEdit.getText().toString();
+    extras.putString("year", year);
+    return extras;
   }
 
   @Override
@@ -142,7 +130,9 @@ public class FxAccountCreateAccountActivity extends FxAccountAbstractSetupActivi
             email = emailEdit.getText().toString();
         }
         final String password = passwordEdit.getText().toString();
-        doSigninInstead(email, password);
+
+        final Bundle extras = makeExtrasBundle(email, password);
+        startActivityInstead(FxAccountSignInActivity.class, CHILD_REQUEST_CODE, extras);
       }
     }, clickableStart, clickableEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
     remoteErrorTextView.setMovementMethod(LinkMovementMethod.getInstance());

--- a/src/main/java/org/mozilla/gecko/fxa/activities/FxAccountCreateAccountActivity.java
+++ b/src/main/java/org/mozilla/gecko/fxa/activities/FxAccountCreateAccountActivity.java
@@ -195,7 +195,7 @@ public class FxAccountCreateAccountActivity extends FxAccountAbstractSetupActivi
   }
 
   public void createAccount(String email, String password, Map<String, Boolean> engines) {
-    String serverURI = FxAccountConstants.DEFAULT_AUTH_SERVER_ENDPOINT;
+    String serverURI = getAuthServerEndpoint();
     PasswordStretcher passwordStretcher = makePasswordStretcher(password);
     // This delegate creates a new Android account on success, opens the
     // appropriate "success!" activity, and finishes this activity.

--- a/src/main/java/org/mozilla/gecko/fxa/activities/FxAccountGetStartedActivity.java
+++ b/src/main/java/org/mozilla/gecko/fxa/activities/FxAccountGetStartedActivity.java
@@ -54,6 +54,10 @@ public class FxAccountGetStartedActivity extends AccountAuthenticatorActivity {
         // Per http://stackoverflow.com/a/8992365, this triggers a known bug with
         // the soft keyboard not being shown for the started activity. Why, Android, why?
         intent.setFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
+        final Bundle extras = getIntent().getExtras();
+        if (extras != null) {
+            intent.putExtras(extras);
+        }
         startActivityForResult(intent, CHILD_REQUEST_CODE);
       }
     });

--- a/src/main/java/org/mozilla/gecko/fxa/activities/FxAccountGetStartedActivity.java
+++ b/src/main/java/org/mozilla/gecko/fxa/activities/FxAccountGetStartedActivity.java
@@ -50,17 +50,21 @@ public class FxAccountGetStartedActivity extends AccountAuthenticatorActivity {
     button.setOnClickListener(new OnClickListener() {
       @Override
       public void onClick(View v) {
-        Intent intent = new Intent(FxAccountGetStartedActivity.this, FxAccountCreateAccountActivity.class);
-        // Per http://stackoverflow.com/a/8992365, this triggers a known bug with
-        // the soft keyboard not being shown for the started activity. Why, Android, why?
-        intent.setFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
         final Bundle extras = getIntent().getExtras();
-        if (extras != null) {
-            intent.putExtras(extras);
-        }
-        startActivityForResult(intent, CHILD_REQUEST_CODE);
+        startFlow(extras);
       }
     });
+  }
+
+  protected void startFlow(Bundle extras) {
+    final Intent intent = new Intent(this, FxAccountCreateAccountActivity.class);
+    // Per http://stackoverflow.com/a/8992365, this triggers a known bug with
+    // the soft keyboard not being shown for the started activity. Why, Android, why?
+    intent.setFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
+    if (extras != null) {
+        intent.putExtras(extras);
+    }
+    startActivityForResult(intent, CHILD_REQUEST_CODE);
   }
 
   @Override
@@ -82,6 +86,17 @@ public class FxAccountGetStartedActivity extends AccountAuthenticatorActivity {
       intent.setFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
       this.startActivity(intent);
       this.finish();
+    }
+
+    // If we've been launched with extras (namely custom server URLs), continue
+    // past go and collect 200 dollars. If we ever get back here (for example,
+    // if the user hits the back button), forget that we had extras entirely, so
+    // that we don't enter a loop.
+    final Bundle extras = getIntent().getExtras();
+    if (extras != null && extras.containsKey(FxAccountAbstractSetupActivity.EXTRA_EXTRAS)) {
+      getIntent().replaceExtras(Bundle.EMPTY);
+      startFlow((Bundle) extras.clone());
+      return;
     }
   }
 

--- a/src/main/java/org/mozilla/gecko/fxa/activities/FxAccountSignInActivity.java
+++ b/src/main/java/org/mozilla/gecko/fxa/activities/FxAccountSignInActivity.java
@@ -65,22 +65,12 @@ public class FxAccountSignInActivity extends FxAccountAbstractSetupActivity {
     createAccountInsteadLink.setOnClickListener(new OnClickListener() {
       @Override
       public void onClick(View v) {
-        Intent intent = new Intent(FxAccountSignInActivity.this, FxAccountCreateAccountActivity.class);
-        intent.putExtra("email", emailEdit.getText().toString());
-        intent.putExtra("password", passwordEdit.getText().toString());
-        // Per http://stackoverflow.com/a/8992365, this triggers a known bug with
-        // the soft keyboard not being shown for the started activity. Why, Android, why?
-        intent.setFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
-        startActivityForResult(intent, CHILD_REQUEST_CODE);
+        final Bundle extras = makeExtrasBundle(null, null);
+        startActivityInstead(FxAccountCreateAccountActivity.class, CHILD_REQUEST_CODE, extras);
       }
     });
 
-    // Only set email/password in onCreate; we don't want to overwrite edited values onResume.
-    if (getIntent() != null && getIntent().getExtras() != null) {
-      Bundle bundle = getIntent().getExtras();
-      emailEdit.setText(bundle.getString("email"));
-      passwordEdit.setText(bundle.getString("password"));
-    }
+    updateFromIntentExtras();
 
     TextView view = (TextView) findViewById(R.id.forgot_password_link);
     ActivityUtils.linkTextView(view, R.string.fxaccount_sign_in_forgot_password, R.string.fxaccount_link_forgot_password);

--- a/src/main/java/org/mozilla/gecko/fxa/activities/FxAccountSignInActivity.java
+++ b/src/main/java/org/mozilla/gecko/fxa/activities/FxAccountSignInActivity.java
@@ -15,7 +15,6 @@ import org.mozilla.gecko.background.fxa.FxAccountClient20;
 import org.mozilla.gecko.background.fxa.FxAccountClient20.LoginResponse;
 import org.mozilla.gecko.background.fxa.FxAccountClientException.FxAccountClientRemoteException;
 import org.mozilla.gecko.background.fxa.PasswordStretcher;
-import org.mozilla.gecko.fxa.FxAccountConstants;
 import org.mozilla.gecko.fxa.tasks.FxAccountSignInTask;
 import org.mozilla.gecko.sync.setup.activities.ActivityUtils;
 
@@ -92,7 +91,7 @@ public class FxAccountSignInActivity extends FxAccountAbstractSetupActivity {
   }
 
   public void signIn(String email, String password) {
-    String serverURI = FxAccountConstants.DEFAULT_AUTH_SERVER_ENDPOINT;
+    String serverURI = getAuthServerEndpoint();
     PasswordStretcher passwordStretcher = makePasswordStretcher(password);
     // This delegate creates a new Android account on success, opens the
     // appropriate "success!" activity, and finishes this activity.

--- a/src/main/java/org/mozilla/gecko/fxa/activities/FxAccountStatusFragment.java
+++ b/src/main/java/org/mozilla/gecko/fxa/activities/FxAccountStatusFragment.java
@@ -18,6 +18,7 @@ import org.mozilla.gecko.fxa.login.Married;
 import org.mozilla.gecko.fxa.login.State;
 import org.mozilla.gecko.fxa.sync.FxAccountSyncStatusHelper;
 import org.mozilla.gecko.fxa.tasks.FxAccountCodeResender;
+import org.mozilla.gecko.sync.ExtendedJSONObject;
 import org.mozilla.gecko.sync.SharedPreferencesClientsDataDelegate;
 import org.mozilla.gecko.sync.SyncConfiguration;
 
@@ -152,6 +153,10 @@ public class FxAccountStatusFragment
   public boolean onPreferenceClick(Preference preference) {
     if (preference == needsPasswordPreference) {
       Intent intent = new Intent(getActivity(), FxAccountUpdateCredentialsActivity.class);
+      final Bundle extras = getExtrasForAccount();
+      if (extras != null) {
+        intent.putExtras(extras);
+      }
       // Per http://stackoverflow.com/a/8992365, this triggers a known bug with
       // the soft keyboard not being shown for the started activity. Why, Android, why?
       intent.setFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
@@ -188,6 +193,17 @@ public class FxAccountStatusFragment
     }
 
     return false;
+  }
+
+  protected Bundle getExtrasForAccount() {
+    final Bundle extras = new Bundle();
+    final ExtendedJSONObject o = new ExtendedJSONObject();
+    o.put(FxAccountAbstractSetupActivity.JSON_KEY_AUTH, fxAccount.getAccountServerURI());
+    final ExtendedJSONObject services = new ExtendedJSONObject();
+    services.put(FxAccountAbstractSetupActivity.JSON_KEY_SYNC, fxAccount.getTokenServerURI());
+    o.put(FxAccountAbstractSetupActivity.JSON_KEY_SERVICES, services);
+    extras.putString(FxAccountAbstractSetupActivity.EXTRA_EXTRAS, o.toJSONString());
+    return extras;
   }
 
   protected void setCheckboxesEnabled(boolean enabled) {

--- a/src/main/java/org/mozilla/gecko/fxa/activities/FxAccountUpdateCredentialsActivity.java
+++ b/src/main/java/org/mozilla/gecko/fxa/activities/FxAccountUpdateCredentialsActivity.java
@@ -77,6 +77,8 @@ public class FxAccountUpdateCredentialsActivity extends FxAccountAbstractSetupAc
 
     TextView view = (TextView) findViewById(R.id.forgot_password_link);
     ActivityUtils.linkTextView(view, R.string.fxaccount_sign_in_forgot_password, R.string.fxaccount_link_forgot_password);
+
+    updateFromIntentExtras();
   }
 
   @Override


### PR DESCRIPTION
This accepts extras from `launchSetup`.  I went with `{auth:"url", services:{sync:"url"}}`, although I'm going to wait for comment from you and @ckarlof before committing to this.
