### PR TITLE
Bug 1112725 - Avoid blue line on Next button in Create Account activity.

### DIFF
--- a/res/layout/fxaccount_create_account.xml
+++ b/res/layout/fxaccount_create_account.xml
@@ -55,8 +55,7 @@
             style="@style/FxAccountErrorItem" />
 
         <RelativeLayout
-            style="@style/FxAccountButtonLayout"
-            android:layout_marginBottom="10dp" >
+            style="@style/FxAccountButtonLayout" >
 
             <ProgressBar
                 android:id="@+id/progress"
@@ -73,7 +72,10 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
-            android:layout_margin="0dp"
+            android:layout_marginTop="10dp"
+            android:layout_marginLeft="0dp"
+            android:layout_marginRight="0dp"
+            android:layout_marginBottom="0dp"
             android:text="@string/fxaccount_create_account_choose_what_to_sync" />
 
         <TextView


### PR DESCRIPTION
Something changed between Android 4.3 and Android 4.4 which folded the
RelativeLayout's marginBottom into the child calculations in some way.
This simple work-around moves the spacing out of the RelativeLayout and
into the marginTop of the control underneath.  All other examples of
this pattern use the marginTop of the control underneath.

Test plan: manually tested on my
- 4.3 Samsung Galaxy S4; and
- 4.4 Google Nexus 5.
