### PR TITLE
Bug 1109361 - Make ProfileInformationCache loading robust against empty files.

### DIFF
--- a/src/main/java/org/mozilla/gecko/background/healthreport/ProfileInformationCache.java
+++ b/src/main/java/org/mozilla/gecko/background/healthreport/ProfileInformationCache.java
@@ -70,9 +70,13 @@ public class ProfileInformationCache implements ProfileInformationProvider {
 
   private volatile JSONObject addons = null;
 
-  public ProfileInformationCache(String profilePath) {
-    file = new File(profilePath + File.separator + CACHE_FILE);
+  protected ProfileInformationCache(final File f) {
+    file = f;
     Logger.pii(LOG_TAG, "Using " + file.getAbsolutePath() + " for profile information cache.");
+  }
+
+  public ProfileInformationCache(final String profilePath) {
+    this(new File(profilePath + File.separator + CACHE_FILE));
   }
 
   public synchronized void beginInitialization() {
@@ -109,6 +113,10 @@ public class ProfileInformationCache implements ProfileInformationProvider {
    * @return false if there's a version mismatch or an error, true on success.
    */
   private boolean fromJSON(JSONObject object) throws JSONException {
+    if (object == null) {
+      return false;
+    }
+
     int version = object.optInt("version", 1);
     switch (version) {
     case FORMAT_VERSION:
@@ -130,9 +138,11 @@ public class ProfileInformationCache implements ProfileInformationProvider {
   protected JSONObject readFromFile() throws FileNotFoundException, JSONException {
     Scanner scanner = null;
     try {
-      scanner = new Scanner(file, "UTF-8");
-      final String contents = scanner.useDelimiter("\\A").next();
-      return new JSONObject(contents);
+      scanner = new Scanner(file, "UTF-8").useDelimiter("\\A");
+      if (!scanner.hasNext()) {
+        return null;
+      }
+      return new JSONObject(scanner.next());
     } finally {
       if (scanner != null) {
         scanner.close();

--- a/src/main/java/org/mozilla/gecko/background/healthreport/ProfileInformationCache.java
+++ b/src/main/java/org/mozilla/gecko/background/healthreport/ProfileInformationCache.java
@@ -114,6 +114,7 @@ public class ProfileInformationCache implements ProfileInformationProvider {
    */
   private boolean fromJSON(JSONObject object) throws JSONException {
     if (object == null) {
+      Logger.debug(LOG_TAG, "Can't load restore PIC from null JSON object.");
       return false;
     }
 

--- a/test/src/org/mozilla/gecko/background/healthreport/MockProfileInformationCache.java
+++ b/test/src/org/mozilla/gecko/background/healthreport/MockProfileInformationCache.java
@@ -16,6 +16,10 @@ public class MockProfileInformationCache extends ProfileInformationCache {
     super(profilePath);
   }
 
+  public MockProfileInformationCache(File mockFile) {
+      super(mockFile);
+  }
+
   public boolean isInitialized() {
     return this.initialized;
   }

--- a/test/src/org/mozilla/gecko/background/healthreport/TestProfileInformationCache.java
+++ b/test/src/org/mozilla/gecko/background/healthreport/TestProfileInformationCache.java
@@ -4,6 +4,7 @@
 package org.mozilla.gecko.background.healthreport;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 
 import org.json.JSONException;
@@ -11,6 +12,21 @@ import org.json.JSONObject;
 import org.mozilla.gecko.background.helpers.FakeProfileTestCase;
 
 public class TestProfileInformationCache extends FakeProfileTestCase {
+
+  public final void testEmptyFile() throws Exception {
+    final File emptyFile = File.createTempFile("empty", "pic", this.fakeProfileDirectory);
+    final FileOutputStream s = new FileOutputStream(emptyFile);
+    try {
+        s.write(new byte[0]);
+    } finally {
+        s.close();
+    }
+
+    final MockProfileInformationCache cache = new MockProfileInformationCache(emptyFile);
+
+    // Should not throw.
+    assertNull(cache.readJSON());
+  }
 
   public final void testInitState() throws IOException {
     MockProfileInformationCache cache = new MockProfileInformationCache(this.fakeProfileDirectory.getAbsolutePath());

--- a/test/src/org/mozilla/gecko/background/healthreport/TestProfileInformationCache.java
+++ b/test/src/org/mozilla/gecko/background/healthreport/TestProfileInformationCache.java
@@ -4,7 +4,6 @@
 package org.mozilla.gecko.background.healthreport;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 
 import org.json.JSONException;
@@ -14,14 +13,8 @@ import org.mozilla.gecko.background.helpers.FakeProfileTestCase;
 public class TestProfileInformationCache extends FakeProfileTestCase {
 
   public final void testEmptyFile() throws Exception {
+    // createTempFile creates an empty file on disk.
     final File emptyFile = File.createTempFile("empty", "pic", this.fakeProfileDirectory);
-    final FileOutputStream s = new FileOutputStream(emptyFile);
-    try {
-        s.write(new byte[0]);
-    } finally {
-        s.close();
-    }
-
     final MockProfileInformationCache cache = new MockProfileInformationCache(emptyFile);
 
     // Should not throw.


### PR DESCRIPTION
This adds a test that reproduces the problem, then fixes it by using `Scanner`'s `hasNext` method and the existing control flow.
