### PR TITLE
Bug 1081317: Don't create redundant temporary objects when converting primitives to strings. r=rnewman

### DIFF
--- a/src/main/java/org/mozilla/gecko/sync/config/ConfigurationMigrator.java
+++ b/src/main/java/org/mozilla/gecko/sync/config/ConfigurationMigrator.java
@@ -239,7 +239,7 @@ public class ConfigurationMigrator {
     }
     if (numClients > -1) {
       Logger.debug(LOG_TAG, "Migrated clients count.");
-      accountManager.setUserData(account, V1_PREF_NUM_CLIENTS, new Long(numClients).toString());
+      accountManager.setUserData(account, V1_PREF_NUM_CLIENTS, Long.toString(numClients));
       count += 1;
     }
     return count;


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1081317
