### PR TITLE
Bug 1081287: Use EnumMap where possible in sync. r=rnewman

### DIFF
--- a/src/main/java/org/mozilla/gecko/fxa/sync/FxAccountGlobalSession.java
+++ b/src/main/java/org/mozilla/gecko/fxa/sync/FxAccountGlobalSession.java
@@ -7,7 +7,9 @@ package org.mozilla.gecko.fxa.sync;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.Map;
 
 import org.json.simple.parser.ParseException;
 import org.mozilla.gecko.sync.GlobalSession;
@@ -34,7 +36,7 @@ public class FxAccountGlobalSession extends GlobalSession {
   @Override
   public void prepareStages() {
     super.prepareStages();
-    HashMap<Stage, GlobalSyncStage> stages = new HashMap<Stage, GlobalSyncStage>();
+    Map<Stage, GlobalSyncStage> stages = new EnumMap<>(Stage.class);
     stages.putAll(this.stages);
     stages.put(Stage.ensureClusterURL, new CheckPreconditionsStage());
     this.stages = Collections.unmodifiableMap(stages);

--- a/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
+++ b/src/main/java/org/mozilla/gecko/sync/GlobalSession.java
@@ -10,6 +10,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -174,7 +175,7 @@ public class GlobalSession implements HttpResponseObserver {
   }
 
   protected void prepareStages() {
-    HashMap<Stage, GlobalSyncStage> stages = new HashMap<Stage, GlobalSyncStage>();
+    Map<Stage, GlobalSyncStage> stages = new EnumMap<Stage, GlobalSyncStage>(Stage.class);
 
     stages.put(Stage.checkPreconditions,      new CheckPreconditionsStage());
     stages.put(Stage.ensureClusterURL,        new EnsureClusterURLStage(nodeAssignmentCallback));


### PR DESCRIPTION
Reviewed on Bugzilla, upstreaming the sync-specific stuff.

... That, or an amusing automation error is about to occur...
