### PR TITLE
Bug 1056227 - Don't always go back to status after updating Firefox Acco...

### DIFF
--- a/src/main/java/org/mozilla/gecko/fxa/activities/FxAccountUpdateCredentialsActivity.java
+++ b/src/main/java/org/mozilla/gecko/fxa/activities/FxAccountUpdateCredentialsActivity.java
@@ -160,7 +160,8 @@ public class FxAccountUpdateCredentialsActivity extends FxAccountAbstractSetupAc
         fxAccount.dump();
       }
 
-      redirectToActivity(FxAccountStatusActivity.class);
+      setResult(RESULT_OK);
+      finish();
     }
   }
 


### PR DESCRIPTION
...unt credentials.

This was a simple oversight.  With embedded links to update your
credentials in Fennec's Remote Tabs interfaces, just returning to where
you came from is the right thing to do.
