### PR TITLE
Bug 1080242 - locked account

### DIFF
--- a/src/main/java/org/mozilla/gecko/background/fxa/FxAccountClient.java
+++ b/src/main/java/org/mozilla/gecko/background/fxa/FxAccountClient.java
@@ -17,4 +17,5 @@ public interface FxAccountClient {
   public void keys(byte[] keyFetchToken, RequestDelegate<TwoKeys> requestDelegate);
   public void sign(byte[] sessionToken, ExtendedJSONObject publicKey, long certificateDurationInMilliseconds, RequestDelegate<String> requestDelegate);
   public void resendCode(byte[] sessionToken, RequestDelegate<Void> delegate);
+  public void resendUnlockCode(byte[] emailUTF8, RequestDelegate<Void> delegate);
 }

--- a/src/main/java/org/mozilla/gecko/background/fxa/FxAccountClient10.java
+++ b/src/main/java/org/mozilla/gecko/background/fxa/FxAccountClient10.java
@@ -770,4 +770,46 @@ public class FxAccountClient10 {
     };
     post(resource, new JSONObject(), delegate);
   }
+
+  /**
+   * Request a fresh unlock code be sent to the account email.
+   * <p>
+   * Since the account can be locked before the device can connect to it, the
+   * only reasonable identifier is the account email. Since the account is
+   * locked out, this request is un-authenticated.
+   *
+   * @param emailUTF8
+   *          identifying account.
+   * @param delegate
+   *          to invoke callbacks.
+   */
+  @SuppressWarnings("unchecked")
+  public void resendUnlockCode(final byte[] emailUTF8, final RequestDelegate<Void> delegate) {
+    final BaseResource resource;
+    final JSONObject body = new JSONObject();
+    try {
+      resource = new BaseResource(new URI(serverURI + "unlock/resend_code"));
+      body.put("email", new String(emailUTF8, "UTF-8"));
+    } catch (URISyntaxException e) {
+      invokeHandleError(delegate, e);
+      return;
+    } catch (UnsupportedEncodingException e) {
+      invokeHandleError(delegate, e);
+      return;
+    }
+
+    resource.delegate = new ResourceDelegate<Void>(resource, delegate) {
+      @Override
+      public void handleSuccess(int status, HttpResponse response, ExtendedJSONObject body) {
+        try {
+          delegate.handleSuccess(null);
+          return;
+        } catch (Exception e) {
+          delegate.handleError(e);
+          return;
+        }
+      }
+    };
+    post(resource, body, delegate);
+  }
 }

--- a/src/main/java/org/mozilla/gecko/background/fxa/FxAccountClientException.java
+++ b/src/main/java/org/mozilla/gecko/background/fxa/FxAccountClientException.java
@@ -96,6 +96,10 @@ public class FxAccountClientException extends Exception {
       return apiErrorNumber == FxAccountRemoteError.INCORRECT_EMAIL_CASE;
     }
 
