### PR TITLE
Bug 1042929 - Don't throw Errors from JSONObject parsing problems.

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/ExtendedJSONObject.java
+++ b/src/main/java/org/mozilla/gecko/sync/ExtendedJSONObject.java
@@ -50,7 +50,12 @@ public class ExtendedJSONObject {
    * @throws IOException
    */
   protected static Object parseRaw(Reader in) throws ParseException, IOException {
-    return getJSONParser().parse(in);
+    try {
+      return getJSONParser().parse(in);
+    } catch (Error e) {
+      // Don't be stupid, org.json.simple. Bug 1042929.
+      throw new ParseException(ParseException.ERROR_UNEXPECTED_EXCEPTION);
+    }
   }
 
   /**
@@ -63,7 +68,12 @@ public class ExtendedJSONObject {
    * @throws ParseException
    */
   protected static Object parseRaw(String input) throws ParseException {
-    return getJSONParser().parse(input);
+    try {
+      return getJSONParser().parse(input);
+    } catch (Error e) {
+      // Don't be stupid, org.json.simple. Bug 1042929.
+      throw new ParseException(ParseException.ERROR_UNEXPECTED_EXCEPTION);
+    }
   }
 
   /**


### PR DESCRIPTION
org.json.simple and Yylex are badly written: rather than correctly
handling parse errors, the JSON parser allows Yylex's Errors to
propagate to callers, which ordinary Exception handlers won't catch.

This patch rewrites those Errors as ParseExceptions with a 0 line
number, which will avoid errors in all consumers.
