### PR TITLE
Bug 1025937 - Silently drop null intents in HealthReportBroadcastService.

### DIFF
--- a/src/main/java/org/mozilla/gecko/background/announcements/AnnouncementsBroadcastService.java
+++ b/src/main/java/org/mozilla/gecko/background/announcements/AnnouncementsBroadcastService.java
@@ -119,6 +119,12 @@ public class AnnouncementsBroadcastService extends BackgroundService {
   @Override
   protected void onHandleIntent(Intent intent) {
     Logger.setThreadLogTag(AnnouncementsConstants.GLOBAL_LOG_TAG);
+
+    // Intent can be null. Bug 1025937.
+    if (intent == null) {
+        Logger.debug(LOG_TAG, "Short-circuiting on null intent.");
+    }
+
     final String action = intent.getAction();
     Logger.debug(LOG_TAG, "Broadcast onReceive. Intent is " + action);
 
@@ -143,8 +149,10 @@ public class AnnouncementsBroadcastService extends BackgroundService {
    * Handle the intent sent by the browser when it wishes to notify us
    * of the value of the user preference. Look at the value and toggle the
    * alarm service accordingly.
+   *
+   * @param intent must be non-null.
    */
-  protected void handlePrefIntent(Intent intent) {
+  private void handlePrefIntent(Intent intent) {
     if (!intent.hasExtra("enabled")) {
       Logger.warn(LOG_TAG, "Got ANNOUNCEMENTS_PREF intent without enabled. Ignoring.");
       return;

--- a/src/main/java/org/mozilla/gecko/background/announcements/AnnouncementsService.java
+++ b/src/main/java/org/mozilla/gecko/background/announcements/AnnouncementsService.java
@@ -117,6 +117,12 @@ public class AnnouncementsService extends BackgroundService implements Announcem
   @Override
   public void onHandleIntent(Intent intent) {
     Logger.setThreadLogTag(AnnouncementsConstants.GLOBAL_LOG_TAG);
+
+    // Intent can be null. Bug 1025937.
+    if (intent == null) {
+        Logger.debug(LOG_TAG, "Short-circuiting on null intent.");
+    }
+
     Logger.debug(LOG_TAG, "Running AnnouncementsService.");
 
     if (AnnouncementsConstants.DISABLED) {

--- a/src/main/java/org/mozilla/gecko/background/healthreport/HealthReportBroadcastService.java
+++ b/src/main/java/org/mozilla/gecko/background/healthreport/HealthReportBroadcastService.java
@@ -100,6 +100,11 @@ public class HealthReportBroadcastService extends BackgroundService {
   protected void onHandleIntent(Intent intent) {
     Logger.setThreadLogTag(HealthReportConstants.GLOBAL_LOG_TAG);
 
+    // Intent can be null. Bug 1025937.
+    if (intent == null) {
+        Logger.debug(LOG_TAG, "Short-circuiting on null intent.");
+    }
+
     // The same intent can be handled by multiple methods so do not short-circuit evaluate.
     boolean handled = attemptHandleIntentForUpload(intent);
     handled = attemptHandleIntentForPrune(intent) ? true : handled;
@@ -111,8 +116,10 @@ public class HealthReportBroadcastService extends BackgroundService {
 
   /**
    * Attempts to handle the given intent for FHR document upload. If it cannot, false is returned.
+   *
+   * @param intent must be non-null.
    */
-  protected boolean attemptHandleIntentForUpload(final Intent intent) {
+  private boolean attemptHandleIntentForUpload(final Intent intent) {
     if (HealthReportConstants.UPLOAD_FEATURE_DISABLED) {
       Logger.debug(LOG_TAG, "Health report upload feature is compile-time disabled; not handling intent.");
       return false;
@@ -143,7 +150,7 @@ public class HealthReportBroadcastService extends BackgroundService {
    * of the value of the user preference. Look at the value and toggle the
    * alarm service accordingly.
    */
-  protected void handleUploadPrefIntent(Intent intent) {
+  private void handleUploadPrefIntent(Intent intent) {
     if (!intent.hasExtra("enabled")) {
       Logger.warn(LOG_TAG, "Got " + HealthReportConstants.ACTION_HEALTHREPORT_UPLOAD_PREF + " intent without enabled. Ignoring.");
       return;
@@ -194,8 +201,10 @@ public class HealthReportBroadcastService extends BackgroundService {
 
   /**
    * Attempts to handle the given intent for FHR data pruning. If it cannot, false is returned.
+   *
+   * @param intent must be non-null.
    */
-  protected boolean attemptHandleIntentForPrune(final Intent intent) {
+  private boolean attemptHandleIntentForPrune(final Intent intent) {
     final String action = intent.getAction();
     Logger.debug(LOG_TAG, "Prune: Attempting to handle intent with action, " + action + ".");
 
@@ -215,7 +224,10 @@ public class HealthReportBroadcastService extends BackgroundService {
     return false;
   }
 
-  protected void handlePruneIntent(final Intent intent) {
+  /**
+   * @param intent must be non-null.
+   */
+  private void handlePruneIntent(final Intent intent) {
     final String profileName = intent.getStringExtra("profileName");
     final String profilePath = intent.getStringExtra("profilePath");
 

--- a/src/main/java/org/mozilla/gecko/background/healthreport/prune/HealthReportPruneService.java
+++ b/src/main/java/org/mozilla/gecko/background/healthreport/prune/HealthReportPruneService.java
@@ -39,6 +39,12 @@ public class HealthReportPruneService extends BackgroundService {
   @Override
   public void onHandleIntent(Intent intent) {
     Logger.setThreadLogTag(HealthReportConstants.GLOBAL_LOG_TAG);
+
+    // Intent can be null. Bug 1025937.
+    if (intent == null) {
+        Logger.debug(LOG_TAG, "Short-circuiting on null intent.");
+    }
+
     Logger.debug(LOG_TAG, "Handling prune intent.");
 
     if (!isIntentValid(intent)) {
@@ -59,7 +65,7 @@ public class HealthReportPruneService extends BackgroundService {
     return new PrunePolicy(storage, getSharedPreferences());
   }
 
-  protected boolean isIntentValid(final Intent intent) {
+  private static boolean isIntentValid(final Intent intent) {
     boolean isValid = true;
 
     final String profileName = intent.getStringExtra("profileName");

--- a/src/main/java/org/mozilla/gecko/background/healthreport/upload/HealthReportUploadService.java
+++ b/src/main/java/org/mozilla/gecko/background/healthreport/upload/HealthReportUploadService.java
@@ -43,6 +43,11 @@ public class HealthReportUploadService extends BackgroundService {
   public void onHandleIntent(Intent intent) {
     Logger.setThreadLogTag(HealthReportConstants.GLOBAL_LOG_TAG);
 
+    // Intent can be null. Bug 1025937.
+    if (intent == null) {
+        Logger.debug(LOG_TAG, "Short-circuiting on null intent.");
+    }
+
     if (HealthReportConstants.UPLOAD_FEATURE_DISABLED) {
       Logger.debug(LOG_TAG, "Health report upload feature is compile-time disabled; not handling upload intent.");
       return;

--- a/src/main/java/org/mozilla/gecko/fxa/receivers/FxAccountDeletedService.java
+++ b/src/main/java/org/mozilla/gecko/fxa/receivers/FxAccountDeletedService.java
@@ -29,6 +29,11 @@ public class FxAccountDeletedService extends IntentService {
 
   @Override
   protected void onHandleIntent(final Intent intent) {
+    // Intent can, in theory, be null. Bug 1025937.
+    if (intent == null) {
+        Logger.debug(LOG_TAG, "Short-circuiting on null intent.");
+    }
+
     final Context context = this;
 
     long intentVersion = intent.getLongExtra(

--- a/src/main/java/org/mozilla/gecko/sync/receivers/SyncAccountDeletedService.java
+++ b/src/main/java/org/mozilla/gecko/sync/receivers/SyncAccountDeletedService.java
@@ -32,6 +32,11 @@ public class SyncAccountDeletedService extends IntentService {
 
   @Override
   protected void onHandleIntent(Intent intent) {
+    // Intent can, in theory, be null. Bug 1025937.
+    if (intent == null) {
+      Logger.debug(LOG_TAG, "Short-circuiting on null intent.");
+    }
+
     final Context context = this;
 
     long intentVersion = intent.getLongExtra(Constants.JSON_KEY_VERSION, 0);


### PR DESCRIPTION
It looks like an IntentService can sometimes be restarted with a null intent. The right thing to do appears to be to ignore it — we'll get another intent if we have to do some work. (If we were restarted mid-operation, we just wait until the next time.)