+    public boolean isAccountLocked() {
+      return apiErrorNumber == FxAccountRemoteError.ACCOUNT_LOCKED;
+    }
+
     public int getErrorMessageStringResource() {
       if (isUpgradeRequired()) {
         return R.string.fxaccount_remote_error_UPGRADE_REQUIRED;
@@ -111,6 +115,8 @@ public class FxAccountClientException extends Exception {
         return R.string.fxaccount_remote_error_CLIENT_HAS_SENT_TOO_MANY_REQUESTS;
       } else if (isServerUnavailable()) {
         return R.string.fxaccount_remote_error_SERVICE_TEMPORARILY_UNAVAILABLE_TO_DUE_HIGH_LOAD;
+      } else if (isAccountLocked()) {
+        return R.string.fxaccount_remote_error_ACCOUNT_LOCKED;
       } else {
         return R.string.fxaccount_remote_error_UNKNOWN_ERROR;
       }

--- a/src/main/java/org/mozilla/gecko/background/fxa/FxAccountRemoteError.java
+++ b/src/main/java/org/mozilla/gecko/background/fxa/FxAccountRemoteError.java
@@ -16,7 +16,6 @@ public interface FxAccountRemoteError {
   public static final int INVALID_REQUEST_SIGNATURE = 109;
   public static final int INVALID_AUTHENTICATION_TOKEN = 110;
   public static final int INVALID_AUTHENTICATION_TIMESTAMP = 111;
-  public static final int INVALID_AUTHENTICATION_NONCE = 115;
   public static final int CONTENT_LENGTH_HEADER_WAS_NOT_PROVIDED = 112;
   public static final int REQUEST_BODY_TOO_LARGE = 113;
   public static final int CLIENT_HAS_SENT_TOO_MANY_REQUESTS = 114;
@@ -26,6 +25,7 @@ public interface FxAccountRemoteError {
   public static final int INCORRECT_KEY_RETRIEVAL_METHOD_FOR_THIS_ACCOUNT = 118;
   public static final int INCORRECT_API_VERSION_FOR_THIS_ACCOUNT = 119;
   public static final int INCORRECT_EMAIL_CASE = 120;
+  public static final int ACCOUNT_LOCKED = 121;
   public static final int SERVICE_TEMPORARILY_UNAVAILABLE_DUE_TO_HIGH_LOAD = 201;
   public static final int UNKNOWN_ERROR = 999;
 }

--- a/src/main/java/org/mozilla/gecko/fxa/activities/FxAccountAbstractSetupActivity.java
+++ b/src/main/java/org/mozilla/gecko/fxa/activities/FxAccountAbstractSetupActivity.java
@@ -25,6 +25,7 @@ import org.mozilla.gecko.fxa.login.State;
 import org.mozilla.gecko.fxa.tasks.FxAccountSetupTask.ProgressDisplay;
 import org.mozilla.gecko.sync.ExtendedJSONObject;
 import org.mozilla.gecko.sync.SyncConfiguration;
+import org.mozilla.gecko.sync.Utils;
 import org.mozilla.gecko.sync.setup.Constants;
 import org.mozilla.gecko.sync.setup.activities.ActivityUtils;
 
@@ -35,9 +36,12 @@ import android.content.Intent;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.text.Editable;
+import android.text.Spannable;
 import android.text.TextWatcher;
+import android.text.method.LinkMovementMethod;
 import android.text.method.PasswordTransformationMethod;
 import android.text.method.SingleLineTransformationMethod;
+import android.text.style.ClickableSpan;
 import android.util.Patterns;
 import android.view.KeyEvent;
 import android.view.View;
@@ -154,7 +158,25 @@ abstract public class FxAccountAbstractSetupActivity extends FxAccountAbstractAc
   }
 
   protected void showClientRemoteException(final FxAccountClientRemoteException e) {
-    remoteErrorTextView.setText(e.getErrorMessageStringResource());
+    if (!e.isAccountLocked()) {
+      remoteErrorTextView.setText(e.getErrorMessageStringResource());
+      return;
+    }
+
+    // This horrible bit of special-casing is because we want this error message
+    // to contain a clickable, extra chunk of text, but we don't want to pollute
+    // the exception class with Android specifics.
+    final int messageId = e.getErrorMessageStringResource();
+    final int clickableId = R.string.fxaccount_resend_unlock_code_button_label;
+    final Spannable span = Utils.interpolateClickableSpan(this, messageId, clickableId, new ClickableSpan() {
+      @Override
+      public void onClick(View widget) {
+        // To be implemented in the next commit.
+        Logger.warn(LOG_TAG, "Temporary until we do the right thing.");
+      }
+    });
+    remoteErrorTextView.setMovementMethod(LinkMovementMethod.getInstance());
+    remoteErrorTextView.setText(span);
   }
 
   protected void addListeners() {

--- a/src/main/java/org/mozilla/gecko/fxa/activities/FxAccountCreateAccountActivity.java
+++ b/src/main/java/org/mozilla/gecko/fxa/activities/FxAccountCreateAccountActivity.java
@@ -22,6 +22,7 @@ import org.mozilla.gecko.background.fxa.FxAccountClientException.FxAccountClient
 import org.mozilla.gecko.background.fxa.PasswordStretcher;
 import org.mozilla.gecko.fxa.FxAccountConstants;
 import org.mozilla.gecko.fxa.tasks.FxAccountCreateAccountTask;
+import org.mozilla.gecko.sync.Utils;
 
 import android.app.AlertDialog;
 import android.app.Dialog;
@@ -30,7 +31,6 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.SystemClock;
 import android.text.Spannable;
-import android.text.Spanned;
 import android.text.method.LinkMovementMethod;
 import android.text.style.ClickableSpan;
 import android.view.View;
@@ -124,13 +124,10 @@ public class FxAccountCreateAccountActivity extends FxAccountAbstractSetupActivi
     // This horrible bit of special-casing is because we want this error message to
     // contain a clickable, extra chunk of text, but we don't want to pollute
     // the exception class with Android specifics.
-    final String clickablePart = getString(R.string.fxaccount_sign_in_button_label);
-    final String message = getString(e.getErrorMessageStringResource(), clickablePart);
-    final int clickableStart = message.lastIndexOf(clickablePart);
-    final int clickableEnd = clickableStart + clickablePart.length();
+    final int messageId = e.getErrorMessageStringResource();
+    final int clickableId = R.string.fxaccount_sign_in_button_label;
 
-    final Spannable span = Spannable.Factory.getInstance().newSpannable(message);
-    span.setSpan(new ClickableSpan() {
+    final Spannable span = Utils.interpolateClickableSpan(this, messageId, clickableId, new ClickableSpan() {
       @Override
       public void onClick(View widget) {
         // Pass through the email address that already existed.
@@ -143,7 +140,7 @@ public class FxAccountCreateAccountActivity extends FxAccountAbstractSetupActivi
         final Bundle extras = makeExtrasBundle(email, password);
         startActivityInstead(FxAccountSignInActivity.class, CHILD_REQUEST_CODE, extras);
       }
-    }, clickableStart, clickableEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+    });
     remoteErrorTextView.setMovementMethod(LinkMovementMethod.getInstance());
     remoteErrorTextView.setText(span);
   }

--- a/src/main/java/org/mozilla/gecko/fxa/tasks/FxAccountUnlockCodeResender.java
+++ b/src/main/java/org/mozilla/gecko/fxa/tasks/FxAccountUnlockCodeResender.java
@@ -1,0 +1,105 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.gecko.fxa.tasks;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import org.mozilla.gecko.R;
+import org.mozilla.gecko.background.common.log.Logger;
+import org.mozilla.gecko.background.fxa.FxAccountClient;
+import org.mozilla.gecko.background.fxa.FxAccountClient10.RequestDelegate;
+import org.mozilla.gecko.background.fxa.FxAccountClient20;
+import org.mozilla.gecko.background.fxa.FxAccountClientException.FxAccountClientRemoteException;
+
+import android.content.Context;
+import android.os.AsyncTask;
+import android.widget.Toast;
+
+/**
+ * A helper class that provides a simple interface for requesting a Firefox
+ * Account unlock account email be (re)-sent.
+ */
+public class FxAccountUnlockCodeResender {
+  private static final String LOG_TAG = FxAccountUnlockCodeResender.class.getSimpleName();
+
+  private static class FxAccountUnlockCodeTask extends FxAccountSetupTask<Void> {
+    protected static final String LOG_TAG = FxAccountUnlockCodeTask.class.getSimpleName();
+
+    protected final byte[] emailUTF8;
+
+    public FxAccountUnlockCodeTask(Context context, byte[] emailUTF8, FxAccountClient client, RequestDelegate<Void> delegate) {
+      super(context, null, client, delegate);
+      this.emailUTF8 = emailUTF8;
+    }
+
+    @Override
+    protected InnerRequestDelegate<Void> doInBackground(Void... arg0) {
+      try {
+        client.resendUnlockCode(emailUTF8, innerDelegate);
+        latch.await();
+        return innerDelegate;
+      } catch (Exception e) {
+        Logger.error(LOG_TAG, "Got exception signing in.", e);
+        delegate.handleError(e);
+      }
+      return null;
+    }
+  }
+
+  private static class ResendUnlockCodeDelegate implements RequestDelegate<Void> {
+    public final Context context;
+
+    public ResendUnlockCodeDelegate(Context context) {
+      this.context = context;
+    }
+
+    @Override
+    public void handleError(Exception e) {
+      Logger.warn(LOG_TAG, "Got exception requesting fresh unlock code; ignoring.", e);
+      Toast.makeText(context, R.string.fxaccount_unlock_code_not_sent, Toast.LENGTH_LONG).show();
+    }
+
+    @Override
+    public void handleFailure(FxAccountClientRemoteException e) {
+      handleError(e);
+    }
+
+    @Override
+    public void handleSuccess(Void result) {
+      Toast.makeText(context, R.string.fxaccount_unlock_code_sent, Toast.LENGTH_SHORT).show();
+    }
+  }
+
+  /**
+   * Resends the account unlock email, and displays an appropriate toast on both
+   * send success and failure. Note that because the underlying implementation
+   * uses {@link AsyncTask}, the provided context must be UI-capable and this
+   * method called from the UI thread.
+   *
+   * Note that it may actually be possible to run this (and the
+   * {@link AsyncTask}) method from a background thread - but this hasn't been
+   * tested.
+   *
+   * @param context
+   *          A UI-capable Android context.
+   * @param authServerURI
+   *          to send request to.
+   * @param emailUTF8
+   *          bytes of email address identifying account; null indicates a local failure.
+   */
+  public static void resendUnlockCode(Context context, String authServerURI, byte[] emailUTF8) {
+    RequestDelegate<Void> delegate = new ResendUnlockCodeDelegate(context);
+
+    if (emailUTF8 == null) {
+      delegate.handleError(new IllegalArgumentException("emailUTF8 must not be null"));
+      return;
+    }
+
+    final Executor executor = Executors.newSingleThreadExecutor();
+    final FxAccountClient client = new FxAccountClient20(authServerURI, executor);
+    new FxAccountUnlockCodeTask(context, emailUTF8, client, delegate).execute();
+  }
+}

--- a/src/main/java/org/mozilla/gecko/sync/Utils.java
+++ b/src/main/java/org/mozilla/gecko/sync/Utils.java
@@ -35,6 +35,9 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.text.Spannable;
+import android.text.Spanned;
+import android.text.style.ClickableSpan;
 
 public class Utils {
 
@@ -613,5 +616,27 @@ public class Utils {
       return language;
     }
     return language + "-" + country;
+  }
+
+  /**
+   * Make a span with a clickable chunk of text interpolated in.
+   *
+   * @param context Android context.
+   * @param messageId of string containing clickable chunk.
+   * @param clickableId of string to make clickable.
+   * @param clickableSpan to activate on click.
+   * @return Spannable.
+   */
+  public static Spannable interpolateClickableSpan(Context context, int messageId, int clickableId, ClickableSpan clickableSpan) {
+    // This horrible bit of special-casing is because we want this error message to
+    // contain a clickable, extra chunk of text, but we don't want to pollute
+    // the exception class with Android specifics.
+    final String clickablePart = context.getString(clickableId);
+    final String message = context.getString(messageId, clickablePart);
+    final int clickableStart = message.lastIndexOf(clickablePart);
+    final int clickableEnd = clickableStart + clickablePart.length();
+    final Spannable span = Spannable.Factory.getInstance().newSpannable(message);
+    span.setSpan(clickableSpan, clickableStart, clickableEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+    return span;
   }
 }

--- a/src/test/java/org/mozilla/gecko/fxa/login/MockFxAccountClient.java
+++ b/src/test/java/org/mozilla/gecko/fxa/login/MockFxAccountClient.java
@@ -183,6 +183,21 @@ public class MockFxAccountClient implements FxAccountClient {
   }
 
   @Override
+  public void resendUnlockCode(byte[] emailUTF8, RequestDelegate<Void> requestDelegate) {
+    User user;
+    try {
+      user = users.get(new String(emailUTF8, "UTF-8"));
+    } catch (UnsupportedEncodingException e) {
+      user = null;
+    }
+    if (user == null) {
+      handleFailure(requestDelegate, HttpStatus.SC_BAD_REQUEST, FxAccountRemoteError.ATTEMPT_TO_ACCESS_AN_ACCOUNT_THAT_DOES_NOT_EXIST, "invalid emailUTF8");
+      return;
+    }
+    requestDelegate.handleSuccess(null);
+  }
+
+  @Override
   public void createAccountAndGetKeys(byte[] emailUTF8, PasswordStretcher passwordStretcher, RequestDelegate<LoginResponse> delegate) {
     delegate.handleError(new RuntimeException("Not yet implemented"));
   }

--- a/strings/strings.xml.in
+++ b/strings/strings.xml.in
@@ -156,6 +156,7 @@
 <string name="fxaccount_confirm_account_resend_email">&fxaccount_confirm_account_resend_email;</string>
 <string name="fxaccount_confirm_account_verification_link_sent">&fxaccount_confirm_account_verification_link_sent2;</string>
 <string name="fxaccount_confirm_account_verification_link_not_sent">&fxaccount_confirm_account_verification_link_not_sent2;</string>
+<string name="fxaccount_resend_unlock_code_button_label">&fxaccount_resend_unlock_code_button_label;</string>
 
 <string name="fxaccount_sign_in_sub_header">&fxaccount_sign_in_sub_header;</string>
 <string name="fxaccount_sign_in_button_label">&fxaccount_sign_in_button_label;</string>
@@ -206,6 +207,7 @@
 <string name="fxaccount_remote_error_SERVICE_TEMPORARILY_UNAVAILABLE_TO_DUE_HIGH_LOAD">&fxaccount_remote_error_SERVICE_TEMPORARILY_UNAVAILABLE_TO_DUE_HIGH_LOAD;</string>
 <string name="fxaccount_remote_error_UNKNOWN_ERROR">&fxaccount_remote_error_UNKNOWN_ERROR;</string>
 <string name="fxaccount_remote_error_COULD_NOT_CONNECT">&fxaccount_remote_error_COULD_NOT_CONNECT;</string>
+<string name="fxaccount_remote_error_ACCOUNT_LOCKED">&fxaccount_remote_error_ACCOUNT_LOCKED;</string>
 
 <string name="fxaccount_sync_sign_in_error_notification_title">&fxaccount_sync_sign_in_error_notification_title2;</string>
 <string name="fxaccount_sync_sign_in_error_notification_text">&fxaccount_sync_sign_in_error_notification_text2;</string>

--- a/strings/strings.xml.in
+++ b/strings/strings.xml.in
@@ -157,6 +157,8 @@
 <string name="fxaccount_confirm_account_verification_link_sent">&fxaccount_confirm_account_verification_link_sent2;</string>
 <string name="fxaccount_confirm_account_verification_link_not_sent">&fxaccount_confirm_account_verification_link_not_sent2;</string>
 <string name="fxaccount_resend_unlock_code_button_label">&fxaccount_resend_unlock_code_button_label;</string>
+<string name="fxaccount_unlock_code_sent">&fxaccount_unlock_code_sent;</string>
+<string name="fxaccount_unlock_code_not_sent">&fxaccount_unlock_code_not_sent;</string>
 
 <string name="fxaccount_sign_in_sub_header">&fxaccount_sign_in_sub_header;</string>
 <string name="fxaccount_sign_in_button_label">&fxaccount_sign_in_button_label;</string>

--- a/strings/sync_strings.dtd
+++ b/strings/sync_strings.dtd
@@ -169,7 +169,7 @@
 <!ENTITY fxaccount_confirm_account_resend_email 'Resend email'>
 <!ENTITY fxaccount_confirm_account_verification_link_sent2 'Verification email sent'>
 <!ENTITY fxaccount_confirm_account_verification_link_not_sent2 'Couldn\&apos;t send verification email'>
-
+<!ENTITY fxaccount_resend_unlock_code_button_label 'Resend unlock email'>
 <!ENTITY fxaccount_sign_in_sub_header 'Sign in'>
 <!ENTITY fxaccount_sign_in_button_label 'Sign in'>
 <!ENTITY fxaccount_sign_in_forgot_password 'Forgot password?'>
@@ -242,6 +242,7 @@
 <!ENTITY fxaccount_remote_error_SERVICE_TEMPORARILY_UNAVAILABLE_TO_DUE_HIGH_LOAD 'Server busy, try again soon'>
 <!ENTITY fxaccount_remote_error_UNKNOWN_ERROR 'There was a problem'>
 <!ENTITY fxaccount_remote_error_COULD_NOT_CONNECT 'Cannot connect to network'>
+<!ENTITY fxaccount_remote_error_ACCOUNT_LOCKED 'Account is locked. &formatS1;'>
 
 <!ENTITY fxaccount_sync_sign_in_error_notification_title2 '&syncBrand.shortName.label; is not connected'>
 <!-- Localization note: the format string below will be replaced

--- a/strings/sync_strings.dtd
+++ b/strings/sync_strings.dtd
@@ -170,6 +170,9 @@
 <!ENTITY fxaccount_confirm_account_verification_link_sent2 'Verification email sent'>
 <!ENTITY fxaccount_confirm_account_verification_link_not_sent2 'Couldn\&apos;t send verification email'>
 <!ENTITY fxaccount_resend_unlock_code_button_label 'Resend unlock email'>
+<!ENTITY fxaccount_unlock_code_sent 'Account unlock email sent'>
+<!ENTITY fxaccount_unlock_code_not_sent 'Couldn\&apos;t send account unlock email'>
+
 <!ENTITY fxaccount_sign_in_sub_header 'Sign in'>
 <!ENTITY fxaccount_sign_in_button_label 'Sign in'>
 <!ENTITY fxaccount_sign_in_forgot_password 'Forgot password?'>


### PR DESCRIPTION
@rnewman: over to you for a preliminary review.  This isn't final, because:
- the error code isn't determined
- the `unlock/resend_code` endpoint hasn't been speced;
- copy isn't agreed to.

But the ideas are in place.
