### PR TITLE
Bug 1149226 - Set Reading List sync automatically after upgrade.

### DIFF
--- a/src/main/java/org/mozilla/gecko/fxa/authenticator/AndroidFxAccount.java
+++ b/src/main/java/org/mozilla/gecko/fxa/authenticator/AndroidFxAccount.java
@@ -58,10 +58,15 @@ public class AndroidFxAccount {
   public static final String ACCOUNT_KEY_PROFILE = "profile";
   public static final String ACCOUNT_KEY_IDP_SERVER = "idpServerURI";
 
-  // The audience should always be a prefix of the token server URI.
-  public static final String ACCOUNT_KEY_AUDIENCE = "audience";                 // Sync-specific.
   public static final String ACCOUNT_KEY_TOKEN_SERVER = "tokenServerURI";       // Sync-specific.
   public static final String ACCOUNT_KEY_DESCRIPTOR = "descriptor";
+
+  // The set of authorities to sync automatically changes over time. The first
+  // new authority is the Reading List. This tracks if we've enabled syncing,
+  // and opted in (or out) of syncing automatically, for the new Reading List
+  // authority. This happens either on when the account is created or when
+  // upgrading.
+  public static final String ACCOUNT_KEY_READING_LIST_AUTHORITY_INITIALIZED = "readingListAuthorityInitialized";
 
   public static final int CURRENT_BUNDLE_VERSION = 2;
   public static final String BUNDLE_KEY_BUNDLE_VERSION = "version";
@@ -401,6 +406,10 @@ public class AndroidFxAccount {
     userdata.putString(ACCOUNT_KEY_IDP_SERVER, idpServerURI);
     userdata.putString(ACCOUNT_KEY_TOKEN_SERVER, tokenServerURI);
     userdata.putString(ACCOUNT_KEY_PROFILE, profile);
+    if (DEFAULT_AUTHORITIES_TO_SYNC_AUTOMATICALLY_MAP.containsKey(BrowserContract.READING_LIST_AUTHORITY)) {
+      // Have we initialized the Reading List authority?
+      userdata.putString(ACCOUNT_KEY_READING_LIST_AUTHORITY_INITIALIZED, "1");
+    }
 
     if (bundle == null) {
       bundle = new ExtendedJSONObject();

--- a/src/main/java/org/mozilla/gecko/fxa/receivers/FxAccountUpgradeReceiver.java
+++ b/src/main/java/org/mozilla/gecko/fxa/receivers/FxAccountUpgradeReceiver.java
@@ -11,6 +11,7 @@ import java.util.concurrent.Executors;
 
 import org.mozilla.gecko.background.common.log.Logger;
 import org.mozilla.gecko.background.fxa.FxAccountUtils;
+import org.mozilla.gecko.db.BrowserContract;
 import org.mozilla.gecko.fxa.FirefoxAccounts;
 import org.mozilla.gecko.fxa.FxAccountConstants;
 import org.mozilla.gecko.fxa.authenticator.AndroidFxAccount;
@@ -19,7 +20,9 @@ import org.mozilla.gecko.fxa.login.State.StateLabel;
 import org.mozilla.gecko.sync.Utils;
 
 import android.accounts.Account;
+import android.accounts.AccountManager;
 import android.content.BroadcastReceiver;
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 
@@ -45,6 +48,7 @@ public class FxAccountUpgradeReceiver extends BroadcastReceiver {
     // Recovering accounts that are in the Doghouse should happen *after* we
     // unpickle any accounts saved to disk.
     runnables.add(new AdvanceFromDoghouseRunnable(context));
+    runnables.add(new MaybeInitializeReadingListAuthority(context));
     return runnables;
   }
 
@@ -126,6 +130,70 @@ public class FxAccountUpgradeReceiver extends BroadcastReceiver {
         } catch (Exception e) {
           Logger.warn(LOG_TAG, "Got exception trying to advance account named like " + Utils.obfuscateEmail(account.name) +
               " from Doghouse to Separated state; ignoring.", e);
+        }
+      }
+    }
+  }
+
+  /**
+   * A Runnable that initializes the Reading List authority (specifically, set
+   * the sync automatically flag) for existing Firefox Accounts that have not
+   * yet seen the authority. That is, if a new authority (Reading List) is added
+   * to the set of defaults, existing Firefox Accounts won't be syncing it
+   * automatically. This tries to set the sync automatically flag for such
+   * existing accounts.
+   *
+   * Public for testing only.
+   */
+  public static class MaybeInitializeReadingListAuthority implements Runnable {
+    protected final Context context;
+
+    public MaybeInitializeReadingListAuthority(Context context) {
+      this.context = context;
+    }
+
+    @Override
+    public void run() {
+      final String authority = BrowserContract.READING_LIST_AUTHORITY;
+      Boolean enabledByDefault = AndroidFxAccount.DEFAULT_AUTHORITIES_TO_SYNC_AUTOMATICALLY_MAP.get(authority);
+      if (enabledByDefault == null || !enabledByDefault.booleanValue()) {
+        Logger.info(LOG_TAG, "Reading List authority is not enabled by default; not trying to initialize Reading List authority for any accounts.");
+      }
+
+      final AccountManager accountManager = AccountManager.get(context);
+      final Account[] accounts = FirefoxAccounts.getFirefoxAccounts(context);
+      Logger.info(LOG_TAG, "Trying to initialize Reading List authority for " + accounts.length + " existing Firefox Accounts (if necessary).");
+
+      for (Account account : accounts) {
+        try {
+          final AndroidFxAccount fxAccount = new AndroidFxAccount(context, account);
+          // For great debugging.
+          if (FxAccountUtils.LOG_PERSONAL_INFORMATION) {
+            fxAccount.dump();
+          }
+
+          final boolean readingListAuthorityInitialized =
+              "1".equals(accountManager.getUserData(account, AndroidFxAccount.ACCOUNT_KEY_READING_LIST_AUTHORITY_INITIALIZED));
+          if (readingListAuthorityInitialized) {
+            Logger.debug(LOG_TAG, "Reading List authority has already been initialized.");
+            continue;
+          }
+
+          // The Reading List authority has not been seen. This happens when an
+          // authority is added after the Firefox Account has been added (and
+          // the package last upgraded). If Firefox Sync is not syncing
+          // automatically, Reading List should not start syncing
+          // automatically: the user has elected not to upload data to Mozilla
+          // servers; we shouldn't opt them in.
+          final boolean syncAutomatically = ContentResolver.getSyncAutomatically(account, BrowserContract.AUTHORITY);
+            Logger.debug(LOG_TAG, "Setting Reading List authority " +
+                (syncAutomatically ? " to " : " to not ") + "sync automatically.");
+            ContentResolver.setSyncAutomatically(account, BrowserContract.READING_LIST_AUTHORITY, syncAutomatically);
+          // Update the account record.
+          accountManager.setUserData(account, AndroidFxAccount.ACCOUNT_KEY_READING_LIST_AUTHORITY_INITIALIZED, "1");
+        } catch (Exception e) {
+          Logger.warn(LOG_TAG, "Got exception trying to set authoritities to sync automatically for account named like " +
+              Utils.obfuscateEmail(account.name) + "; ignoring.", e);
         }
       }
     }

--- a/test/src/org/mozilla/gecko/fxa/receivers/TestFxAccountUpgradeReceiver.java
+++ b/test/src/org/mozilla/gecko/fxa/receivers/TestFxAccountUpgradeReceiver.java
@@ -1,0 +1,101 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+package org.mozilla.gecko.fxa.receivers;
+
+import org.mozilla.gecko.background.sync.AndroidSyncTestCaseWithAccounts;
+import org.mozilla.gecko.db.BrowserContract;
+import org.mozilla.gecko.fxa.FxAccountConstants;
+import org.mozilla.gecko.fxa.authenticator.AndroidFxAccount;
+import org.mozilla.gecko.fxa.login.Separated;
+import org.mozilla.gecko.fxa.login.State;
+import org.mozilla.gecko.fxa.receivers.FxAccountUpgradeReceiver.MaybeInitializeReadingListAuthority;
+
+import android.accounts.Account;
+import android.content.ContentResolver;
+
+public class TestFxAccountUpgradeReceiver extends AndroidSyncTestCaseWithAccounts {
+  private static final String TEST_TOKEN_SERVER_URI = "tokenServerURI";
+  private static final String TEST_AUTH_SERVER_URI = "serverURI";
+  private static final String TEST_PROFILE = "profile";
+
+  private final static String TEST_ACCOUNTTYPE = FxAccountConstants.ACCOUNT_TYPE;
+
+  // Test account names must start with TEST_USERNAME in order to be recognized
+  // as test accounts and deleted in tearDown.
+  public static final String TEST_USERNAME = "testFirefoxAccount@mozilla.com";
+
+  public Account account;
+
+  public TestFxAccountUpgradeReceiver() {
+    super(TEST_ACCOUNTTYPE, TEST_USERNAME);
+  }
+
+  public AndroidFxAccount addTestAccount() throws Exception {
+    final State state = new Separated(TEST_USERNAME, "uid", false); // State choice is arbitrary.
+    final AndroidFxAccount account = AndroidFxAccount.addAndroidAccount(context, TEST_USERNAME,
+        TEST_PROFILE, TEST_AUTH_SERVER_URI, TEST_TOKEN_SERVER_URI, state,
+        AndroidSyncTestCaseWithAccounts.TEST_SYNC_AUTOMATICALLY_MAP_WITH_ALL_AUTHORITIES_DISABLED);
+    assertNotNull(account);
+    assertNotNull(account.getProfile());
+    assertTrue(testAccountsExist()); // Sanity check.
+    this.account = account.getAndroidAccount(); // To remove in tearDown() if we throw.
+    return account;
+  }
+
+  protected AndroidFxAccount addTestAccountWithReadingListNotInitialized() throws Exception {
+    final AndroidFxAccount fxAccount = addTestAccount();
+    // Pretend we've not seen the Reading List authority.
+    accountManager.setUserData(fxAccount.getAndroidAccount(),
+        AndroidFxAccount.ACCOUNT_KEY_READING_LIST_AUTHORITY_INITIALIZED,
+        null);
+    return fxAccount;
+  }
+
+  protected void assertReadingListAuthorityInitialized(AndroidFxAccount fxAccount) throws Exception {
+    final String authoritiesSeenString = accountManager.getUserData(fxAccount.getAndroidAccount(),
+        AndroidFxAccount.ACCOUNT_KEY_READING_LIST_AUTHORITY_INITIALIZED);
+    assertEquals("1", authoritiesSeenString);
+  }
+
+  private void upgrade(AndroidFxAccount fxAccount) {
+    final MaybeInitializeReadingListAuthority runnable = new FxAccountUpgradeReceiver.MaybeInitializeReadingListAuthority(context);
+    runnable.run();
+  }
+
+  public void testNewAccount() throws Exception {
+    final AndroidFxAccount fxAccount = addTestAccount();
+    assertReadingListAuthorityInitialized(fxAccount);
+    // The test account has Firefox Sync and Reading List turned off.
+    assertEquals(false, ContentResolver.getSyncAutomatically(fxAccount.getAndroidAccount(), BrowserContract.AUTHORITY));
+    assertEquals(false, ContentResolver.getSyncAutomatically(fxAccount.getAndroidAccount(), BrowserContract.READING_LIST_AUTHORITY));
+    // Turn on Firefox Sync.
+    ContentResolver.setSyncAutomatically(fxAccount.getAndroidAccount(), BrowserContract.AUTHORITY, true);
+    // The upgrade should do nothing: we should not enable syncing Reading List
+    // automatically, even though Firefox Sync is enabled.
+    upgrade(fxAccount);
+    assertEquals(false, ContentResolver.getSyncAutomatically(fxAccount.getAndroidAccount(), BrowserContract.READING_LIST_AUTHORITY));
+  }
+
+  public void testExistingccountWithSyncEnabled() throws Exception {
+    final AndroidFxAccount fxAccount = addTestAccountWithReadingListNotInitialized();
+    // Turn on Firefox Sync.
+    ContentResolver.setSyncAutomatically(fxAccount.getAndroidAccount(), BrowserContract.AUTHORITY, true);
+    // We should upgrade and turn Reading List sync automatically on.
+    upgrade(fxAccount);
+    assertEquals(true, ContentResolver.getSyncAutomatically(fxAccount.getAndroidAccount(), BrowserContract.READING_LIST_AUTHORITY));
+    // After upgrade, we've initialized the Reading List authority.
+    assertReadingListAuthorityInitialized(fxAccount);
+  }
+
+  public void testExistingAccountWithSyncDisabled() throws Exception {
+    final AndroidFxAccount fxAccount = addTestAccountWithReadingListNotInitialized();
+    // Turn off Firefox Sync.
+    ContentResolver.setSyncAutomatically(fxAccount.getAndroidAccount(), BrowserContract.AUTHORITY, false);
+    // We should upgrade but not turn Reading List sync automatically on.
+    upgrade(fxAccount);
+    assertEquals(false, ContentResolver.getSyncAutomatically(fxAccount.getAndroidAccount(), BrowserContract.READING_LIST_AUTHORITY));
+    // After upgrade, we've initialized the Reading List authority.
+    assertReadingListAuthorityInitialized(fxAccount);
+  }
+}


### PR DESCRIPTION
The desired behaviour is: Reading List is syncing automatically if
Firefox Sync is syncing automatically.

Test plan: remove all Firefox Accounts.

1) Install old version.  Add a Firefox Account.  Ensure that Firefox
Sync is enabled.  Upgrade to new version.  Verify that Reading List is
enabled.

2) Install old version.  Add a Firefox Account.  Manually disable
Firefox Sync by unchecking the checkbox in Android Settings >
Accounts.  (This can not be done from the Firefox Account settings
activity; unchecking the 4 boxes there is not the same.)  Upgrade to new
version.  Verify that Reading List is disabled.

3) Install new version.  Add a new Firefox Account.  Verify that Reading
List is enabled.

(There are automated tests for these scenarios.)
